### PR TITLE
docs(adr): record and enforce architecture decisions

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -13,18 +13,18 @@ This directory is the single source of truth for reusable agent skills.
 
 | Skill     | Description |
 | --------- | ----------- |
-| `neovim`  | Maintain this repository's Neovim and LazyVim configuration. Use when editing Lua files under… |
-| `scripts` | Create and maintain portable Bash scripts in this repository. Use when adding or editing standalone… |
+| `neovim`  | Maintain this repository's Neovim and LazyVim configuration. |
+| `scripts` | Create and maintain portable Bash scripts in this repository. |
 
 ## Ops
 
-| Skill            | Description |
-| ---------------- | ----------- |
-| `apple-notes`    | Create, move, and rename folders and notes in Apple Notes with AppleScript, including… |
-| `do-nothing-script` | Turn a manual, repeated procedure into a do-nothing script (Dan Slimmon's gradual automation… |
-| `dotfiles`       | Apply this dotfiles repository's configuration and installation conventions. Use when changing… |
-| `handoff`        | Hand the current work over to a fresh agent session instead of letting the context be… |
-| `johnny-decimal` | Organize files in ~/Documents with the Johnny Decimal and PARA hybrid system. Use when naming,… |
-| `para-organizer` | Implement the PARA Method (Projects, Areas, Resources, Archives) on a local file system outside… |
-| `skill-manager`  | Manage .agents/skills: create new skills with proper scaffolding, run doctor checks on existing skills… |
-| `things-tasks`   | Manage Things 3 tasks, projects, and areas through the thangs CLI. Use when listing Things lists… |
+| Skill               | Description |
+| ------------------- | ----------- |
+| `apple-notes`       | Write to Apple Notes with AppleScript: create, move, rename notes and folders, HTML bodies, attachments. |
+| `do-nothing-script` | Turn a repeated manual procedure into a do-nothing script (Slimmon): one function per step, printed then awaiting the operator, automated one step at a time. |
+| `dotfiles`          | Apply this repository's conventions for configuration, symlinks, platform differences, and tool installation. |
+| `handoff`           | Hand the current work to a fresh session instead of letting the context compact. |
+| `johnny-decimal`    | Organize ~/Documents with the Johnny Decimal and PARA hybrid. |
+| `para-organizer`    | Apply PARA (Projects, Areas, Resources, Archives) to a file tree outside ~/Documents and ~/Brain. |
+| `skill-manager`     | Manage .agents/skills: create, doctor, fix, cross-check, and sync the README index. |
+| `things-tasks`      | Manage Things 3 tasks, projects, and areas through the thangs CLI. |

--- a/.agents/skills/apple-notes/SKILL.md
+++ b/.agents/skills/apple-notes/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: apple-notes
 description: >
-  Create, move, and rename folders and notes in Apple Notes with AppleScript, including
-  HTML-formatted bodies, nested folders, and exporting a note's attachments. Use when adding,
-  writing, filing, or triaging content in Apple Notes from the command line. Make sure to use this
-  skill whenever a request mentions creating a note, a Notes folder, processing the Notes inbox,
-  moving or retitling an existing note, saving something "in my Notes", handling photos or
-  attachments inside a note, or scripting Notes with osascript, even if AppleScript is never
-  named — the apple-notes MCP server is read-only and cannot write.
+  Write to Apple Notes with AppleScript: create, move, rename notes and folders, HTML bodies,
+  attachments. Use when adding, filing, or triaging Notes content. Make sure to use it whenever a
+  request writes to Notes, even if AppleScript is unnamed — the apple-notes MCP server is read-
+  only.
 license: MIT
 compatibility: macOS with the Notes app; osascript. Requires Automation permission for the calling terminal.
 metadata:

--- a/.agents/skills/do-nothing-script/SKILL.md
+++ b/.agents/skills/do-nothing-script/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: do-nothing-script
 description: >
-  Turn a manual, repeated procedure into a do-nothing script (Dan Slimmon's gradual automation
-  technique): one function per step, each printing its instructions and waiting for the operator,
-  automated one step at a time. Use when documenting or automating a runbook, checklist, release
-  process, onboarding, incident procedure, or any multi-step manual chore. Make sure to use this
-  skill whenever a request mentions a runbook, checklist, "steps I always do by hand", gradual or
-  partial automation, or asks to script a procedure whose steps cannot all be automated yet, even if
-  the words "do-nothing script" are never used.
+  Turn a repeated manual procedure into a do-nothing script (Slimmon): one function per step,
+  printed then awaiting the operator, automated one step at a time. Use when scripting a runbook,
+  checklist, release, or onboarding. Make sure to use it whenever the steps cannot all be
+  automated yet, even if the term is never used.
 metadata:
   category: ops
 ---

--- a/.agents/skills/dotfiles/SKILL.md
+++ b/.agents/skills/dotfiles/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: dotfiles
 description: >
-  Apply this dotfiles repository's configuration and installation conventions. Use when changing
-  dotfiles, symlinks, platform-specific configuration, or tool installation. Make sure to use this
-  skill whenever editing the Makefile or a configuration managed from this repository, even if the
-  request only mentions a single application.
+  Apply this repository's conventions for configuration, symlinks, platform differences, and tool
+  installation. Use when editing the Makefile or any file managed from here. Make sure to use it
+  whenever a change lands in this repository, even if the request names a single application.
 metadata:
   category: ops
 ---

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: handoff
 description: >
-  Hand the current work over to a fresh agent session instead of letting the context be compacted.
-  Use when the context window is nearly full, when a Stop hook reports the handoff threshold was
-  reached, or when the user asks for a resume prompt. Make sure to use this skill whenever a session
-  must end and continue elsewhere — approaching the token limit, avoiding auto-compaction, or
-  starting a new session on the same task — even if the request only asks for "the prompt to keep
-  going" or to "start over from scratch" without naming the context limit.
+  Hand the current work to a fresh session instead of letting the context compact. Use when the
+  window is nearly full, a Stop hook reports the handoff threshold, or a resume prompt is asked
+  for. Make sure to use it whenever a session must continue elsewhere, even if the context limit
+  is never named.
 compatibility: Claude Code with scripts/claude_handoff_check installed as a Stop hook
 metadata:
   category: ops

--- a/.agents/skills/johnny-decimal/SKILL.md
+++ b/.agents/skills/johnny-decimal/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: johnny-decimal
 description: >
-  Organize files in ~/Documents with the Johnny Decimal and PARA hybrid system. Use when naming,
-  filing, moving, or locating numbered personal documents. Make sure to use this skill whenever a
-  request concerns Johnny Decimal categories, PARA mapping, or document filenames under
-  ~/Documents, even if the user only asks where a document belongs.
+  Organize ~/Documents with the Johnny Decimal and PARA hybrid. Use when naming, filing, moving,
+  or locating numbered personal documents. Make sure to use it whenever a request concerns
+  categories or filenames under ~/Documents, even if it only asks where a document belongs.
 metadata:
   category: ops
 ---

--- a/.agents/skills/neovim/SKILL.md
+++ b/.agents/skills/neovim/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: neovim
 description: >
-  Maintain this repository's Neovim and LazyVim configuration. Use when editing Lua files under
-  nvim/, adding plugins, changing options, or updating keymaps. Make sure to use this skill whenever
-  a request affects LazyVim plugin specifications or Neovim behavior, even if Neovim is not named
-  explicitly.
+  Maintain this repository's Neovim and LazyVim configuration. Use when editing Lua under nvim/,
+  adding plugins, changing options, or updating keymaps. Make sure to use it whenever a change
+  affects LazyVim specs or Neovim behaviour, even if Neovim is unnamed.
 metadata:
   category: dev
 ---

--- a/.agents/skills/para-organizer/SKILL.md
+++ b/.agents/skills/para-organizer/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: para-organizer
 description: >
-  Implement the PARA Method (Projects, Areas, Resources, Archives) on a local file system outside
-  `~/Documents` and `~/Brain`. Use when setting up PARA from scratch, auditing or cleaning up an
-  existing PARA tree, classifying folders into Projects/Areas/Resources/Archives, or reorganizing a
-  messy folder by actionability. Make sure to use this skill whenever a request mentions PARA,
-  "Second Brain file organization", or asks which folders should be projects vs areas vs resources,
-  even if the user only asks where one folder belongs. For `~/Documents`, use `johnny-decimal`
-  instead.
+  Apply PARA (Projects, Areas, Resources, Archives) to a file tree outside ~/Documents and
+  ~/Brain. Use when setting up, auditing, or reclassifying folders by actionability. Make sure to
+  use it whenever a request mentions PARA or asks where a folder belongs. For ~/Documents use
+  johnny-decimal.
 metadata:
   category: ops
   author: Tiago Forte (Forte Labs)

--- a/.agents/skills/scripts/SKILL.md
+++ b/.agents/skills/scripts/SKILL.md
@@ -2,9 +2,8 @@
 name: scripts
 description: >
   Create and maintain portable Bash scripts in this repository. Use when adding or editing
-  standalone scripts, shebangs, error handling, or executable tooling. Make sure to use this skill
-  whenever a change touches scripts/ or introduces shell automation, even if the request calls it a
-  helper or hook.
+  standalone scripts, shebangs, error handling, or executable tooling. Make sure to use it
+  whenever a change touches scripts/, even if the request calls it a helper or a hook.
 metadata:
   category: dev
 ---

--- a/.agents/skills/skill-manager/SKILL.md
+++ b/.agents/skills/skill-manager/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: skill-manager
 description: >
-  Manage .agents/skills: create new skills with proper scaffolding, run doctor checks on existing skills for quality and portability, fix non-conforming skills after a doctor run, detect inter-skill
-  inconsistencies with cross-check, and keep the README index synchronized. Use when creating a new
-  skill, improving an existing skill, modifying a skill's description or frontmatter, fixing doctor findings, detecting trigger overlaps or rule contradictions between skills, organizing the skills
-  directory, or ensuring multi-agent compatibility. Make sure to use this skill whenever authoring a
-  new skill, reviewing skill quality, cross-checking skills for conflicts, restructuring skills,
-  modifying any SKILL.md file (even a single field like description or metadata), applying fixes from doctor, or migrating to the agentskills.io standard, even if you're just tweaking one line in an
-  existing skill — references/conventions.md must be read first.
+  Manage .agents/skills: create, doctor, fix, cross-check, and sync the README index. Use when
+  authoring a skill or changing any SKILL.md, down to a single frontmatter field. Make sure to use
+  it whenever skill quality, triggers, or portability are at stake; references/conventions.md must
+  be read first.
 metadata:
   category: ops
   author: Bellman

--- a/.agents/skills/skill-manager/references/conventions.md
+++ b/.agents/skills/skill-manager/references/conventions.md
@@ -91,6 +91,12 @@ even if <where user might not mention the domain>.
 > discrepancies, charge balance issues, or missing invoices, even if the user doesn't explicitly
 > mention "accounting" or "reconciliation".
 
+**Keep it under ~300 characters.** The initial skill list is capped — Codex bounds it to 2% of the
+context window or 8000 characters, shortening descriptions first and then dropping skills outright;
+Claude Code truncates `description` + `when_to_use` at 1536 characters per entry. A long description
+is therefore the first thing sacrificed, so the distinctive case goes in the opening clause. The
+1024-character ceiling below is a hard limit, not a target.
+
 **Bad examples**:
 
 - ❌ Generic: `"Helps manage skills"` (no activation keywords)
@@ -346,7 +352,7 @@ The README uses `metadata.category` to organize skills into sections:
 - [ ] No custom fields at top-level (no `disable-model-invocation`, `category`, `paths`)
 - [ ] `metadata.category` is one of: `dev`, `support`, `product`, `ops`
 - [ ] Description is "pushy" (includes "Use when" and/or "Make sure to use")
-- [ ] Description is < 1024 characters
+- [ ] Description is < 1024 characters, and ideally < 300 (the list is capped and truncated)
 - [ ] SKILL.md is < 500 lines, < 5000 tokens
 - [ ] All 7 required sections present (Overview, Usage, Steps, Gotchas, Constraints, + H1 +
       frontmatter)

--- a/.agents/skills/things-tasks/SKILL.md
+++ b/.agents/skills/things-tasks/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: things-tasks
 description: >
-  Manage Things 3 tasks, projects, and areas through the thangs CLI. Use when listing Things lists,
-  creating or editing tasks, completing or canceling tasks, managing projects or areas, filtering
-  by project, area, or tag, or inspecting thangs options. Make sure to use this skill whenever the
-  user asks about their todos, Today list, deadlines, or Things data, even if they do not explicitly
-  mention Things 3 or thangs.
+  Manage Things 3 tasks, projects, and areas through the thangs CLI. Use when listing, creating,
+  editing, completing, or filtering tasks by project, area, or tag. Make sure to use it whenever
+  the user asks about todos, the Today list, or deadlines, even if Things is never named.
 metadata:
   category: ops
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,15 @@ This file is the single source of truth for all coding agents working in this re
 - **Keep changes minimal.** Reuse existing structures and ask when the intended scope is ambiguous.
 - **Avoid broad refactors.** Do not migrate or reorganize unrelated configuration by default.
 
+## Architecture Decisions
+
+- `docs/adr/` records the structural decisions of this repository, indexed in `docs/adr/README.md`. Only decisions still in force are recorded.
+- Before changing a structural choice (installer, shell, editor, package source, container runtime, agent instructions, skills layout), read the matching ADR. Its "Alternatives écartées" section usually already covers the option being reconsidered, with the reason it was dropped.
+- Never contradict an ADR silently. Either follow it, or state the conflict, then deliver what was asked along with the ADR that would need superseding.
+- A new structural decision gets a new ADR in the same MADR format, citing the commit hashes that carry it. A decision that replaces another one absorbs it: the superseded ADR is deleted, and its rationale moves to the new "Alternatives écartées" section.
+- **Everything under `docs/`, ADRs included, is written in French**, by explicit exception to the English-documentation rule; `docs/AGENTS.md` holds the detail. Do not translate existing documents, and do not write the next one in English.
+- Routine changes — adding a tool target, updating a lockfile, editing a skill — need no ADR.
+
 ## Personal Brain
 
 - Before operating on content under `~/Brain`, read and follow `~/Brain/AGENTS.md`.

--- a/Makefile
+++ b/Makefile
@@ -202,8 +202,7 @@ ai: \
 	openspec \
 	pi-coding-agent \
 	scrapling \
-	skills \
-	skill-caveman
+	skills
 
 .PHONY: brain
 brain:
@@ -433,26 +432,6 @@ cloakbrowser: docker
 skills: ${VOLTA_BIN}/skills
 ${VOLTA_BIN}/skills: ${VOLTA_BIN}/node
 	${VOLTA_BIN}/npm install -g skills
-
-skill-caveman: skill-caveman-codex skill-caveman-cursor skill-caveman-claude
-
-skill-caveman-codex: ${VOLTA_BIN}/skills ${HOME}/.local/state/dotfiles/caveman/codex
-${HOME}/.local/state/dotfiles/caveman/codex: ${VOLTA_BIN}/skills
-	${VOLTA_BIN}/skills add JuliusBrussee/caveman -a codex -g --yes
-	mkdir -p $(dir $@)
-	touch $@
-
-skill-caveman-cursor: ${VOLTA_BIN}/skills ${HOME}/.local/state/dotfiles/caveman/cursor
-${HOME}/.local/state/dotfiles/caveman/cursor: ${VOLTA_BIN}/skills
-	${VOLTA_BIN}/skills add JuliusBrussee/caveman -a cursor -g --yes
-	mkdir -p $(dir $@)
-	touch $@
-
-skill-caveman-claude: ${VOLTA_BIN}/skills ${HOME}/.local/state/dotfiles/caveman/claude-code
-${HOME}/.local/state/dotfiles/caveman/claude-code: ${VOLTA_BIN}/skills
-	${VOLTA_BIN}/skills add JuliusBrussee/caveman -a claude-code -g --yes
-	mkdir -p $(dir $@)
-	touch $@
 
 chatgpt: brew ${APP_BIN}/ChatGPT.app
 ${APP_BIN}/ChatGPT.app:

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,6 @@ work: \
 	feedmd \
 	language-tool \
 	qovery-cli \
-	rtk \
 	docker \
 	doppler \
 	frontcli \
@@ -412,13 +411,6 @@ ${BREW_BIN}/opencode:
 qovery-cli:
 	# Homebrew version is outdated, use the upstream installer
 	curl -s https://get.qovery.com | bash
-
-rtk: brew ${BREW_BIN}/rtk
-${BREW_BIN}/rtk:
-	brew tap rtk-ai/tap
-	@if [ "$(HAS_BREW_TRUST)" = "yes" ]; then brew trust --tap rtk-ai/tap; fi
-	@if [ "$(HAS_BREW_TRUST)" = "yes" ]; then brew trust --formula rtk-ai/tap/rtk; fi
-	brew install rtk-ai/tap/rtk
 
 .PHONY: firecrawl
 firecrawl: docker

--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ cd && \
   git clone --depth 1 https://github.com/SebastienElet/dotfiles.git .dotfiles &&
   make all
 ```
+
+## Architecture decisions
+
+Structural choices — installer, shell, editor, container runtime, agent
+instructions — are recorded as ADRs in [`docs/adr/`](docs/adr/README.md), one
+file per decision, reconstructed from the git history. Only decisions still in
+force are recorded; superseded ones survive as the "Alternatives écartées"
+section of whichever decision replaced them.
+
+Read the relevant ADR before changing one of these choices, and add a new ADR
+when making one.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,23 @@
+# Docs Agent Instructions
+
+Scoped to `docs/`. The repository-wide rules in the root `AGENTS.md` still apply; this file only
+narrows the documentation language.
+
+## Language
+
+- **Documents under `docs/` are written in French**, by explicit exception to the
+  English-documentation rule that governs the rest of the repository. They record reasoning —
+  decisions, designs, trade-offs — for a French-speaking author, not a public interface of the
+  repository.
+- The exception covers prose only. Identifiers, commands, file paths, API names, commit hashes and
+  quoted commit bodies stay verbatim.
+- Do not translate an existing document to satisfy this rule. `superpowers/specs/` predates it and
+  is left in English on purpose: retranslating a design note loses the wording its conclusions were
+  reached in, for no reader.
+- This file and any other agent-instruction file stay in English, being an interface rather than
+  reasoning.
+
+## Architecture Decisions
+
+- `adr/` holds the architecture decision records; see `adr/README.md` for the index, the MADR format
+  and the scope rule (only decisions still in force are recorded).

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+See @AGENTS.md for the instructions covering this directory.

--- a/docs/adr/001-makefile-installateur.md
+++ b/docs/adr/001-makefile-installateur.md
@@ -1,0 +1,37 @@
+# ADR-001 — Makefile idempotent comme installateur de poste
+
+- **Statut** : accepté
+- **Date** : 2014-08
+- **Commits** : `8411881`, `319529c`, `0777897`, `f9ac76b`
+
+## Contexte
+
+Un poste macOS neuf doit être réinstallé à l'identique sans procédure manuelle,
+et l'installation doit pouvoir être rejouée sur un poste déjà configuré sans
+tout refaire ni rien casser.
+
+## Décision
+
+Le `Makefile` est l'unique point d'entrée de l'installation. Une cible par
+outil, regroupée en sections (`terminal`, `work`, `utils`, `personal`,
+`extra`), agrégées par la cible `all`. Les cibles reposent sur des fichiers
+sentinelles (le binaire installé, le symlink créé) afin que `make` détermine
+lui-même ce qui reste à faire ; les cibles sans fichier déclarent `.PHONY`
+individuellement. `install.sh` se limite à amorcer Homebrew puis à appeler
+`make`.
+
+## Conséquences
+
+- Réinstallation et mise à jour partielle par la même commande, sans état
+  externe à maintenir.
+- L'idempotence est une propriété à défendre cible par cible : plusieurs
+  correctifs ont porté sur des cibles qui se reconstruisaient à chaque appel.
+- Le `Makefile` grossit avec le temps et devient la pièce la plus dense du
+  dépôt, d'où l'élagage périodique ([ADR-005](005-elagage-des-cibles.md)).
+
+## Alternatives écartées
+
+- Un script shell impératif : pas de reprise partielle, pas de graphe de
+  dépendances.
+- Ansible ou un gestionnaire de configuration : la cible `ansible` a existé
+  puis a été retirée ; disproportionné pour un poste unique.

--- a/docs/adr/002-homebrew-source-unique.md
+++ b/docs/adr/002-homebrew-source-unique.md
@@ -1,0 +1,34 @@
+# ADR-002 — Homebrew et `mas` comme unique source de paquets
+
+- **Statut** : accepté
+- **Date** : 2015-02
+- **Commits** : `5c64955`, `ab9771e`
+
+## Contexte
+
+Les outils proviennent de canaux hétérogènes : formules Homebrew, casks,
+App Store, installateurs éditeur. Multiplier les canaux rend la mise à jour
+impossible à automatiser et l'installation impossible à rejouer en CI.
+
+## Décision
+
+Tout paquet passe par Homebrew (formule ou cask), et par `mas` pour ce que
+seul l'App Store distribue. Les services sont pilotés par `brew services`. Les
+applications payantes de l'App Store sont exclues par défaut via
+`SKIP_PAID_APPS`, ce qui permet à la CI d'exécuter l'installation complète.
+`HOMEBREW_NO_ASK` supprime les invites interactives, et les taps sont
+approuvés (`brew trust`) avant toute mise à jour.
+
+## Conséquences
+
+- Une seule commande de mise à jour pour l'ensemble du poste
+  ([ADR-004](004-script-upgrade-unique.md)).
+- Dépendance forte aux dépréciations Homebrew : plusieurs commits ne font que
+  suivre des taps ou des formules retirés en amont.
+- Quelques outils échappent à la règle (installateur natif de Claude Code,
+  images Docker des MCP) et constituent des exceptions assumées.
+
+## Alternatives écartées
+
+- Installateurs éditeur ou téléchargements manuels : non rejouables.
+- Nix : rupture d'outillage disproportionnée au regard du besoin.

--- a/docs/adr/003-deploiement-par-symlinks.md
+++ b/docs/adr/003-deploiement-par-symlinks.md
@@ -1,0 +1,38 @@
+# ADR-003 — Déploiement de la configuration par symlinks
+
+- **Statut** : accepté
+- **Date** : 2014-10
+- **Commits** : `9160770`, `0fb9e89`, `1772db9`
+
+## Contexte
+
+Les fichiers de configuration doivent rester versionnés dans `~/.dotfiles`
+tout en étant lus depuis leur emplacement attendu par chaque outil. Copier les
+fichiers imposerait une resynchronisation après chaque modification.
+
+## Décision
+
+Le `Makefile` crée des symlinks de `$(DOTFILES_PATH)/…` vers `~/…` (`~/.config`,
+`~/.gitconfig.delta`, `~/.wezterm.lua`, `~/.psqlrc`, instructions d'agents…).
+L'édition se fait dans le dépôt, l'effet est immédiat.
+
+Une exception documentée : `~/.codex/AGENTS.md` est **assemblé** par
+concaténation à l'installation. Le commit `1772db9` en donne la raison —
+« Codex loads AGENTS.md but ignores its @import directives, verified with a
+control prompt » —, la concaténation étant alors le seul mécanisme disponible.
+
+## Conséquences
+
+- Aucune étape de synchronisation ; un `git pull` suffit à propager un
+  changement.
+- Un fichier assemblé se périme silencieusement : il faut relancer la cible
+  après modification des sources.
+- La cible doit rester idempotente et ne pas se reconstruire à vide, condition
+  vérifiée à plusieurs reprises dans l'historique.
+
+## Alternatives écartées
+
+- `stow` ou `chezmoi` : une dépendance de plus pour ce que quelques règles
+  `make` couvrent déjà.
+- Copie des fichiers à l'installation : divergence garantie entre dépôt et
+  poste.

--- a/docs/adr/004-script-upgrade-unique.md
+++ b/docs/adr/004-script-upgrade-unique.md
@@ -1,0 +1,31 @@
+# ADR-004 — Script `upgrade` unique pour toutes les mises à jour
+
+- **Statut** : accepté
+- **Date** : 2017-09
+- **Commits** : `2e9c796`, `6c70ca1`
+
+## Contexte
+
+Les mises à jour se répartissent entre plusieurs gestionnaires : Homebrew
+(formules et casks), paquets npm globaux, plugins Neovim, plugins d'agents,
+runtime Node. Les lancer séparément conduit à en oublier.
+
+## Décision
+
+`scripts/upgrade` orchestre l'ensemble en une commande : `git pull` du dépôt,
+`brew upgrade` (avec `--greedy` pour les casks), mise à jour des paquets npm
+globaux, des plugins Neovim — dont le lockfile résultant est committé —, des
+plugins d'agents et du Node LTS géré par Volta.
+
+## Conséquences
+
+- Une seule habitude à tenir ; le poste ne dérive pas.
+- Les mises à jour sont groupées, donc une régression est plus difficile à
+  imputer à un composant précis.
+- Le script doit tolérer l'absence d'un outil : les échecs partiels ont donné
+  lieu à plusieurs correctifs de robustesse.
+
+## Alternatives écartées
+
+- Mise à jour automatique planifiée : perte de contrôle sur le moment où
+  l'environnement de travail change.

--- a/docs/adr/005-elagage-des-cibles.md
+++ b/docs/adr/005-elagage-des-cibles.md
@@ -1,0 +1,31 @@
+# ADR-005 — Élagage périodique des cibles inutilisées
+
+- **Statut** : accepté
+- **Date** : 2025-12
+- **Commits** : `0d6d00c`, `dad06aa`, `0777897`
+
+## Contexte
+
+Onze ans d'ajouts avaient laissé dans le `Makefile` des dizaines de cibles
+correspondant à des outils abandonnés (`vagrant`, `virtualbox`, `travis`,
+`youtube-dl`, `postman`, `ncdu`…). Chacune allonge la durée d'installation
+d'un poste neuf et le temps de la CI, pour un outil qui ne sera pas utilisé.
+
+## Décision
+
+Retirer les cibles dès que l'outil n'est plus utilisé, plutôt que de les
+conserver « au cas où ». L'historique git reste la mémoire : une cible
+supprimée se restaure par `git revert`.
+
+## Conséquences
+
+- Installation d'un poste neuf plus rapide et représentative de l'usage réel.
+- Une réinstallation ancienne n'est plus reproductible telle quelle depuis
+  `main` ; il faut remonter dans l'historique.
+- L'élagage se fait par vagues plutôt qu'en continu, ce qui produit des séries
+  de commits `refactor(makefile)` peu lisibles isolément.
+
+## Alternatives écartées
+
+- Cible `deprecated` conservant les anciens outils : maintient le coût
+  d'installation sans bénéfice.

--- a/docs/adr/006-neovim-editeur-par-defaut.md
+++ b/docs/adr/006-neovim-editeur-par-defaut.md
@@ -1,0 +1,31 @@
+# ADR-006 — Neovim comme éditeur par défaut
+
+- **Statut** : accepté
+- **Date** : 2019-11
+- **Commits** : `d6c33a5`
+
+## Contexte
+
+Vim était l'éditeur depuis 2014. Neovim, essayé dès 2016, apportait un serveur
+LSP intégré, une API Lua et un modèle asynchrone que Vim 8 ne couvrait
+qu'imparfaitement, notamment pour le formatage et le diagnostic à la volée.
+
+## Décision
+
+Neovim devient l'éditeur par défaut : `EDITOR` et `VISUAL` pointent sur `nvim`,
+l'ancien `vimrc` est retiré et la configuration migre progressivement vers Lua.
+
+## Conséquences
+
+- Accès aux distributions et plugins de l'écosystème Lua
+  ([ADR-007](007-lazyvim-comme-distribution.md)).
+- Toute la configuration éditeur devient du Lua, donc lintable en CI
+  ([ADR-023](023-ci-lint-et-installation.md)).
+- Dépendance à un écosystème en évolution rapide, d'où le verrouillage des
+  versions ([ADR-008](008-lockfile-plugins-versionne.md)).
+
+## Alternatives écartées
+
+- Rester sur Vim 8 : asynchronisme et LSP moins aboutis.
+- Emacs : essayé en 2017, abandonné la même année.
+- Un IDE graphique : conserverait deux environnements d'édition à maintenir.

--- a/docs/adr/007-lazyvim-comme-distribution.md
+++ b/docs/adr/007-lazyvim-comme-distribution.md
@@ -1,0 +1,32 @@
+# ADR-007 — LazyVim comme distribution Neovim
+
+- **Statut** : accepté
+- **Date** : 2023-12
+- **Commits** : `c7ad20e` (#29), `2bfac4b` (#30)
+
+## Contexte
+
+La configuration Neovim maison, puis NvChad et NvChad 2, imposaient de suivre
+manuellement l'évolution de chaque plugin et les ruptures de la distribution.
+Le coût de maintenance dépassait la valeur d'une configuration sur mesure.
+
+## Décision
+
+Adopter LazyVim : les réglages par défaut et les « extras » de la distribution
+font foi, la configuration locale se limite aux surcharges. La reconstruction à
+neuf de 2024-06 (#30) a supprimé les vestiges de la configuration précédente
+plutôt que de les porter.
+
+## Conséquences
+
+- Les mises à jour de plugins deviennent une opération de routine
+  ([ADR-004](004-script-upgrade-unique.md)).
+- La surcharge doit rester minimale : plusieurs commits retirent des réglages
+  redondants avec les extras LazyVim.
+- Dépendance au rythme et aux choix d'un projet tiers.
+
+## Alternatives écartées
+
+- NvChad et NvChad 2 : remplacés, ruptures de version coûteuses.
+- Configuration entièrement maison : le point de départ, abandonné pour son
+  coût de maintenance.

--- a/docs/adr/008-lockfile-plugins-versionne.md
+++ b/docs/adr/008-lockfile-plugins-versionne.md
@@ -1,0 +1,33 @@
+# ADR-008 — `lazy-lock.json` versionné et Renovate
+
+- **Statut** : accepté
+- **Date** : 2024-10
+- **Commits** : `bef7198`
+
+## Contexte
+
+Un plugin Neovim suivi sur sa branche par défaut peut casser l'éditeur à la
+première mise à jour, sans possibilité de revenir à un état connu. Le reste
+des dépendances du dépôt souffre du même problème à une échelle plus lente.
+
+## Décision
+
+Committer `nvim/lazy-lock.json` : chaque plugin est épinglé à un commit précis,
+et les mises à jour produisent un commit dédié (`chore(nvim): update plugins`)
+généré par le script d'upgrade. Renovate prend en charge les dépendances
+restantes du dépôt.
+
+## Conséquences
+
+- Retour arrière immédiat par `git revert` du commit de lockfile.
+- L'historique est dominé en volume par ces commits automatiques — plus de
+  trois cents sur douze ans — ce qui nuit à sa lisibilité.
+- Un poste neuf installe exactement les versions validées sur le poste
+  courant.
+
+## Alternatives écartées
+
+- Ne pas versionner le lockfile : aucune reproductibilité, aucun retour
+  arrière.
+- Mises à jour manuelles plugin par plugin : coût sans bénéfice, puisque le
+  lockfile permet déjà l'annulation.

--- a/docs/adr/009-lsp-natif-et-conform.md
+++ b/docs/adr/009-lsp-natif-et-conform.md
@@ -1,0 +1,32 @@
+# ADR-009 — Lint et format par LSP natif et conform
+
+- **Statut** : accepté
+- **Date** : 2026-07
+- **Commits** : `f3a547a`
+
+## Contexte
+
+La chaîne de qualité dans l'éditeur a traversé quatre générations : jshint et
+jscs, puis ESLint (2015-03), syntastic puis ALE (2019-04), coc.nvim
+(2019-11). Chacune apportait son propre gestionnaire d'extensions, en doublon
+avec celui des plugins Neovim.
+
+## Décision
+
+S'appuyer sur le LSP natif de Neovim pour le diagnostic et sur `conform.nvim`
+pour le formatage, tous deux fournis par les extras LazyVim. Les outils
+proviennent de Mason. Depuis 2026-07, oxlint et oxfmt sont configurés en
+parallèle d'ESLint et Prettier, chaque projet imposant sa chaîne.
+
+## Conséquences
+
+- Un seul mécanisme d'extension, celui de Neovim, plus de gestionnaire
+  parallèle.
+- La configuration du projet prime sur celle de l'éditeur : plusieurs commits
+  retirent des formateurs codés en dur au profit du Prettier local.
+- Deux chaînes de lint coexistent pendant la transition vers oxlint.
+
+## Alternatives écartées
+
+- coc.nvim : écosystème d'extensions séparé, redondant avec le LSP natif.
+- ALE et syntastic : antérieurs au LSP, diagnostic moins riche.

--- a/docs/adr/010-fish-shell-par-defaut.md
+++ b/docs/adr/010-fish-shell-par-defaut.md
@@ -1,0 +1,34 @@
+# ADR-010 — Fish comme shell par défaut
+
+- **Statut** : accepté
+- **Date** : 2025-01
+- **Commits** : `b697242`, `5cb3a76`, `5375b5c`, `c7bec47`
+
+## Contexte
+
+La configuration zsh reposait sur des gestionnaires de plugins successifs
+(prezto puis antigen) qui pesaient sur le temps de démarrage et demandaient un
+entretien constant, pour des fonctionnalités — complétion contextuelle,
+suggestion à la frappe, coloration syntaxique — que Fish fournit nativement.
+
+## Décision
+
+Fish devient le shell par défaut, installé et déclaré comme shell de connexion
+par le `Makefile`. La configuration zsh est supprimée (`5375b5c`), à
+l'exception d'un `.zshrc` minimal conservé pour les outils qui présument un
+shell POSIX ou injectent leur initialisation dans zsh (`c7bec47`).
+
+## Conséquences
+
+- Complétion et historique fournis sans plugins ; démarrage plus rapide.
+- Fish n'est pas POSIX : les extraits d'installation copiés depuis une
+  documentation doivent être traduits, ce dont témoignent plusieurs correctifs
+  de syntaxe.
+- Le `.zshrc` minimal doit rester minimal, sous peine de reconstituer une
+  seconde configuration de shell.
+
+## Alternatives écartées
+
+- zsh avec prezto ou antigen : remplacés, coût d'entretien et lenteur au
+  démarrage.
+- bash : aucune des fonctionnalités interactives recherchées.

--- a/docs/adr/011-starship-comme-prompt.md
+++ b/docs/adr/011-starship-comme-prompt.md
@@ -1,0 +1,30 @@
+# ADR-011 — Starship comme prompt unique
+
+- **Statut** : accepté
+- **Date** : 2025-01
+- **Commits** : `2fd5580`
+
+## Contexte
+
+Le prompt zsh maison, construit puis ajusté entre 2016 et 2018, était lié au
+shell et devait être réécrit pour Fish. Il portait aussi ses propres appels
+externes, coûteux à chaque affichage.
+
+## Décision
+
+Adopter Starship, configuré par un unique `.config/starship.toml` versionné et
+indépendant du shell.
+
+## Conséquences
+
+- Un changement de shell ne remet plus le prompt en cause.
+- Le prompt affiche contexte git, versions de runtimes et durée d'exécution
+  sans code maison.
+- Dépendance à un binaire supplémentaire dans le chemin critique de chaque
+  invite.
+
+## Alternatives écartées
+
+- Prompt maison porté vers Fish : réécriture à recommencer au prochain
+  changement de shell.
+- Powerlevel10k : lié à zsh, donc écarté par [ADR-010](010-fish-shell-par-defaut.md).

--- a/docs/adr/012-abbreviations-fish.md
+++ b/docs/adr/012-abbreviations-fish.md
@@ -1,0 +1,32 @@
+# ADR-012 — Abbreviations Fish plutôt qu'alias git
+
+- **Statut** : accepté
+- **Date** : 2026-01
+- **Commits** : `8349aa4` (#40)
+
+## Contexte
+
+Les raccourcis git étaient des alias : l'historique du shell ne conservait que
+`gcb`, jamais la commande réellement exécutée, ce qui complique le diagnostic
+et la relecture d'une session.
+
+## Décision
+
+Convertir les raccourcis git en abbreviations Fish, regroupées dans
+`git-abbreviations.fish`. Le commit `8349aa4` en donne la raison :
+« Abbreviations expand only when typed, showing full command in history […]
+This improves debugging and follows Fish shell conventions ». Seuls `gp` et
+`gpsup`, qui enchaînent plusieurs commandes, restent des alias.
+
+## Conséquences
+
+- L'historique contient les commandes complètes, réutilisables hors contexte.
+- Le raccourci est visible au moment de la frappe, donc vérifiable avant
+  exécution.
+- Mécanisme propre à Fish : ces raccourcis ne sont pas portables vers un autre
+  shell.
+
+## Alternatives écartées
+
+- Alias git côté `~/.gitconfig` : ne couvre pas les raccourcis qui ne sont pas
+  des sous-commandes git.

--- a/docs/adr/013-wezterm-emulateur.md
+++ b/docs/adr/013-wezterm-emulateur.md
@@ -1,0 +1,33 @@
+# ADR-013 — WezTerm comme émulateur de terminal
+
+- **Statut** : accepté
+- **Date** : 2026-01
+- **Commits** : `dc58857`, `c1ce30c`, `a372ba5`, `61d847b`
+
+## Contexte
+
+iTerm2 puis Alacritty ont précédé. iTerm2 se configure par interface graphique
+et par un plist difficile à versionner ; Alacritty, versionnable, ne gère ni
+les ligatures ni certains besoins de rendu, et son format de configuration a
+changé plusieurs fois.
+
+## Décision
+
+Adopter WezTerm, configuré par un `.wezterm.lua` versionné et symlinké. Le cask
+`nightly` est installé (`a372ba5`), la version stable accusant un retard
+important sur les correctifs de rendu.
+
+## Conséquences
+
+- Configuration en Lua, versionnée, cohérente avec celle de Neovim.
+- Le canal `nightly` expose à des régressions : c'est le prix des correctifs de
+  rendu, ajustés dans `61d847b`.
+- Le thème est piloté depuis le dépôt, ce qui rend possible la bascule
+  automatique clair/sombre ([ADR-014](014-theme-catppuccin-unique.md)).
+
+## Alternatives écartées
+
+- iTerm2 : configuration non versionnable.
+- Alacritty : format de configuration instable, fonctionnalités de rendu
+  manquantes.
+- Terminal.app : insuffisant sur les couleurs et les polices.

--- a/docs/adr/014-theme-catppuccin-unique.md
+++ b/docs/adr/014-theme-catppuccin-unique.md
@@ -1,0 +1,31 @@
+# ADR-014 — Thème Catppuccin unique et bascule automatique
+
+- **Statut** : accepté
+- **Date** : 2026-01
+- **Commits** : `93db313`, `d7b14c9`, `2919a49`
+
+## Contexte
+
+Chaque outil portait son propre thème — Nord ici, TokyoNight là, thème par
+défaut ailleurs — avec des variantes claires incohérentes. En extérieur ou
+selon l'heure, la bascule clair/sombre devait être faite outil par outil, et
+certains thèmes référencés n'existaient plus en amont.
+
+## Décision
+
+Retenir Catppuccin comme palette unique, déclinée sur WezTerm, bat, git-delta
+et Neovim, avec installation automatique des thèmes bat par le `Makefile`. La
+bascule suit le mode système via `auto-dark-mode`, l'intervalle de scrutation
+étant réduit à cinq secondes.
+
+## Conséquences
+
+- Rendu homogène entre terminal, pager, diff et éditeur.
+- Une seule décision de thème à reprendre lors d'un changement de palette.
+- Les variantes claires demandent des ajustements de contraste spécifiques,
+  visibles dans l'historique.
+
+## Alternatives écartées
+
+- Un thème par outil : incohérence visuelle et bascules manuelles.
+- Thème fixe sombre : illisible en forte luminosité.

--- a/docs/adr/015-cli-modernes.md
+++ b/docs/adr/015-cli-modernes.md
@@ -1,0 +1,32 @@
+# ADR-015 — CLI modernes en remplacement des historiques
+
+- **Statut** : accepté
+- **Date** : 2026-01
+- **Commits** : `2ef0caf`, `3ccc657`, `b4fbc26`, `313c417`, `fb45dca`
+
+## Contexte
+
+Les outils Unix historiques et leurs premiers remplaçants (`ag`, `exa`,
+`diff-so-fancy`) sont soit lents sur de gros dépôts, soit non maintenus, soit
+dépourvus des intégrations attendues (respect du `.gitignore`, couleurs,
+navigation).
+
+## Décision
+
+Remplacer chaque outil par son équivalent moderne maintenu : `rg` pour `ag` et
+`grep`, `eza` pour `exa` et `ls`, `git-delta` pour `diff-so-fancy`, `fd`,
+`fzf`, `zoxide`, `bat`, `bottom`, `broot`, `lazygit`, `lazydocker`. Les
+remplacements se font par substitution complète, sans coexistence durable.
+
+## Conséquences
+
+- Recherche et navigation nettement plus rapides sur les dépôts volumineux.
+- Les habitudes reposent sur des outils absents d'un serveur distant ; les
+  scripts du dépôt s'en tiennent aux outils POSIX.
+- Chaque outil est une dépendance de plus à installer et mettre à jour.
+
+## Alternatives écartées
+
+- S'en tenir aux outils POSIX : perte des intégrations git et de la vitesse.
+- Conserver les remplaçants historiques : `ag` et `exa` ne sont plus
+  maintenus.

--- a/docs/adr/016-volta-gestionnaire-node.md
+++ b/docs/adr/016-volta-gestionnaire-node.md
@@ -1,0 +1,32 @@
+# ADR-016 — Volta comme gestionnaire Node
+
+- **Statut** : accepté
+- **Date** : 2021-05
+- **Commits** : `498aacd`
+
+## Contexte
+
+nvm (2017) puis fnm (2020) exigeaient un changement de version explicite à
+chaque projet et alourdissaient le démarrage du shell. Un oubli de bascule
+signifie exécuter un projet sur la mauvaise version de Node.
+
+## Décision
+
+Adopter Volta : la version est déclarée dans le `package.json` du projet et
+appliquée automatiquement par des shims, sans hook de shell. Le `Makefile`
+installe Volta puis le Node LTS, et le script d'upgrade fait suivre le LTS.
+
+## Conséquences
+
+- Plus de bascule manuelle ni de coût au démarrage du shell.
+- Les shims ajoutent une indirection qui s'est révélée fragile pour les
+  paquets globaux ([ADR-017](017-npm-pour-paquets-globaux.md)), notamment en
+  CI.
+- L'ordre des cibles `make` doit garantir que Volta précède toute installation
+  Node, ce qu'attestent plusieurs correctifs de dépendances.
+
+## Alternatives écartées
+
+- nvm : lent au démarrage, bascule manuelle.
+- fnm : plus rapide, mais bascule manuelle également.
+- Node installé par Homebrew : une seule version pour tous les projets.

--- a/docs/adr/017-npm-pour-paquets-globaux.md
+++ b/docs/adr/017-npm-pour-paquets-globaux.md
@@ -1,0 +1,32 @@
+# ADR-017 — npm pour les paquets globaux
+
+- **Statut** : accepté
+- **Date** : 2026-01
+- **Commits** : `8e91200`
+
+## Contexte
+
+Les paquets npm globaux avaient été confiés à pnpm. L'articulation entre le
+répertoire global de pnpm (`PNPM_HOME`, `pnpm setup`) et les shims Volta a
+demandé une série de correctifs successifs sur l'ordre des cibles et
+l'exportation des variables, sans jamais devenir fiable en CI.
+
+## Décision
+
+Revenir à npm pour les installations globales. Le commit `8e91200` l'explique :
+« Replace pnpm with npm for global package installation to avoid Volta shim
+issues in CI. npm is bundled with Node and works seamlessly. » pnpm reste
+installé pour le développement de projets locaux.
+
+## Conséquences
+
+- Aucun répertoire global ni variable d'environnement supplémentaire à
+  configurer.
+- Installations globales plus lentes et plus volumineuses qu'avec pnpm.
+- La CI installe la chaîne Node sans étape de contournement.
+
+## Alternatives écartées
+
+- pnpm en global : source du problème, retiré.
+- Installation par Homebrew des CLI Node : version découplée du runtime du
+  projet.

--- a/docs/adr/018-orbstack-runtime-conteneurs.md
+++ b/docs/adr/018-orbstack-runtime-conteneurs.md
@@ -1,0 +1,30 @@
+# ADR-018 — OrbStack comme runtime de conteneurs
+
+- **Statut** : accepté
+- **Date** : 2024-02
+- **Commits** : `4610246`
+
+## Contexte
+
+boot2docker puis docker-machine puis Docker Desktop se sont succédé. Sur macOS
+Apple Silicon, Docker Desktop consomme des ressources notables au repos, démarre
+lentement et impose des conditions de licence en entreprise.
+
+## Décision
+
+Installer OrbStack à la place de Docker Desktop. L'intégration shell est
+conditionnée à la présence effective d'OrbStack, afin que la configuration
+Fish reste utilisable sans lui.
+
+## Conséquences
+
+- Démarrage rapide et empreinte réduite au repos ; CLI `docker` inchangée.
+- Les cibles Docker doivent tolérer l'absence de daemon — en CI, ou juste
+  après une installation neuve — d'où le garde `DOCKER_OR_SKIP`
+  ([ADR-023](023-ci-lint-et-installation.md)).
+- Dépendance à un produit tiers propriétaire.
+
+## Alternatives écartées
+
+- Docker Desktop : lourd, licence contraignante.
+- Colima ou Lima : intégration macOS moins aboutie.

--- a/docs/adr/019-pas-de-tiling-window-manager.md
+++ b/docs/adr/019-pas-de-tiling-window-manager.md
@@ -1,0 +1,30 @@
+# ADR-019 — Aucun gestionnaire de fenêtres en tuiles
+
+- **Statut** : accepté
+- **Date** : 2025-12
+- **Commits** : `0b6a5b9`, `163e6df`
+
+## Contexte
+
+Quatre gestionnaires en tuiles se sont succédé entre 2014 et 2022 : slate, kwm
+avec khd, chunkwm, puis yabai. Chacun demandait une configuration
+substantielle, cassait à chaque version majeure de macOS et, pour yabai,
+exigeait la désactivation partielle de la protection d'intégrité du système.
+
+## Décision
+
+Abandonner le pavage automatique. La cible `yabai` et le fichier `yabairc` sont
+supprimés ; Rectangle Pro couvre le besoin réel — positionner une fenêtre au
+raccourci clavier — sans configuration ni concession de sécurité.
+
+## Conséquences
+
+- Plus de rupture à chaque mise à jour de macOS, ni d'affaiblissement de SIP.
+- Perte du pavage automatique et des espaces virtuels scriptés.
+- Une dépendance payante de plus, exclue des installations par défaut
+  ([ADR-002](002-homebrew-source-unique.md)).
+
+## Alternatives écartées
+
+- yabai : coût de maintenance et exigence de désactivation partielle de SIP.
+- AeroSpace : non évalué dans l'historique ; réexamen possible.

--- a/docs/adr/020-hooks-de-push-maison.md
+++ b/docs/adr/020-hooks-de-push-maison.md
@@ -1,0 +1,33 @@
+# ADR-020 — Hooks de push maison dans `scripts/`
+
+- **Statut** : accepté
+- **Date** : 2022-11
+- **Commits** : `a99248c`, `c3ee8ca`
+
+## Contexte
+
+Certaines erreurs ne se découvrent qu'en revue ou en CI, alors qu'elles sont
+détectables localement en quelques secondes : fautes de frappe, `TODO` oubliés,
+fichiers vides commités, erreurs ESLint, copier-coller massif.
+
+## Décision
+
+Des scripts autonomes dans `scripts/` (`git_hook_assert_typos`,
+`git_hook_assert_todoes`, `git_hook_assert_empty_files`,
+`git_hook_assert_eslint`, `git_hook_detect_copy_paste`) sont enchaînés par
+`git_hook_push` et exécutés au push, pas au commit.
+
+## Conséquences
+
+- Le commit reste rapide ; la vérification a lieu au moment où le travail
+  devient visible des autres.
+- Chaque script est testable et exécutable seul.
+- Un push peut échouer pour une raison stylistique, contournable par
+  `--no-verify` en cas d'urgence.
+
+## Alternatives écartées
+
+- Hooks de pre-commit : ralentissent chaque commit, y compris les commits
+  intermédiaires.
+- Framework de hooks (husky, pre-commit) : dépendance supplémentaire pour ce
+  que cinq scripts shell couvrent.

--- a/docs/adr/021-branche-main-detectee.md
+++ b/docs/adr/021-branche-main-detectee.md
@@ -1,0 +1,32 @@
+# ADR-021 — `main` détectée dynamiquement
+
+- **Statut** : accepté
+- **Date** : 2023-12
+- **Commits** : `cc9e0db`, `7070bc9`
+
+## Contexte
+
+La branche principale est passée de `master` à `main` dans ce dépôt, mais les
+dépôts fréquentés au quotidien n'ont pas basculé au même moment. Coder le nom
+en dur dans les fonctions de rebase et de revue casse sur la moitié d'entre
+eux.
+
+## Décision
+
+Ce dépôt utilise `main`. Les fonctions et scripts qui ont besoin du nom de la
+branche principale — l'abbreviation `grbm`, `scripts/review`, les hooks de
+push — passent par
+`scripts/git_main_branch`, qui interroge le dépôt courant et retombe sur
+`master` le cas échéant.
+
+## Conséquences
+
+- Les mêmes raccourcis fonctionnent sur les dépôts anciens et récents.
+- Une indirection de plus dans chaque fonction concernée.
+- La logique de détection est centralisée en un point unique.
+
+## Alternatives écartées
+
+- Nom en dur : casse sur les dépôts restés en `master`.
+- Variable de configuration par dépôt : à renseigner manuellement à chaque
+  clone.

--- a/docs/adr/022-conventional-commits.md
+++ b/docs/adr/022-conventional-commits.md
@@ -1,0 +1,31 @@
+# ADR-022 — Conventional Commits imposés
+
+- **Statut** : accepté
+- **Date** : 2025-12
+- **Commits** : `28f9caa`
+
+## Contexte
+
+Les messages de commit antérieurs à 2015 sont des phrases libres (« Add
+wallpapers », « Fix tmux install »), impossibles à filtrer par nature de
+changement. La convention `type(scope): sujet` s'était installée par usage
+sans être écrite, et les agents ne pouvaient donc pas la respecter.
+
+## Décision
+
+Formaliser Conventional Commits comme règle d'agent : `type(scope): sujet` à
+l'impératif, corps expliquant le pourquoi quand il n'est pas évident.
+
+## Conséquences
+
+- L'historique devient filtrable par type et par périmètre — c'est ce qui a
+  rendu possible la reconstitution de ces ADR.
+- La convention est appliquée sans automatisation : ni commitlint, ni hook de
+  vérification du message.
+- Les commits antérieurs restent non conformes ; la convention ne vaut que
+  pour la suite.
+
+## Alternatives écartées
+
+- commitlint en hook : une dépendance Node dans le chemin de chaque commit.
+- Aucune convention : historique non exploitable.

--- a/docs/adr/023-ci-lint-et-installation.md
+++ b/docs/adr/023-ci-lint-et-installation.md
@@ -1,0 +1,36 @@
+# ADR-023 — CI de lint et test d'installation
+
+- **Statut** : accepté
+- **Date** : 2026-01
+- **Commits** : `62a7644` (#41), `8d658d4`
+
+## Contexte
+
+Une erreur de syntaxe dans un fichier Fish ou Lua ne se manifeste qu'à
+l'ouverture du shell ou de l'éditeur, souvent après le push. Une cible
+`Makefile` cassée ne se découvre qu'à la réinstallation d'un poste, c'est-à-dire
+au pire moment.
+
+## Décision
+
+Deux workflows GitHub Actions. `lint.yml` vérifie la syntaxe Fish
+(`fish --no-execute`), le formatage (`fish_indent`), le Lua Neovim (`luacheck`)
+et les scripts shell (ShellCheck). `test.yml` exécute l'installation complète
+sur un runner macOS, apps payantes exclues (`SKIP_PAID_APPS`) et cibles Docker
+ignorées en l'absence de daemon (`DOCKER_OR_SKIP`).
+
+## Conséquences
+
+- Le `Makefile` est vérifié en continu, pas seulement lors d'une
+  réinstallation.
+- Le test d'installation est long, d'où les timeouts relevés à plusieurs
+  reprises dans l'historique.
+- La CI impose des garde-fous au `Makefile` (approbation des taps, absence de
+  daemon Docker) qui n'ont pas d'utilité sur un poste réel.
+
+## Alternatives écartées
+
+- Vérification manuelle avant push : oubliée dès que le changement paraît
+  anodin.
+- Test d'installation dans une VM locale : plus lent, non déclenché
+  automatiquement.

--- a/docs/adr/024-instructions-ia-versionnees.md
+++ b/docs/adr/024-instructions-ia-versionnees.md
@@ -1,0 +1,29 @@
+# ADR-024 — Instructions IA versionnées dans le dépôt
+
+- **Statut** : accepté
+- **Date** : 2026-01
+- **Commits** : `242b577`
+
+## Contexte
+
+Chaque agent stocke ses instructions à son emplacement propre
+(`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, règles Cursor). Ces fichiers
+répétaient les mêmes attentes, divergeaient à la première modification et
+n'étaient pas versionnés.
+
+## Décision
+
+Les instructions vivent dans le dépôt, sous `ai/`, et sont distribuées à chaque
+agent depuis là — par symlink, ou par assemblage quand l'agent ne suit pas les
+imports ([ADR-003](003-deploiement-par-symlinks.md)).
+
+## Conséquences
+
+- Les instructions sont versionnées, relues et révocables comme du code.
+- Une modification profite à tous les agents simultanément.
+- Chaque nouvel agent ajoute une cible de distribution au `Makefile`.
+
+## Alternatives écartées
+
+- Instructions par agent : divergence garantie.
+- Instructions par projet uniquement : ne couvre pas les attentes transverses.

