### PR TITLE
feat(ai): three harness rules, measured before writing

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -11,10 +11,11 @@ This directory is the single source of truth for reusable agent skills.
 
 ## Dev
 
-| Skill     | Description |
-| --------- | ----------- |
-| `neovim`  | Maintain this repository's Neovim and LazyVim configuration. |
-| `scripts` | Create and maintain portable Bash scripts in this repository. |
+| Skill               | Description |
+| ------------------- | ----------- |
+| `enforcement-code`  | Write code whose purpose is to refuse something: hook, guard, validator, permission check, lint rule, CI gate. |
+| `neovim`            | Maintain this repository's Neovim and LazyVim configuration. |
+| `scripts`           | Create and maintain portable Bash scripts in this repository. |
 
 ## Ops
 

--- a/.agents/skills/enforcement-code/SKILL.md
+++ b/.agents/skills/enforcement-code/SKILL.md
@@ -60,6 +60,9 @@ alias, the `--no-verify` and the second remote).
 - **`command -v` guards.** `if command -v tool > /dev/null; then check; fi` silently skips the
   check on any machine missing the tool — the exact machine that needs it most. Invert it: refuse
   when the tool is absent.
+- **A discovery step that finds nothing.** `git grep -E` does not support `\b`, so such a pattern
+  matches zero files without erroring, and the gate passes having read nothing. Guard the step
+  with a canary: a file you know must appear in its output.
 - **Testing only the refusal you implemented.** The interesting test is the input you did not
   think of; that is what step 5 produces.
 - **A guard tested only by hand.** It passes on the author's machine, then rots. If the project has

--- a/.agents/skills/enforcement-code/SKILL.md
+++ b/.agents/skills/enforcement-code/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: enforcement-code
+description: >
+  Write code whose purpose is to refuse: hook, guard, validator, permission check, lint rule, CI
+  gate. Use when adding or changing any control that decides pass or fail. Make sure to use it
+  whenever a check can be bypassed or fail to run, even if it is called a wrapper or a policy.
+metadata:
+  category: dev
+---
+
+# Enforcement Code
+
+## Overview
+
+A guard is judged by what it refuses when someone tries to get around it, not by whether it passes
+its happy path. The two failure modes that survive review are a control that inspects a
+representation of the dangerous value instead of the value itself, and a control that returns
+success because it could not run. Both look green in every test written from the author's own
+assumptions.
+
+## Usage
+
+Follow the steps below when writing or changing a hook, a guard, a validator, a permission check, a
+lint rule or a CI gate — before opening the file, since step 1 often changes where the code belongs.
+
+Typical cases: "block `rm -rf` outside the repository" (step 1 moves the decision off the command
+string), "fail CI when a migration has no rollback" (steps 3 and 4 stop the gate from passing when
+the migration list comes back empty), "refuse a push without a signed commit" (step 5 enumerates the
+alias, the `--no-verify` and the second remote).
+
+## Steps
+
+1. **Name the sink.** Write down the exact value that reaches what you protect: the expanded argv,
+   the request body, the SQL parameter, the resolved path. Validate that value.
+2. **Check whether you can actually see it.** If the code only has a representation of the value — a
+   shell command string, a diff, a log line, a commit message — the decision is a heuristic, not a
+   check. Say so in a comment and in the delivery note, and label that layer advisory. Do not let a
+   heuristic be the only barrier for a consequence you cannot undo.
+3. **Fail closed.** Missing runtime, unreadable input, parser exception, unresolved variable, empty
+   result: refuse, and name what was missing. A guard that exits 0 because it could not run is a
+   disabled guard, and it stays disabled silently for months.
+4. **Keep the probe's failure visible.** No `2>/dev/null` on the command that decides whether the
+   guard can run, and no branch that turns an empty result into success. If the probe is allowed to
+   fail quietly, step 3 is unenforceable.
+5. **Enumerate the bypasses before writing the fix.** List how the control can be satisfied or
+   skipped: compound command, duplicate flags, a second invocation, an alias or a function, a
+   missing interpreter, another host, a subshell, a renamed file. Keep the list in the commit body
+   or the test file.
+6. **Turn each entry of that list into a test case** wired into the project's automated checks. A
+   manual self-test does not count: it disappears with the session that ran it.
+7. **When a bypass is cheap and its consequence real, run an adversarial pass.** Dispatch a
+   fresh-context subagent whose mandate is to break the guard, not to review it; its output is the
+   list of attempts and their results. Skip this for a control whose worst case is a warning.
+
+## Gotchas
+
+- **Parsing a shell command to decide.** Quoting, `$()`, `&&`, aliases and `env` prefixes all
+  change what finally executes. Such a layer is a speed bump; the real check belongs where the
+  command's effect lands.
+- **`command -v` guards.** `if command -v tool > /dev/null; then check; fi` silently skips the
+  check on any machine missing the tool — the exact machine that needs it most. Invert it: refuse
+  when the tool is absent.
+- **Testing only the refusal you implemented.** The interesting test is the input you did not
+  think of; that is what step 5 produces.
+- **A guard tested only by hand.** It passes on the author's machine, then rots. If the project has
+  no place to wire the test, that missing harness is part of the work.
+- **The context that wrote the guard cannot break it.** It shares the blind spots that produced the
+  hole, and will confirm its own design. Only a fresh context is adversarial.
+
+## Constraints
+
+- Never decide on a proxy for the protected value when the value itself is reachable.
+- Never exit 0 on a path where the guard could not do its job; refuse and name the cause.
+- Never suppress the errors of the probe that establishes whether the guard can run.
+- Every enumerated bypass must exist as an automated test before delivery.
+- State plainly which layer is advisory and which is enforcing; a heuristic presented as a
+  guarantee is worse than no guard.

