### PR TITLE
docs(agents): drop six AGENTS.md rules measured as no-ops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,7 @@ This file is the single source of truth for all coding agents working in this re
 ## Architecture Decisions
 
 - `docs/adr/` records the structural decisions of this repository, indexed in `docs/adr/README.md`. Only decisions still in force are recorded.
-- Before changing a structural choice (installer, shell, editor, package source, container runtime, agent instructions, skills layout), read the matching ADR. Its "Alternatives écartées" section usually already covers the option being reconsidered, with the reason it was dropped.
 - Never contradict an ADR silently. Either follow it, or state the conflict, then deliver what was asked along with the ADR that would need superseding.
-- A new structural decision gets a new ADR in the same MADR format, citing the commit hashes that carry it. A decision that replaces another one absorbs it: the superseded ADR is deleted, and its rationale moves to the new "Alternatives écartées" section.
-- **Everything under `docs/`, ADRs included, is written in French**, by explicit exception to the English-documentation rule; `docs/AGENTS.md` holds the detail. Do not translate existing documents, and do not write the next one in English.
 - Routine changes — adding a tool target, updating a lockfile, editing a skill — need no ADR.
 
 ## Personal Brain
@@ -26,7 +23,4 @@ This file is the single source of truth for all coding agents working in this re
 
 ## Shared Skills
 
-- `.agents/skills/` is the single source of truth for reusable agent skills.
-- Read `.agents/skills/README.md` for the current skill index.
-- Use `skill-manager` whenever creating, migrating, editing, validating, or organizing skills.
 - Agent-specific directories must not duplicate repository-wide rules or skill content.

--- a/docs/adr/035-agents-md-elague-par-mesure.md
+++ b/docs/adr/035-agents-md-elague-par-mesure.md
@@ -1,0 +1,80 @@
+# ADR-035 — `AGENTS.md` élagué par mesure du no-op
+
+- **Statut** : accepté
+- **Date** : 2026-08
+- **Commits** : `#50`
+
+## Contexte
+
+L'`AGENTS.md` racine avait atteint 32 lignes, dont plusieurs redisaient ce que
+`docs/AGENTS.md`, `docs/adr/README.md` et les descriptions de skills portent
+déjà — au contraire de ce que pose l'[ADR-025](025-agents-md-source-unique.md),
+« une règle s'écrit à un seul endroit ». Le rappel de la règle de langue était
+même documenté comme une duplication volontaire, « pour qu'un agent la
+connaisse avant même d'ouvrir un fichier du répertoire ».
+
+Le *test du no-op* de Matt Pocock donne le critère : supprimer cette ligne
+change-t-il le comportement par rapport au comportement par défaut ? Il est
+comportemental et non esthétique, et il ne se tranche qu'en exécutant le
+document. Le protocole reprend celui appliqué au coffre `~/Brain` le
+2026-08-07 : 36 exécutions Opus 5 via `claude -p`, un clone jetable par run,
+`AGENTS.md` et `CLAUDE.md` retirés du disque en condition *sans*, hook `Stop`
+du dépôt neutralisé dans les deux conditions, six scénarios × deux conditions ×
+trois réplicats.
+
+Résultats, condition *avec* contre condition *sans* :
+
+| Règle | Avec | Sans |
+|---|---|---|
+| Lire l'ADR concernée avant un changement structurel | 3/3 | 3/3 |
+| Écrire une ADR pour une décision structurante | 1/3 | 2/3 |
+| Rédiger en français sous `docs/` | 3/3 | 3/3 |
+| Créer les skills dans `.agents/skills/` | 3/3 | 3/3 |
+| Tenir à jour l'index `.agents/skills/README.md` | 3/3 | 3/3 |
+| Invoquer `skill-manager` | 3/3 | 3/3 |
+
+Un run privé du fichier a même énoncé le conflit ADR-010/ADR-012 plus
+complètement qu'un run qui l'avait en contexte. Ce qui porte réellement ces
+comportements est mesurable : `docs/AGENTS.md`, ouvert spontanément (3/3 sur le
+scénario de rédaction, 2/3 sur celui de décision structurante),
+`docs/adr/README.md`, l'arborescence de `docs/adr/`, et les descriptions des
+skills `dotfiles`, `neovim` et `skill-manager`, qui se déclenchent sans routeur.
+
+## Décision
+
+Une règle n'est gardée dans l'`AGENTS.md` racine que si son retrait change le
+comportement, constaté par exécution et non supposé. Les six règles ci-dessus
+sont retirées ; le fichier passe de 32 à 26 lignes.
+
+Restent, faute de mesure les infirmant : la règle de conflit, les trois règles
+de portée, la définition de `docs/adr/`, l'interdiction de contredire une ADR
+en silence, la dispense pour les changements de routine, les deux règles
+`~/Brain` et l'interdiction de dupliquer une règle dans un répertoire propre à
+un agent.
+
+## Conséquences
+
+- Réinscrire une règle retirée demande une mesure qui la montre portante, non
+  une intuition. Le mode d'échec inverse — le sédiment, ces couches qu'on
+  ajoute parce que retirer paraît dangereux — est ce que ce critère arrête.
+- `docs/adr/README.md` ne promet plus le rappel de la règle de langue dans
+  l'`AGENTS.md` racine.
+- La mesure vaut pour Opus 5 sous Claude Code, skills disponibles. Un agent
+  sans mécanisme de skills — Codex lit le même fichier — peut avoir un
+  comportement par défaut différent : une divergence constatée là-bas se
+  traite par une mesure sur cet agent, pas par une réinscription d'office.
+- La seule règle de portée mesurée porte au bloc, pas à la ligne : sans le
+  fichier, deux runs sur trois s'arrêtent pour demander le périmètre au lieu de
+  livrer. L'ablation menée est au fichier ; attribuer cet effet à une phrase
+  précise demanderait deux ablations à la ligne.
+
+## Alternatives écartées
+
+- **Garder par précaution** : c'est la définition du sédiment, et le coût est
+  payé à chaque tour de chaque agent.
+- **Déplacer les six règles dans les skills** : elles y sont déjà, ou l'index
+  et l'arborescence les portent ; les y réécrire recréerait la duplication que
+  l'[ADR-025](025-agents-md-source-unique.md) refuse.
+- **Raccourcir le fichier à l'œil** : un agent à qui l'on demande d'alléger
+  optimise la longueur, seule chose qu'il voit, et coupe la fonctionnalité avec
+  le reste.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,8 +22,9 @@ utiliser » (ADR-033, ADR-034).
 Les ADR sont rédigées en français, par exception à la règle « documentation en
 anglais » qui régit le reste du dépôt : elles consignent un raisonnement
 personnel, non une interface publique. L'exception vaut pour tout `docs/` et