--- a/docs/adr/025-agents-md-source-unique.md
+++ b/docs/adr/025-agents-md-source-unique.md
@@ -1,0 +1,33 @@
+# ADR-025 — `AGENTS.md` comme source unique agent-agnostique
+
+- **Statut** : accepté
+- **Date** : 2026-02
+- **Commits** : `170c966` (#42), `0fb9e89`
+
+## Contexte
+
+Les règles se dupliquaient entre `AGENTS.md`, les règles Cursor et les
+instructions Claude. `AGENTS.md` décrivait en outre ses propres adaptateurs :
+le commit `0fb9e89` relève « a self-referential CLAUDE.md bullet and a list of
+skills symlinks already visible in the tree. Both named specific agents in a
+file every agent reads. »
+
+## Décision
+
+`AGENTS.md` est la source unique des règles du dépôt et ne nomme aucun agent.
+Les fichiers spécifiques à un agent se réduisent à une redirection explicite —
+`CLAUDE.md` contient un import `@AGENTS.md` plutôt qu'un symlink — et la règle
+de conflit est écrite : en cas de désaccord, `AGENTS.md` l'emporte.
+
+## Conséquences
+
+- Une règle s'écrit à un seul endroit et vaut pour tous les agents.
+- Un agent qui ne suit pas les imports demande un traitement particulier
+  ([ADR-003](003-deploiement-par-symlinks.md)).
+- La redirection est visible dans le fichier plutôt que cachée dans le système
+  de fichiers.
+
+## Alternatives écartées
+
+- Un fichier de règles par agent : duplication et divergence.
+- Symlink `CLAUDE.md → AGENTS.md` : redirection invisible à la lecture.

--- a/docs/adr/026-agents-cli-plutot-que-copilot.md
+++ b/docs/adr/026-agents-cli-plutot-que-copilot.md
@@ -1,0 +1,31 @@
+# ADR-026 — Agents CLI plutôt que Copilot
+
+- **Statut** : accepté
+- **Date** : 2025-10
+- **Commits** : `ce71590`
+
+## Contexte
+
+GitHub Copilot, intégré à Neovim depuis 2021 et complété par ses alias CLI en
+2024, se limite à la complétion dans le tampon courant. Les agents en ligne de
+commande apparus depuis lisent le dépôt, exécutent des commandes et
+travaillent sur plusieurs fichiers.
+
+## Décision
+
+Retirer Copilot, de Neovim comme du shell, et travailler avec Claude Code,
+Codex et Cursor, installés et mis à jour par le `Makefile`, avec leurs alias
+Fish (`c`, `co`).
+
+## Conséquences
+
+- Un seul mode d'interaction avec l'assistance, hors de l'éditeur.
+- L'éditeur redevient un éditeur, sans complétion propriétaire dans le tampon.
+- Trois agents à installer, configurer et instruire, d'où
+  [ADR-024](024-instructions-ia-versionnees.md) et
+  [ADR-025](025-agents-md-source-unique.md).
+
+## Alternatives écartées
+
+- Conserver Copilot en complément : deux abonnements et deux modèles
+  d'interaction pour un bénéfice marginal.

--- a/docs/adr/027-soul-et-user-separes.md
+++ b/docs/adr/027-soul-et-user-separes.md
@@ -1,0 +1,33 @@
+# ADR-027 — `SOUL.md` et `USER.md` séparés de `AGENTS.md`
+
+- **Statut** : accepté
+- **Date** : 2026-08
+- **Commits** : `3005717` (#47)
+
+## Contexte
+
+`AGENTS.md` mélangeait trois natures d'information : les règles du dépôt, la
+voix attendue de l'agent et les préférences de travail de l'utilisateur. Le
+mélange produisait des contradictions — le commit `3005717` relève une règle
+« ASK rather than assume » incompatible avec le principe « assume and
+declare » — et empêchait de charger la voix hors du dépôt.
+
+## Décision
+
+Trois fichiers de portées distinctes : `ai/SOUL.md` pour l'identité (langue,
+registre, priorités), `ai/USER.md` pour les biais et attentes de travail,
+`AGENTS.md` pour les règles du dépôt. `SOUL.md` et `USER.md` sont importés dans
+les instructions globales et valent donc pour tous les projets.
+
+## Conséquences
+
+- Voix et préférences s'appliquent hors de ce dépôt.
+- Une contradiction se tranche par la portée du fichier concerné.
+- Trois fichiers à tenir cohérents, avec un risque de recouvrement à
+  surveiller.
+
+## Alternatives écartées
+
+- Tout garder dans `AGENTS.md` : contradictions et portée limitée au dépôt.
+- Configuration propre à chaque agent : contraire à
+  [ADR-025](025-agents-md-source-unique.md).

--- a/docs/adr/028-skills-ssot.md
+++ b/docs/adr/028-skills-ssot.md
@@ -1,0 +1,34 @@
+# ADR-028 — `.agents/skills/` comme source unique des skills
+
+- **Statut** : accepté
+- **Date** : 2026-05
+- **Commits** : `170c966` (#42), `293c6e1`, `3133e06`
+
+## Contexte
+
+Les procédures réutilisables — conventions du dépôt, Neovim, scripts, Johnny
+Decimal — existaient sous forme de règles Cursor, donc liées à un agent et
+invisibles des autres. Leur qualité variait, et une skill mal décrite n'est
+jamais déclenchée.
+
+## Décision
+
+`.agents/skills/` est la source unique des skills, chaque skill étant un
+répertoire portant son `SKILL.md`, distribué aux agents par symlink.
+`skill-manager` encadre la création, la validation et la synchronisation de
+l'index `README.md`. Le budget de description a été réduit de moitié
+(`3133e06`), la description conditionnant le déclenchement.
+
+## Conséquences
+
+- Une skill écrite une fois est utilisable par tous les agents.
+- La contrainte de description force à énoncer le déclencheur plutôt que le
+  contenu.
+- Toute modification, fût-ce un champ de frontmatter, passe par
+  `skill-manager`.
+
+## Alternatives écartées
+
+- Règles Cursor : liées à un agent, non réutilisables.
+- Instructions inline dans `AGENTS.md` : fichier illisible et chargé en
+  totalité à chaque session.

--- a/docs/adr/029-pas-de-skills-tierces.md
+++ b/docs/adr/029-pas-de-skills-tierces.md
@@ -1,0 +1,33 @@
+# ADR-029 — Skills tierces refusées par défaut
+
+- **Statut** : accepté
+- **Date** : 2026-05
+- **Commits** : `e43f299`, `265f17e`, `39530c3`, `1ecef61`
+
+## Contexte
+
+Début 2026, une vingtaine de cibles installaient des skills tierces
+(typescript, supabase, shadcn, next, turborepo, prisma, bash-pro, caveman,
+rtk…). Chacune occupe du contexte à chaque session, se périme au rythme d'un
+tiers et recouvre partiellement les autres.
+
+## Décision
+
+N'installer par défaut que les skills maintenues dans ce dépôt. Les paquets de
+skills tierces ont été retirés par vagues successives, jusqu'à caveman et rtk
+en 2026-08. Une skill tierce doit justifier sa place, comme toute dépendance.
+
+## Conséquences
+
+- Contexte d'agent plus léger et déclenchements plus prévisibles.
+- Le savoir-faire d'un domaine doit être réécrit localement quand il est
+  nécessaire.
+- Décision cohérente avec la vigilance sur les dépendances inscrite dans
+  `USER.md`.
+- Les deux retraits les mieux documentés font l'objet d'une ADR propre :
+  [ADR-033](033-pas-de-rtk.md) et [ADR-034](034-pas-de-caveman.md).
+
+## Alternatives écartées
+
+- Installer largement et laisser l'agent trier : coût de contexte permanent,
+  déclenchements parasites.

--- a/docs/adr/030-brain-memoire-durable.md
+++ b/docs/adr/030-brain-memoire-durable.md
@@ -1,0 +1,33 @@
+# ADR-030 — `~/Brain` comme mémoire durable partagée
+
+- **Statut** : accepté
+- **Date** : 2026-07
+- **Commits** : `ff5b87d` (#45)
+
+## Contexte
+
+Chaque agent propose sa propre mémoire persistante. Une information consignée
+dans la mémoire de Claude est invisible de Codex et de Cursor, et disparaît
+avec l'agent. Les faits, décisions et références réutilisables méritent un
+support indépendant de l'outil.
+
+## Décision
+
+`~/Brain`, hébergé sur iCloud Drive (`BRAIN_PATH`) et symlinké par le
+`Makefile`, est la cible par défaut de la mémoire durable, avec ses propres
+instructions (`~/Brain/AGENTS.md`) que tout agent doit lire avant d'y écrire.
+La mémoire propre à un agent reste réservée à ce qui concerne son
+comportement.
+
+## Conséquences
+
+- Un fait consigné une fois est disponible pour tous les agents, et survit au
+  changement d'outil.
+- La règle d'aiguillage doit être rappelée dans `AGENTS.md`, les agents
+  privilégiant spontanément leur mémoire native.
+- Dépendance à la synchronisation iCloud.
+
+## Alternatives écartées
+
+- Mémoire native de chaque agent : cloisonnée et volatile.
+- Dépôt git dédié : synchronisation manuelle, moins immédiate qu'iCloud.

--- a/docs/adr/031-mcp-en-conteneurs-nommes.md
+++ b/docs/adr/031-mcp-en-conteneurs-nommes.md
@@ -1,0 +1,36 @@
+# ADR-031 — MCP en conteneurs Docker nommés
+
+- **Statut** : accepté
+- **Date** : 2026-08
+- **Commits** : `425af01`, `a2c71cf`, `508feb4`, `0525f5a`
+
+## Contexte
+
+Les serveurs MCP de récupération web (scrapling, firecrawl, CloakBrowser)
+embarquent navigateurs et dépendances Python lourdes, mal adaptées à une
+installation directe sur le poste. Enregistrés en `docker run -i --rm … mcp`,
+ils créaient un conteneur par session : le commit `0525f5a` constate
+« five were still running, the oldest for 12 hours ».
+
+## Décision
+
+Livrer ces MCP par images Docker et n'exécuter qu'un conteneur nommé par
+service : un script d'enveloppe démarre le conteneur à la demande
+(`docker start` ou `docker run`) puis lance le serveur stdio de chaque session
+à l'intérieur. Une escalade par paliers est inscrite dans les instructions
+globales : fetch intégré, puis `stealthy_fetch`, puis CloakBrowser, avec
+`--idle-timeout` pour l'arrêt automatique.
+
+## Conséquences
+
+- Un conteneur oublié coûte au plus un conteneur, non un par session.
+- Les dépendances lourdes restent isolées du poste.
+- Les cibles Docker doivent tolérer l'absence de daemon
+  ([ADR-018](018-orbstack-runtime-conteneurs.md),
+  [ADR-023](023-ci-lint-et-installation.md)).
+
+## Alternatives écartées
+
+- `docker run --rm` par session : fuite de conteneurs constatée.
+- Installation native des serveurs : dépendances navigateur ingérables sur le
+  poste.

--- a/docs/adr/032-johnny-decimal-documents.md
+++ b/docs/adr/032-johnny-decimal-documents.md
@@ -1,0 +1,30 @@
+# ADR-032 — Johnny Decimal pour `~/Documents`
+
+- **Statut** : accepté
+- **Date** : 2025-08
+- **Commits** : `135f67c`, `83b0f78`
+
+## Contexte
+
+Un classement libre de documents personnels dérive : catégories qui se
+recouvrent, mêmes documents rangés à deux endroits, noms de fichiers
+hétérogènes qui rendent la recherche inopérante.
+
+## Décision
+
+Appliquer Johnny Decimal, hybridé avec PARA, à `~/Documents` : catégories
+numérotées, un préfixe par document. Le script `scripts/jdl` vérifie la
+structure et renomme les fichiers non conformes avec `--fix`. La skill
+`johnny-decimal` porte la convention pour les agents ; `para-organizer`
+couvre les arborescences hors `~/Documents`.
+
+## Conséquences
+
+- Emplacement d'un document déductible de son numéro, sans recherche.
+- La convention est vérifiable automatiquement plutôt que tenue de mémoire.
+- Toute nouvelle catégorie exige une décision de numérotation explicite.
+
+## Alternatives écartées
+
+- Classement libre par dossiers thématiques : dérive constatée.
+- PARA seul : actionnable, mais sans identifiant stable par document.

--- a/docs/adr/033-pas-de-rtk.md
+++ b/docs/adr/033-pas-de-rtk.md
@@ -1,0 +1,43 @@
+# ADR-033 — Ne pas utiliser RTK pour réduire les tokens des outils
+
+- **Statut** : accepté
+- **Date** : 2026-08
+- **Commits** : `833a209` (adoption), `51e16d7`, `1ecef61` (retrait)
+
+## Contexte
+
+RTK avait été installé en 2026-03 : formule Homebrew, hook `PreToolUse`
+réécrivant les commandes de l'agent vers les équivalents `rtk`, une quarantaine
+d'entrées de permissions et un `~/.claude/RTK.md`. La promesse était une
+réduction du coût en tokens des sorties d'outils.
+
+Deux mesures l'ont infirmée, citées dans `1ecef61` :
+
+- Mesure JetBrains sur 86 tâches appariées de SkillsBench : **+7,6 % de coût**
+  à faible effort de raisonnement, **+0,1 %** à effort élevé — jamais un gain.
+- La métrique interne `rtk gain` note son propre contrefactuel : localement,
+  690,5 M des 781,5 M de tokens « économisés » provenaient de `rtk grep` à
+  24,5 % de réduction moyenne, c'est-à-dire de sortie brute que l'agent
+  n'aurait de toute façon jamais lue en entier.
+
+Par ailleurs, `~/.claude/RTK.md` n'était référencé par rien.
+
+## Décision
+
+Retirer RTK : cible `Makefile`, hook de réécriture `PreToolUse`, entrées de
+permissions et fichier d'instructions. Les agents utilisent directement `rg`,
+`fd` et les outils natifs ([ADR-015](015-cli-modernes.md)).
+
+## Conséquences
+
+- Un hook de moins dans le chemin de chaque appel d'outil, donc un point de
+  défaillance et une source d'écart de comportement en moins.
+- La configuration de permissions redevient lisible.
+- Une réadoption exigera une mesure appariée sur ce poste, non l'annonce d'un
+  gain.
+
+## Alternatives écartées
+
+- Conserver RTK en n'activant que `rtk grep` : c'est précisément la commande
+  dont le gain mesuré est un artefact de comptage.
+- Garder l'outil sans le hook : le coût d'installation subsiste sans usage.

--- a/docs/adr/034-pas-de-caveman.md
+++ b/docs/adr/034-pas-de-caveman.md
@@ -1,0 +1,46 @@
+# ADR-034 — Ne pas utiliser les skills Caveman
+
+- **Statut** : accepté
+- **Date** : 2026-08
+- **Commits** : `9e42a94` (adoption), `e5fcd90`, `39530c3` (retrait)
+
+## Contexte
+
+Les skills Caveman, installées en 2026-05, promettaient de comprimer les
+réponses de l'agent (annonce : −65 % de tokens de sortie). Le retrait
+(`39530c3`) constate trois choses :
+
+- **Elles ne s'activaient pas.** Installées telles quelles sous
+  `~/.agents/skills` sans hook `SessionStart`, elles n'ont jamais pu
+  s'auto-activer : l'activation automatique que promet leur README provient du
+  plugin, non des fichiers de skills.
+- **Le coût était payé quand même** : 2,5 Ko de descriptions, soit environ
+  620 tokens injectés dans la liste des skills à chaque démarrage de session.
+- **Le gain serait négatif ici de toute façon.** `SOUL.md` plafonne déjà les
+  réponses à cinq phrases, ce qui place l'usage dans le régime que l'auteur
+  documente lui-même dans `docs/HONEST-NUMBERS.md` : en dessous d'environ
+  1 500 tokens de sortie par réponse, les règles injectées coûtent plus que la
+  compression ne rapporte. Une mesure indépendante plafonne par ailleurs le
+  gain réel à −8,5 %, contre les −65 % annoncés.
+
+## Décision
+
+Retirer les cibles Caveman du `Makefile`. La concision reste obtenue par la
+contrainte de registre inscrite dans `SOUL.md`
+([ADR-027](027-soul-et-user-separes.md)).
+
+## Conséquences
+
+- 620 tokens récupérés à chaque démarrage de session.
+- La concision dépend d'une règle lisible et modifiable plutôt que d'un paquet
+  tiers.
+- Confirme la règle générale
+  ([ADR-029](029-pas-de-skills-tierces.md)) : une skill tierce doit prouver son
+  déclenchement autant que son gain.
+
+## Alternatives écartées
+
+- Installer le plugin complet pour obtenir l'auto-activation : ferait payer le
+  coût réel d'un gain mesuré négatif dans ce régime d'usage.
+- Conserver les skills en activation manuelle : le coût de description est dû à
+  chaque session, quel que soit l'usage.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,72 @@
+# Architecture Decision Records
+
+Décisions structurantes de ce dépôt, reconstituées depuis l'historique git
+(934 commits, 2014-08 → 2026-08). Format inspiré de
+[MADR](https://adr.github.io/madr/).
+
+## Portée
+
+Seules les décisions **en vigueur** sont enregistrées. Les décisions
+remplacées ne font pas l'objet d'une ADR ; elles apparaissent dans la section
+« Alternatives écartées » de celle qui les a remplacées (NvChad, prezto puis
+antigen, gestion des plugins Vim par cibles Makefile, nvm puis fnm,
+docker-machine, iTerm2 puis Alacritty, chunkwm puis yabai, Copilot, pnpm pour
+les paquets globaux).
+
+Exception : un retrait dont la justification est mesurée et réutilisable fait
+l'objet d'une ADR propre, la décision en vigueur étant alors « ne pas
+utiliser » (ADR-033, ADR-034).
+
+## Langue
+
+Les ADR sont rédigées en français, par exception à la règle « documentation en
+anglais » qui régit le reste du dépôt : elles consignent un raisonnement
+personnel, non une interface publique. L'exception vaut pour tout `docs/` et
+est portée par `docs/AGENTS.md`, rappelée dans l'`AGENTS.md` racine pour qu'un
+agent la connaisse avant même d'ouvrir un fichier du répertoire.
+
+## Fiabilité des motivations
+
+Le champ **Contexte** est une reconstitution a posteriori, sauf lorsqu'il cite
+le corps d'un commit — dans ce cas la citation est explicite. L'historique a
+été réécrit : les dates de commit valent toutes 2026-08-06, les dates citées
+ici sont les dates d'auteur.
+
+## Index
+
+| # | Titre | Date |
+|---|---|---|
+| [001](001-makefile-installateur.md) | Makefile idempotent comme installateur de poste | 2014-08 |
+| [002](002-homebrew-source-unique.md) | Homebrew et `mas` comme unique source de paquets | 2015-02 |
+| [003](003-deploiement-par-symlinks.md) | Déploiement de la configuration par symlinks | 2014-10 |
+| [004](004-script-upgrade-unique.md) | Script `upgrade` unique pour toutes les mises à jour | 2017-09 |
+| [005](005-elagage-des-cibles.md) | Élagage périodique des cibles inutilisées | 2025-12 |
+| [006](006-neovim-editeur-par-defaut.md) | Neovim comme éditeur par défaut | 2019-11 |
+| [007](007-lazyvim-comme-distribution.md) | LazyVim comme distribution Neovim | 2023-12 |
+| [008](008-lockfile-plugins-versionne.md) | `lazy-lock.json` versionné et Renovate | 2024-10 |
+| [009](009-lsp-natif-et-conform.md) | Lint et format par LSP natif et conform | 2026-07 |
+| [010](010-fish-shell-par-defaut.md) | Fish comme shell par défaut | 2025-01 |
+| [011](011-starship-comme-prompt.md) | Starship comme prompt unique | 2025-01 |
+| [012](012-abbreviations-fish.md) | Abbreviations Fish plutôt qu'alias git | 2026-01 |
+| [013](013-wezterm-emulateur.md) | WezTerm comme émulateur de terminal | 2026-01 |
+| [014](014-theme-catppuccin-unique.md) | Thème Catppuccin unique et bascule automatique | 2026-01 |
+| [015](015-cli-modernes.md) | CLI modernes en remplacement des historiques | 2026-01 |
+| [016](016-volta-gestionnaire-node.md) | Volta comme gestionnaire Node | 2021-05 |
+| [017](017-npm-pour-paquets-globaux.md) | npm pour les paquets globaux | 2026-01 |
+| [018](018-orbstack-runtime-conteneurs.md) | OrbStack comme runtime de conteneurs | 2024-02 |
+| [019](019-pas-de-tiling-window-manager.md) | Aucun gestionnaire de fenêtres en tuiles | 2025-12 |
+| [020](020-hooks-de-push-maison.md) | Hooks de push maison dans `scripts/` | 2022-11 |
+| [021](021-branche-main-detectee.md) | `main` détectée dynamiquement | 2023-12 |
+| [022](022-conventional-commits.md) | Conventional Commits imposés | 2025-12 |
+| [023](023-ci-lint-et-installation.md) | CI de lint et test d'installation | 2026-01 |
+| [024](024-instructions-ia-versionnees.md) | Instructions IA versionnées dans le dépôt | 2026-01 |
+| [025](025-agents-md-source-unique.md) | `AGENTS.md` comme source unique agent-agnostique | 2026-02 |
+| [026](026-agents-cli-plutot-que-copilot.md) | Agents CLI plutôt que Copilot | 2025-10 |
+| [027](027-soul-et-user-separes.md) | `SOUL.md` et `USER.md` séparés de `AGENTS.md` | 2026-08 |
+| [028](028-skills-ssot.md) | `.agents/skills/` comme source unique des skills | 2026-05 |
+| [029](029-pas-de-skills-tierces.md) | Skills tierces refusées par défaut | 2026-05 |
+| [030](030-brain-memoire-durable.md) | `~/Brain` comme mémoire durable partagée | 2026-07 |
+| [031](031-mcp-en-conteneurs-nommes.md) | MCP en conteneurs Docker nommés | 2026-08 |
+| [032](032-johnny-decimal-documents.md) | Johnny Decimal pour `~/Documents` | 2025-08 |
+| [033](033-pas-de-rtk.md) | Ne pas utiliser RTK | 2026-08 |
+| [034](034-pas-de-caveman.md) | Ne pas utiliser les skills Caveman | 2026-08 |


### PR DESCRIPTION
## Description

- Remove the `rtk` and Caveman integrations that are no longer part of the supported setup.
- Shorten shared skill descriptions while preserving their activation semantics.
- Record the architecture decisions still in force and bind repository agent guidance to the French ADR documentation.

## Useful Links

- Issue: N/A

## How to Test

- Run `git diff --check origin/main...HEAD`.
- Run the shared-skill doctor checks.
- Run `make -n all SKIP_PAID_APPS=1`.
- Confirm the GitHub Actions `Lint` and `Smoke tests` workflows pass.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)