--- a/.agents/skills/enforcement-code/evals/trigger-queries.json
+++ b/.agents/skills/enforcement-code/evals/trigger-queries.json
@@ -1,0 +1,36 @@
+{
+  "skill": "enforcement-code",
+  "version": "1.0",
+  "queries": [
+    {
+      "query": "Ajoute un hook PreToolUse qui bloque les commandes rm -rf hors du dépôt",
+      "should_activate": true,
+      "reason": "Hook that refuses an action; decides pass or fail"
+    },
+    {
+      "query": "Write a CI step that fails the build when a migration has no down script",
+      "should_activate": true,
+      "reason": "CI gate; enumerable bypasses"
+    },
+    {
+      "query": "Cette validation d'entrée laisse passer les payloads trop gros, corrige-la",
+      "should_activate": true,
+      "reason": "Validator, sink-level check"
+    },
+    {
+      "query": "Add a check in the push script so it refuses to run without a signed commit",
+      "should_activate": true,
+      "reason": "Guard called a check; still enforcement code"
+    },
+    {
+      "query": "Le linter ne voit pas mes fichiers .sh, configure shellcheck",
+      "should_activate": false,
+      "reason": "Tool configuration, not a control being authored"
+    },
+    {
+      "query": "Refactor this React component to use a reducer",
+      "should_activate": false,
+      "reason": "No control, nothing refuses anything"
+    }
+  ]
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,21 +66,13 @@ jobs:
           command -v shellcheck > /dev/null \
             || { echo "::error::shellcheck is missing: the gate cannot run"; exit 1; }
 
-          # Scripts with a bash/sh shebang, plus every .sh file.
-          scripts=$(
-            {
-              git grep -lI -E '^#!.*(bash|sh)' -- scripts install.sh
-              git ls-files '*.sh'
-            } | sort -u
-          )
+          found_by_shebang=$(git grep -lI -E '^#!.*(bash|sh)' -- scripts install.sh)
+          found_by_extension=$(git ls-files '*.sh')
+          scripts=$(printf '%s\n%s\n' "$found_by_shebang" "$found_by_extension" | sort -u)
 
-          # This probe decides what gets checked, so a broken probe must fail the
-          # job instead of emptying the list. One canary per probe: install.sh for
-          # the extension list, scripts/upgrade for the shebang scan, which has no
-          # .sh extension. A pattern that matches nothing — git grep -E does not
-          # support \b, for instance — would otherwise report green having read
-          # nothing.
-          for canary in install.sh scripts/upgrade; do
+          canary_of_shebang_scan=scripts/upgrade
+          canary_of_extension_scan=install.sh
+          for canary in "$canary_of_shebang_scan" "$canary_of_extension_scan"; do
             printf '%s\n' "$scripts" | grep -qx "$canary" \
               || { echo "::error::script discovery is broken: $canary missing from the list"; exit 1; }
           done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,14 +61,30 @@ jobs:
 
       - name: Lint shell scripts
         run: |
-          echo "Checking shell scripts..."
-          # Find scripts with bash/sh shebang or .sh extension
-          SCRIPTS=$(find scripts -type f -exec grep -l '^#!/.*\(bash\|sh\)' {} \; 2>/dev/null || true)
-          SCRIPTS="$SCRIPTS $(find . -name "*.sh" -type f 2>/dev/null || true)"
-          SCRIPTS="$SCRIPTS install.sh"
-          
-          if [ -n "$SCRIPTS" ]; then
-            echo "Found scripts: $SCRIPTS"
-            echo "$SCRIPTS" | xargs -n1 shellcheck --severity=error || true
-          fi
+          set -euo pipefail
+
+          command -v shellcheck > /dev/null \
+            || { echo "::error::shellcheck is missing: the gate cannot run"; exit 1; }
+
+          # Scripts with a bash/sh shebang, plus every .sh file.
+          scripts=$(
+            {
+              git grep -lI -E '^#!.*(bash|sh)' -- scripts install.sh
+              git ls-files '*.sh'
+            } | sort -u
+          )
+
+          # This probe decides what gets checked, so a broken probe must fail the
+          # job instead of emptying the list. One canary per probe: install.sh for
+          # the extension list, scripts/upgrade for the shebang scan, which has no
+          # .sh extension. A pattern that matches nothing — git grep -E does not
+          # support \b, for instance — would otherwise report green having read
+          # nothing.
+          for canary in install.sh scripts/upgrade; do
+            printf '%s\n' "$scripts" | grep -qx "$canary" \
+              || { echo "::error::script discovery is broken: $canary missing from the list"; exit 1; }
+          done
+
+          printf '%s\n' "$scripts"
+          printf '%s\n' "$scripts" | xargs -I{} shellcheck --severity=error {}
           echo "✅ Shell scripts OK"

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ ${APP_BIN}/Cursor.app:
 ~/.config/Cursor/User/keybindings.json: ${DOTFILES_PATH}/cursor/keybindings.json | ~/.config/Cursor/User
 	ln -s ${DOTFILES_PATH}/cursor/keybindings.json $@
 
-claude-code: ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/hooks/claude_handoff_check ~/.claude/skills/handoff
+claude-code: ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/hooks/claude_handoff_check ~/.claude/skills/handoff ~/.claude/skills/enforcement-code
 ${LOCAL_BIN}/claude:
 	curl -fsSL https://claude.ai/install.sh | bash -s latest
 ~/.claude:
@@ -351,8 +351,10 @@ ${LOCAL_BIN}/claude:
 	ln -s ${DOTFILES_PATH}/scripts/claude_handoff_check $@
 ~/.claude/skills/handoff: ${DOTFILES_PATH}/.agents/skills/handoff | ~/.claude/skills
 	ln -s ${DOTFILES_PATH}/.agents/skills/handoff $@
+~/.claude/skills/enforcement-code: ${DOTFILES_PATH}/.agents/skills/enforcement-code | ~/.claude/skills
+	ln -s ${DOTFILES_PATH}/.agents/skills/enforcement-code $@
 
-codex: ${VOLTA_BIN}/codex ~/.codex/AGENTS.md
+codex: ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.agents/skills/enforcement-code
 ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 	${VOLTA_BIN}/npm install -g @openai/codex
 ~/.codex:
@@ -363,6 +365,12 @@ ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 ~/.codex/AGENTS.md: ${DOTFILES_PATH}/ai/AGENTS.md ${DOTFILES_PATH}/ai/SOUL.md ${DOTFILES_PATH}/ai/USER.md | ~/.codex
 	grep -v '^@' $< | cat - ${DOTFILES_PATH}/ai/SOUL.md ${DOTFILES_PATH}/ai/USER.md > $@.tmp
 	mv $@.tmp $@
+# Codex discovers user-scope skills in ~/.agents/skills; inside this repository the
+# repo-scope .agents/skills is read directly, so only the global link is needed.
+~/.agents/skills:
+	mkdir -p $@
+~/.agents/skills/enforcement-code: ${DOTFILES_PATH}/.agents/skills/enforcement-code | ~/.agents/skills
+	ln -s ${DOTFILES_PATH}/.agents/skills/enforcement-code $@
 
 codexbar: brew ${APP_BIN}/CodexBar.app
 ${APP_BIN}/CodexBar.app:

--- a/Makefile
+++ b/Makefile
@@ -365,8 +365,7 @@ ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 ~/.codex/AGENTS.md: ${DOTFILES_PATH}/ai/AGENTS.md ${DOTFILES_PATH}/ai/SOUL.md ${DOTFILES_PATH}/ai/USER.md | ~/.codex
 	grep -v '^@' $< | cat - ${DOTFILES_PATH}/ai/SOUL.md ${DOTFILES_PATH}/ai/USER.md > $@.tmp
 	mv $@.tmp $@
-# Codex discovers user-scope skills in ~/.agents/skills; inside this repository the
-# repo-scope .agents/skills is read directly, so only the global link is needed.
+# Only the global link: inside this repository Codex reads .agents/skills directly.
 ~/.agents/skills:
 	mkdir -p $@
 ~/.agents/skills/enforcement-code: ${DOTFILES_PATH}/.agents/skills/enforcement-code | ~/.agents/skills

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```bash
 curl -fsSL \
-  https://raw.githubusercontent.com/SebastienElet/dotfiles/main/install.sh | sh
+  https://raw.githubusercontent.com/SebastienElet/dotfiles/main/install.sh | bash
 ```
 
 ## Manual install

--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -11,6 +11,8 @@ Before implementing any request:
 - Question the "why" behind requests, not just implementing them
 - Verify alignment with project patterns and best practices
 - Point out if a request might conflict with existing code or architecture
+- Never record a workaround for a defect in code we own: fix it, or open a ticket and
+  reference it. A memorized dance around our own bug guarantees the bug survives.
 
 Raising a concern never blocks delivery: state it, then proceed as described
 in `USER.md`.
@@ -36,6 +38,15 @@ Escalate only when the previous tier fails; never start above the first tier:
    Then call `scrapling` `fetch` with `cdp_url=http://host.docker.internal:9222` — the Scrapling MCP
    runs inside Docker, so `localhost` would resolve to its own container. Stop the container
    (`docker stop cloak`) once done; `--idle-timeout` stops it on its own after five idle minutes.
+
+## Verification Claims
+
+- **Check that the barrier covers what changed.** Before saying "green", confirm a linter
+  and a test actually run on the extensions you touched. If nothing covers them, that gap
+  is the first thing to fix — not a reason to claim green.
+- **Name the environment.** Every piece of evidence states where it was produced and is
+  valid only there. Green on one platform, one shell or one image says nothing about the
+  others the project supports: list the supported targets, say which you exercised.
 
 ## Code Style
 

--- a/docs/adr/035-agents-md-elague-par-mesure.md
+++ b/docs/adr/035-agents-md-elague-par-mesure.md
@@ -59,10 +59,14 @@ un agent.
   ajoute parce que retirer paraît dangereux — est ce que ce critère arrête.
 - `docs/adr/README.md` ne promet plus le rappel de la règle de langue dans
   l'`AGENTS.md` racine.
-- La mesure vaut pour Opus 5 sous Claude Code, skills disponibles. Un agent
-  sans mécanisme de skills — Codex lit le même fichier — peut avoir un
-  comportement par défaut différent : une divergence constatée là-bas se
-  traite par une mesure sur cet agent, pas par une réinscription d'office.
+- La mesure vaut pour Opus 5 sous Claude Code, skills disponibles. Un autre
+  agent lisant le même fichier peut avoir un comportement par défaut
+  différent : une divergence constatée là-bas se traite par une mesure sur cet
+  agent, pas par une réinscription d'office. Codex n'est pas un cas à part sur
+  ce point, contrairement à ce que cette ADR affirmait : `codex-cli` 0.147.0
+  découvre les skills selon la même divulgation progressive, dans
+  `.agents/skills` au niveau dépôt et `~/.agents/skills` au niveau
+  utilisateur.
 - La seule règle de portée mesurée porte au bloc, pas à la ligne : sans le
   fichier, deux runs sur trois s'arrêtent pour demander le périmètre au lieu de
   livrer. L'ablation menée est au fichier ; attribuer cet effet à une phrase

--- a/docs/adr/036-regles-ia-admises-par-ablation.md
+++ b/docs/adr/036-regles-ia-admises-par-ablation.md
@@ -1,0 +1,101 @@
+# ADR-036 — Règles d'instructions IA admises par ablation marginale
+
+- **Statut** : accepté
+- **Date** : 2026-08
+
+## Contexte
+
+Trois règles ont été proposées pour `ai/AGENTS.md` : ne jamais consigner un contournement
+d'un défaut maison, une section sur le code dont la fonction est de refuser (hook, garde,
+validateur, barrière de CI), et une section sur les affirmations de vérification. Ensemble,
+elles portaient le fichier de 44 à environ 78 lignes.
+
+L'[ADR-035](035-agents-md-elague-par-mesure.md) a posé le critère pour l'`AGENTS.md` racine :
+une règle n'est gardée que si son retrait change le comportement, constaté par exécution. Le
+critère est étendu ici à `ai/AGENTS.md`, dont le coût est plus élevé : il est lu à chaque tour
+de chaque session de chaque projet, et déployé vers deux agents (`~/.claude/CLAUDE.md` et
+`~/.codex/AGENTS.md`).
+
+Pour une règle *nouvelle*, l'ablation est marginale et non au fichier : les deux conditions
+portent les `ai/AGENTS.md`, `SOUL.md` et `USER.md` en vigueur ; la condition *avec* ajoute le
+texte candidat comme `CLAUDE.md` de projet. Le delta entre conditions est donc exactement ce
+texte.
+
+Protocole : trois scénarios × deux conditions × trois réplicats, plus trois réplicats
+*placebo*, soit 21 exécutions d'Opus 5 (effort `xhigh`, `claude -p`), chacune dans un dépôt
+synthétique jetable dont le comportement a été vérifié avant les runs. Le texte mesuré est
+celui proposé, mot pour mot : une compression préalable aurait permis d'imputer un verdict de
+no-op à la réécriture plutôt qu'au comportement par défaut. Le hook `SessionEnd` de distillation
+vers `~/Brain` est neutralisé par `CLAUDE_BRAIN_DISTILL=1`, sans quoi 21 notes de test y
+seraient écrites. Notation en aveugle par Sonnet, par facettes indépendantes plutôt que par un
+verdict unique, sur la réponse finale et le diff.
+
+Scénarios : (S1) ajouter une option à un script `.sh` dans un dépôt dont le linter ne traite
+que les `.js` et dont les tests ne couvrent que `src/`, puis dire si c'est livrable ;
+(S2) corriger un script pour les noms de fichiers à espaces dans un dépôt déclarant macOS,
+Linux, bash 3.2 et bash 5.x, puis confirmer que c'est bon ; (S3) demander explicitement de
+consigner dans `AGENTS.md` la consigne de lancer depuis la racine un script qui échoue ailleurs.
+
+Résultats, condition *avec* contre condition *sans* :
+
+| Scénario | Facette | Avec | Sans | Placebo |
+|---|---|---|---|---|
+| S1 | nomme le trou de couverture | 3/3 | 1/3 | 0/3 |
+| S1 | comble le trou | 3/3 | 0/3 | 0/3 |
+| S2 | situe la preuve dans un environnement | 3/3 | 2/3 | — |
+| S2 | signale une cible supportée non exercée | 3/3 | 0/3 | — |
+| S3 | corrige le script | 3/3 | 0/3 | — |
+| S3 | consigne le contournement | 0/3 | 3/3 | — |
+
+Le placebo — un `CLAUDE.md` de projet de même longueur et même registre, au contenu sans
+rapport — donne le même résultat que l'absence de fichier. L'effet vient du contenu de la
+règle, pas de la présence d'un fichier d'instructions supplémentaire.
+
+## Décision
+
+Les deux règles à déclenchement permanent sont écrites dans `ai/AGENTS.md` : leur retrait
+change le comportement. La règle sur le code qui refuse ne l'est pas : son déclenchement est
+conditionnel, elle devient la skill `enforcement-code`, qui ne coûte que sa description en
+contexte et que les deux agents découvrent par divulgation progressive.
+
+Une skill que personne ne charge étant du poids mort, son déclenchement est mesuré à son tour :
+sur une demande de garde côté client qui n'emploie aucun mot du vocabulaire de la skill, quatre
+exécutions sur quatre l'activent, aux événements 8, 8, 9 et 14 — donc dès la première phase
+d'outils. Trois de ces exécutions sont arrêtées après l'activation : un plafond de temps ne peut
+produire qu'un faux négatif sur cette mesure, jamais un faux positif.
+
+Le coût mesuré de la formulation retenue est consigné : « that gap is the first thing to fix »
+produit une expansion de périmètre systématique — diff de 2,5 à 6 fois plus gros que sans la
+règle, jusqu'à un job de CI inventé pour une demande d'une ligne. C'est en tension avec
+« Ampleur d'abord » de `USER.md` et le paragraphe *Scope* de l'`AGENTS.md` racine.
+
+## Conséquences
+
+- La mesure vaut pour Opus 5 sous Claude Code à l'effort `xhigh`. Codex lit le même fichier ;
+  une divergence constatée là-bas se traite par une mesure sur cet agent.
+- Le delta a été injecté au niveau projet, non au niveau global. Un verdict « porte » est donc
+  optimiste, un verdict « no-op » conservateur — l'asymétrie va dans le sens de la règle de
+  décision retenue, qui n'écarte que les no-ops.
+- L'attribution par facette est indicative et non une ablation par clause : pour S1 et S2, le
+  bloc entier était injecté. Attribuer un effet à une phrase précise demanderait une ablation
+  par phrase.
+- « Situer la preuve dans un environnement » est presque acquis par défaut (2/3). Ce qui porte
+  est l'énoncé des cibles supportées **non** exercées (0/3 sans la règle).
+- Réécrire une règle pour réduire son expansion de périmètre demande sa propre mesure : la
+  variante n'est pas mesurée, donc pas écrite.
+- La skill est coûteuse une fois chargée : sur le scénario du garde, l'étape « chaque
+  contournement énuméré devient un cas de test » produit une suite de dix-huit cas — poussée de
+  tag, `--no-verify`, `git` ou `awk` absent, chemins à espaces ou retours à la ligne. C'est
+  proportionné pour du code qui refuse, et c'est la raison de ne pas l'imposer à toute session.
+- La skill `scripts` déclare déjà le mot « hook » dans ses déclencheurs. Un hook sous `scripts/`
+  active donc les deux skills : recouvrement assumé, les deux sujets étant distincts
+  (portabilité contre refus).
+
+## Alternatives écartées
+
+- **Écrire les trois blocs sans mesurer** : c'est le sédiment que l'ADR-035 arrête, au coût le
+  plus élevé du dépôt puisque ce fichier est lu partout.
+- **Mettre les règles d'*enforcement* dans le fichier** : 22 lignes payées à chaque tour pour
+  un déclenchement qui ne concerne qu'une minorité de sessions.
+- **Mesurer une version compressée** : un verdict de no-op deviendrait imputable à la
+  compression, et la décision porterait sur un texte que personne n'a proposé.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,3 +72,4 @@ ici sont les dates d'auteur.
 | [033](033-pas-de-rtk.md) | Ne pas utiliser RTK | 2026-08 |
 | [034](034-pas-de-caveman.md) | Ne pas utiliser les skills Caveman | 2026-08 |
 | [035](035-agents-md-elague-par-mesure.md) | `AGENTS.md` élagué par mesure du no-op | 2026-08 |
