### PR TITLE
Feat: Add git-delta for better git diffs

### DIFF
--- a/.gitconfig.delta
+++ b/.gitconfig.delta
@@ -1,0 +1,11 @@
+[core]
+	pager = delta
+
+[delta]
+	features = side-by-side line-numbers decorations
+	syntax-theme = TokyoNight
+	navigate = true
+	light = false
+
+[interactive]
+	diffFilter = delta --color-only

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ terminal: \
 	fd \
 	fish \
 	fzf \
+	git-delta \
 	gnu-sed \
 	htop \
 	jq \
@@ -339,6 +340,12 @@ ${BREW_BIN}/rg:
 zoxide: brew ${BREW_BIN}/zoxide
 ${BREW_BIN}/zoxide:
 	brew install zoxide
+
+git-delta: brew ${BREW_BIN}/delta ~/.gitconfig
+${BREW_BIN}/delta:
+	brew install git-delta
+~/.gitconfig: ${DOTFILES_PATH}/.gitconfig
+	ln -s ${DOTFILES_PATH}/.gitconfig ~/.gitconfig
 
 starship: brew ${BREW_BIN}/starship ~/.config/starship.toml
 ${BREW_BIN}/starship:

--- a/Makefile
+++ b/Makefile
@@ -341,11 +341,15 @@ zoxide: brew ${BREW_BIN}/zoxide
 ${BREW_BIN}/zoxide:
 	brew install zoxide
 
-git-delta: brew ${BREW_BIN}/delta ~/.gitconfig
+git-delta: brew ${BREW_BIN}/delta ~/.gitconfig.delta
 ${BREW_BIN}/delta:
 	brew install git-delta
-~/.gitconfig: ${DOTFILES_PATH}/.gitconfig
-	ln -s ${DOTFILES_PATH}/.gitconfig ~/.gitconfig
+~/.gitconfig.delta: ${DOTFILES_PATH}/.gitconfig.delta
+	ln -s ${DOTFILES_PATH}/.gitconfig.delta ~/.gitconfig.delta
+	@if ! git config --global --get include.path | grep -q "\.gitconfig\.delta"; then \
+		git config --global include.path "~/.gitconfig.delta"; \
+		echo "Added include.path to ~/.gitconfig"; \
+	fi
 
 starship: brew ${BREW_BIN}/starship ~/.config/starship.toml
 ${BREW_BIN}/starship:


### PR DESCRIPTION
## Description

This PR adds git-delta, a syntax-highlighting pager for git that improves diff readability. The configuration is added via `include.path` to preserve existing git config with sensitive information.

Changes include:
- Added git-delta to Makefile terminal tools section
- Created `.gitconfig.delta` with delta-specific configuration (no sensitive data)
- Configured Makefile to automatically add `include.path` to existing `.gitconfig` without overwriting it

## How to Test

1. Install git-delta: `make git-delta`
2. Verify delta is installed: `which delta`
3. Test git diff: `git diff` (should show syntax-highlighted, side-by-side diff)
4. Test git log with diffs: `git log -p` (delta will be used for diffs)
5. Verify config: `git config --global --get include.path` should show `~/.gitconfig.delta`

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)