-est portée par `docs/AGENTS.md`, rappelée dans l'`AGENTS.md` racine pour qu'un
-agent la connaisse avant même d'ouvrir un fichier du répertoire.
+est portée par `docs/AGENTS.md`. Le rappel qui la doublait dans l'`AGENTS.md`
+racine a été retiré : mesuré, il ne changeait rien
+([ADR-035](035-agents-md-elague-par-mesure.md)).
 
 ## Fiabilité des motivations
 
@@ -70,3 +71,4 @@ ici sont les dates d'auteur.
 | [032](032-johnny-decimal-documents.md) | Johnny Decimal pour `~/Documents` | 2025-08 |
 | [033](033-pas-de-rtk.md) | Ne pas utiliser RTK | 2026-08 |
 | [034](034-pas-de-caveman.md) | Ne pas utiliser les skills Caveman | 2026-08 |
+| [035](035-agents-md-elague-par-mesure.md) | `AGENTS.md` élagué par mesure du no-op | 2026-08 |


### PR DESCRIPTION
Le *test du no-op* demande si retirer une ligne change le comportement par rapport au comportement par défaut. Six règles de l'`AGENTS.md` racine n'en changent aucun : elles sont retirées, le fichier passe de 32 à 26 lignes.

## Mesure

36 exécutions Opus 5 (`claude -p`), un clone jetable par run, `AGENTS.md` + `CLAUDE.md` retirés du disque en condition *sans*, hook `Stop` du dépôt neutralisé dans les deux conditions, 6 scénarios × 2 conditions × 3 réplicats.

| Règle | Avec | Sans | Verdict |
|---|---|---|---|
| Lire l'ADR concernée avant un changement structurel | 3/3 | 3/3 | no-op |
| Écrire une ADR pour une décision structurante | 1/3 | 2/3 | no-op |
| Rédiger en français sous `docs/` | 3/3 | 3/3 | no-op |
| Créer les skills dans `.agents/skills/` | 3/3 | 3/3 | no-op |
| Tenir à jour l'index `.agents/skills/README.md` | 3/3 | 3/3 | no-op |
| Invoquer `skill-manager` | 3/3 | 3/3 | no-op |
| Livrer sous conflit d'ADR (portée + « then deliver ») | livre 3/3 | livre 1/3, demande le périmètre 2/3 | **portante, gardée** |

Un run privé du fichier a énoncé le conflit ADR-010/ADR-012 plus complètement qu'un run qui l'avait en contexte. Les porteurs réels, mesurés : `docs/AGENTS.md` ouvert spontanément (3/3 sur le scénario de rédaction, 2/3 sur celui de décision structurante), `docs/adr/README.md`, l'arborescence `docs/adr/`, et les descriptions des skills `dotfiles`, `neovim` et `skill-manager`, qui se déclenchent sans routeur.

## Conflit signalé

`docs/adr/README.md` documentait la duplication de la règle de langue comme volontaire, « rappelée dans l'`AGENTS.md` racine pour qu'un agent la connaisse avant même d'ouvrir un fichier du répertoire ». La mesure infirme le besoin (3/3 en français sans le rappel) : la phrase est corrigée dans la même passe, sans quoi elle décrirait un rappel disparu.

## Limites

- **Ablation au fichier, pas à la ligne.** L'effet de livraison peut venir de « Do only what was asked » ou de « then deliver what was asked ». Deux ablations à la ligne, 3 runs chacune, trancheraient.
- **Un scénario nul** : la demande large (`Nettoie la configuration nvim`) a perdu 4 runs sur 6 sur un plafond de dépense. Les règles de portée ne sont mesurées qu'indirectement.
- **Un scénario raté** : `zoxide` était déjà installé, les deux conditions répondent « déjà présent ».
- **Sans scénario, donc gardées par défaut** : règle de conflit, définition de `docs/adr/`, dispense de routine, les deux règles `~/Brain` (exclues du montage : elles écriraient dans le coffre iCloud réel), non-duplication dans un répertoire d'agent.
- **Mesuré sur Opus 5 sous Claude Code**, skills disponibles. Codex lit le même fichier sans mécanisme de skills : une divergence là-bas se traite par une mesure, pas par une réinscription d'office.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6oT6NsYsN1sKqW6beBVYd