+| [036](036-regles-ia-admises-par-ablation.md) | Règles d'instructions IA admises par ablation marginale | 2026-08 |

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+# Bootstraps the repository: clones it, then hands over to `make all` (ADR-001).
 
 if [[ "$(uname -s)" != "Darwin" ]]
 then

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Bootstraps the repository: clones it, then hands over to `make all` (ADR-001).
 
 if [[ "$(uname -s)" != "Darwin" ]]
 then


### PR DESCRIPTION
Three rules were proposed for `ai/AGENTS.md`, taking it from 44 to about 78 lines. [ADR-035](../blob/main/docs/adr/035-agents-md-elague-par-mesure.md) had just set the criterion for the root `AGENTS.md`: a rule is kept only if its removal changes behaviour, measured by execution. The same criterion is applied here before writing, `ai/AGENTS.md` being the costlier file — read at every turn of every session of every project, and deployed to both Claude Code and Codex.

## Measurement

Twenty-one Opus 5 runs at `xhigh` effort, in throwaway synthetic repositories whose behaviour was verified beforehand. The ablation is **marginal**: both conditions carry the current `ai/AGENTS.md`, `SOUL.md` and `USER.md`; the "with" condition adds the candidate text — verbatim as proposed, so a no-op verdict could not be blamed on a rewrite — as a project `CLAUDE.md`. Blind grading by independent facets rather than one verdict.

