### PR TITLE
Feat: Add zoxide for smart directory navigation

### DIFF
--- a/.cursor/rules/general.md
+++ b/.cursor/rules/general.md
@@ -12,6 +12,10 @@ globs:
 - Avoid macOS-specific features when a cross-platform alternative exists
 - Use `uname` or similar checks when platform-specific code is unavoidable
 
+## Installation & Package Management
+
+**CRITICAL**: Always use the Makefile for installing tools and applications. Never install packages directly with `brew install`, `npm install -g`, or other package managers. See `makefile.md` for details.
+
 ## Symlink Conventions
 
 Configuration files are symlinked from this repo:

--- a/.cursor/rules/makefile.md
+++ b/.cursor/rules/makefile.md
@@ -5,6 +5,8 @@ globs: Makefile
 
 # Makefile Conventions
 
+**CRITICAL RULE**: **ALWAYS use the Makefile for installing tools and applications**. Never install tools directly with `brew install`, `npm install -g`, or any other package manager commands. The Makefile is the single source of truth for what tools are installed and how they're configured.
+
 Structure targets to be self-documenting — the target name should clearly indicate its purpose, avoiding the need for comments.
 
 ## Sections (respect this organization)
@@ -30,3 +32,27 @@ ${BREW_BIN}/newtool:
 ```
 
 Note: Homebrew works on both macOS and Linux. For Linux-only alternatives, consider adding conditional targets.
+
+## Installation Workflow
+
+**When installing a new tool:**
+
+1. **First**: Add the tool to the Makefile in the appropriate section (terminal/work/personal/utils)
+2. **Then**: Run `make <tool-name>` to install it
+3. **Never**: Install tools directly with `brew install`, `npm install -g`, etc. outside the Makefile
+
+**Example workflow:**
+```bash
+# ✅ CORRECT: Add to Makefile first, then install
+# 1. Edit Makefile to add the tool
+# 2. Run: make zoxide
+
+# ❌ WRONG: Installing directly
+brew install zoxide  # Don't do this!
+```
+
+This ensures:
+- All installations are tracked and documented
+- Reproducible setup across machines
+- Easy to see what tools are installed
+- Consistent with the dotfiles philosophy

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ terminal: \
 	ripgrep \
 	tmux \
 	tokei \
-	wezterm
+	wezterm \
+	zoxide
 
 ~/.config:
 	mkdir -p $@
@@ -334,6 +335,10 @@ fzf: ~/.fzf
 ripgrep: brew ${BREW_BIN}/rg
 ${BREW_BIN}/rg:
 	brew install ripgrep
+
+zoxide: brew ${BREW_BIN}/zoxide
+${BREW_BIN}/zoxide:
+	brew install zoxide
 
 starship: brew ${BREW_BIN}/starship ~/.config/starship.toml
 ${BREW_BIN}/starship:

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -19,6 +19,11 @@ end
 set --export BUN_INSTALL "$HOME/.bun"
 set --export PATH $BUN_INSTALL/bin $PATH
 
+# zoxide - smarter cd command
+if type -q zoxide
+    zoxide init fish | source
+end
+
 # Added by OrbStack: command-line tools and integration
 # This won't be added again if you remove it.
 if test -f ~/.orbstack/shell/init2.fish


### PR DESCRIPTION
## Description

This PR adds zoxide, a smarter `cd` command that learns from your navigation habits. It provides intelligent directory jumping based on frequently visited paths.

Changes include:
- Added zoxide to Makefile terminal tools section
- Configured zoxide initialization in Fish shell config
- Added Cursor rules to enforce Makefile usage for all installations (prevents direct package manager installations)

## How to Test

1. Install zoxide: `make zoxide`
2. Reload Fish shell: `source ~/.config/fish/config.fish` (or open a new terminal)
3. Navigate to some directories using `cd`
4. Test zoxide:
   - Use `z <keyword>` to jump to frequently visited directories (e.g., `z dotfiles`)
   - Use `zi` for interactive directory selection
   - Verify that `cd` still works normally

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)