### PR TITLE
Feat: Add language-tool to personal apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,8 @@ personal: \
 	calibre \
 	chatgpt \
 	claude \
-	flow
+	flow \
+	language-tool
 
 # Local vault on 1password does not work with 1password
 # app from the app store. We need to manually download
@@ -255,6 +256,10 @@ flow: mas /Applications/Flow.app
 		echo "Installing Flow"; \
 		mas install 1423210932 || echo "Warning: Failed to install Flow (may not be purchased on this Apple account)"; \
 	fi
+
+language-tool: brew ${APP_BIN}/LanguageTool.app
+${APP_BIN}/LanguageTool.app:
+	brew install --cask languagetool
 
 ################################################################################
 # End of personal section


### PR DESCRIPTION
## Description

Add LanguageTool desktop application to the personal apps section in the Makefile. This allows LanguageTool to be installed via `make personal` or `make all`.

## How to Test

1. Run `make personal` or `make all`
2. Verify that LanguageTool desktop app is installed in `/Applications/LanguageTool.app`
3. Launch the application to confirm it works correctly

## Checklist

- [x] Changes have been tested locally
- [ ] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)