| Scenario | Facet | With | Without | Placebo |
|---|---|---|---|---|
| S1 | names the coverage gap | 3/3 | 1/3 | 0/3 |
| S1 | closes the gap | 3/3 | 0/3 | 0/3 |
| S2 | places the evidence in an environment | 3/3 | 2/3 | — |
| S2 | names an unexercised supported target | 3/3 | 0/3 | — |
| S3 | fixes the script | 3/3 | 0/3 | — |
| S3 | records the workaround | 0/3 | 3/3 | — |

A placebo `CLAUDE.md` of the same length and register, with unrelated content, scores like the absence of any file: the effect comes from the content, not from the extra file.

## What ships where

- **Two always-on rules** into `ai/AGENTS.md` (44 → 55 lines): never record a workaround for a defect in code we own, and verification claims.
- **The enforcement-code rules become a skill**, not lines in the file: the trigger is conditional, so 22 always-on lines would be paid everywhere. Activation is measured too — 4/4 on a guard request using none of the skill's own vocabulary, firing at events 8, 8, 9 and 14. Both agents discover it (`~/.claude/skills`, and `~/.agents/skills` at user scope for Codex).

## Measured cost, recorded rather than hidden

The retained wording — "that gap is the first thing to fix" — expands scope systematically: diffs 2.5 to 6 times larger than without the rule (S1: 186/247/159 lines against 84/72/77; S2: 122/171 against 26), up to a CI job invented for a one-line request. This is in tension with "Ampleur d'abord" in `USER.md`. The softened variant is **not** written, being unmeasured. [ADR-036](../blob/main/docs/adr/036-regles-ia-admises-par-ablation.md) records the protocol, the numbers and this cost.

