### PR TITLE
feat(fish): add c alias for Claude and co alias for Codex

### DIFF
--- a/fish/conf.d/aliases.fish
+++ b/fish/conf.d/aliases.fish
@@ -21,7 +21,7 @@ if type -q nvim
 end
 
 if type -q claude
-    alias cc='claude'
+    alias c='claude'
 end
 
 if type -q codex

--- a/fish/conf.d/aliases.fish
+++ b/fish/conf.d/aliases.fish
@@ -20,12 +20,12 @@ if type -q nvim
     alias n='nvim'
 end
 
-if type -q cursor
-    alias c='cursor'
-end
-
 if type -q claude
     alias cc='claude'
+end
+
+if type -q codex
+    alias co='codex'
 end
 
 if type -q tokei

--- a/fish/conf.d/aliases.fish
+++ b/fish/conf.d/aliases.fish
@@ -24,6 +24,10 @@ if type -q cursor
     alias c='cursor'
 end
 
+if type -q claude
+    alias cc='claude'
+end
+
 if type -q tokei
     alias loc='tokei'
 end


### PR DESCRIPTION
## Résumé

Ajoute des alias Fish pour lancer rapidement les agents CLI :

- `c` → `claude`
- `co` → `codex`

L'ancien alias `c='cursor'` a été supprimé car il ouvrait directement l'application Cursor au lieu de permettre de lancer l'agent en local. La lettre `c` est désormais réutilisée pour Claude.

Les deux alias suivent le pattern conditionnel `type -q` déjà utilisé dans le fichier, donc ils ne sont créés que si la commande correspondante est disponible.

## Changements

`fish/conf.d/aliases.fish` :

```fish
if type -q claude
    alias c='claude'
end

if type -q codex
    alias co='codex'
end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVaKQRsSTZ2pBFFK8m6PmR)_