### PR TITLE
fix(make): assemble ~/.codex/AGENTS.md for Codex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,17 +354,17 @@ ${LOCAL_BIN}/claude:
 ~/.claude/skills/handoff: ${DOTFILES_PATH}/.agents/skills/handoff | ~/.claude/skills
 	ln -s ${DOTFILES_PATH}/.agents/skills/handoff $@
 
-codex: ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.codex/SOUL.md ~/.codex/USER.md
+codex: ${VOLTA_BIN}/codex ~/.codex/AGENTS.md
 ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 	${VOLTA_BIN}/npm install -g @openai/codex
 ~/.codex:
 	mkdir -p $@
-~/.codex/AGENTS.md: ${DOTFILES_PATH}/ai/AGENTS.md | ~/.codex
-	ln -s ${DOTFILES_PATH}/ai/AGENTS.md $@
-~/.codex/SOUL.md: ${DOTFILES_PATH}/ai/SOUL.md | ~/.codex
-	ln -s ${DOTFILES_PATH}/ai/SOUL.md $@
-~/.codex/USER.md: ${DOTFILES_PATH}/ai/USER.md | ~/.codex
-	ln -s ${DOTFILES_PATH}/ai/USER.md $@
+# Codex ignores AGENTS.md @import directives, so the three files are assembled
+# here instead of symlinked. Written to a temporary path then moved, so an
+# existing symlink is replaced rather than written through.
+~/.codex/AGENTS.md: ${DOTFILES_PATH}/ai/AGENTS.md ${DOTFILES_PATH}/ai/SOUL.md ${DOTFILES_PATH}/ai/USER.md | ~/.codex
+	grep -v '^@' $< | cat - ${DOTFILES_PATH}/ai/SOUL.md ${DOTFILES_PATH}/ai/USER.md > $@.tmp
+	mv $@.tmp $@
 
 codexbar: brew ${APP_BIN}/CodexBar.app
 ${APP_BIN}/CodexBar.app:


### PR DESCRIPTION
## Why

Follow-up to #47, which left an open question: does Codex resolve `@import` in `AGENTS.md`?

**Tested — it does not.**

| Prompt | Result |
|---|---|
| "List the items of your *Points de vigilance* list" | `NO_IMPORT` |
| Control: "What is tier 3 of Web Fetching?" | `CloakBrowser` ✅ |

So `~/.codex/AGENTS.md` is loaded, but the `@SOUL.md` / `@USER.md` lines are inert, and the sibling symlinks added in #47 were useless.

### Evidence, strongest first

1. **The test above.** Decisive: a positive control rules out "the file was never loaded".
2. **Official documentation** — [Custom instructions with AGENTS.md](https://learn.chatgpt.com/docs/agent-configuration/agents-md) documents only per-directory discovery and concatenation "from the root down". No import syntax of any kind.
3. **Upstream** — [openai/codex#11838](https://github.com/openai/codex/issues/11838) describes exactly this gap: instructions must be generated dynamically because one `AGENTS.md` cannot chain to another file. No issue or changelog entry references an existing import feature.
4. **CLI surface** — `codex --help` and `codex exec --help` expose no per-file instruction option; `config.toml` has no equivalent key.

The [third-party post](https://codex.danielvaughan.com/2026/05/27/agent-instruction-files-agents-md-claude-md-cross-tool-portability-codex-cli/) cited in #47, which claimed `@./file.md` works in Codex CLI, is wrong.

## Change

`~/.codex/AGENTS.md` becomes a generated file rather than a symlink: the three sources are concatenated, `@` directive lines stripped. Make regenerates it whenever any source changes. Writing goes through `$@.tmp` then `mv`, so an existing symlink is replaced instead of written through — a plain `>` would have overwritten `ai/AGENTS.md` in the repository.

Claude Code is unaffected: it resolves the imports, and `~/.claude/` keeps its symlinks.

## Test plan

- [x] Assembly verified: 124 lines, zero remaining `@` lines, all three headings present
- [ ] `make codex` then re-run the Codex prompt above, expecting the vigilance list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzpdoFkEcFRR8Lx1Be2DW3