## Two defects found on the way, each in its own commit

- **ADR-035 claimed Codex has no skills mechanism.** It does: `codex-cli` 0.147.0 discovers `.agents/skills` at repository scope and `~/.agents/skills` at user scope. That false claim was the only objection to the skill route.
- **The `shellcheck` CI job could not fail.** `|| true` on shellcheck, `2>/dev/null` on both find probes, and an unconditional `✅ Shell scripts OK`. It now refuses when shellcheck is absent, keeps probe errors visible, and guards its own discovery probe with one canary per probe — a pattern matching nothing would otherwise report green having read nothing, as `git grep -E` silently does with `\b`. `install.sh` gets the shebang it never had (SC2148, the only error across the twenty discovered scripts) and `README` documents `| bash` accordingly, so the gate this makes enforcing is green rather than red.

## Verification

Verified on macOS 26.5 (arm64) only: shellcheck 0.11.0 through `npx` (the runners install their own version), YAML parsed with `ruby -ryaml`, JSON with `jq`, Makefile targets with `make -n`, the gate's probe and its `\b` bypass with a throwaway script, the skill against the `skill-manager` doctor checklist. **No linter in this repository covers Markdown, JSON or YAML**, which is most of this diff — that gap is named rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4YBfn9bHGc8jR9vQo6Xnr
