### PR TITLE
feat(daily-routine): report only Todo and In Progress issues

### DIFF
--- a/daily-routine/src/model.rs
+++ b/daily-routine/src/model.rs
@@ -79,6 +79,13 @@ impl IssueState {
     pub const fn is_resolved(self) -> bool {
         matches!(self, Self::Completed | Self::Canceled)
     }
+
+    // Linear names the two columns the routine acts on Todo and In Progress; its API calls their
+    // state types `unstarted` and `started`.
+    /// Every other state is either not scheduled yet or already resolved.
+    pub const fn is_actionable(self) -> bool {
+        matches!(self, Self::Unstarted | Self::Started)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -127,7 +134,6 @@ impl PartialOrd for Category {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum LinearReason {
     MergedIssueIncomplete,
-    OpenIssueNotStarted,
     StartedWithoutBranchOrPr,
     StartedStale,
     MissingProject,
@@ -140,7 +146,6 @@ impl LinearReason {
     pub const fn label(self) -> &'static str {
         match self {
             Self::MergedIssueIncomplete => "merged PR with incomplete issue",
-            Self::OpenIssueNotStarted => "open PR with issue not started",
             Self::StartedWithoutBranchOrPr => "started issue without branch or PR",
             Self::StartedStale => "stale started issue",
             Self::MissingProject => "missing project",

--- a/daily-routine/src/rules.rs
+++ b/daily-routine/src/rules.rs
@@ -52,16 +52,10 @@ fn contains_team(teams: &[String], team_key: &str) -> bool {
 }
 
 pub fn pr_linear_reasons(pr: &PullRequest, issue: &Issue) -> Vec<LinearReason> {
-    match pr.state {
-        PullRequestState::Merged if issue.state_type != IssueState::Completed => {
-            vec![LinearReason::MergedIssueIncomplete]
-        }
-        PullRequestState::Open
-            if matches!(issue.state_type, IssueState::Backlog | IssueState::Triage) =>
-        {
-            vec![LinearReason::OpenIssueNotStarted]
-        }
-        _ => Vec::new(),
+    if pr.state == PullRequestState::Merged && issue.state_type != IssueState::Completed {
+        vec![LinearReason::MergedIssueIncomplete]
+    } else {
+        Vec::new()
     }
 }
 
@@ -100,6 +94,11 @@ pub fn issue_linear_reasons(
 // the next candidates, whatever else is wrong with it.
 fn is_blocked(issue: &Issue) -> bool {
     !issue.blockers.is_empty()
+}
+
+/// An issue outside Todo and In Progress, or held by a blocker, yields no report item at all.
+fn is_out_of_scope(issue: &Issue) -> bool {
+    !issue.state_type.is_actionable() || is_blocked(issue)
 }
 
 /// Keeps the `limit` oldest items of each section and warns about the rest, so a large backlog
@@ -305,7 +304,7 @@ fn add_linear_items(
         let Some(track_index) = track_for_issue(config, issue) else {
             continue;
         };
-        if is_blocked(issue) {
+        if is_out_of_scope(issue) {
             continue;
         }
         let reasons = issue_linear_reasons(
@@ -355,7 +354,7 @@ fn add_linear_items(
         }
 
         if let Some(issue) = scoped.issue {
-            if is_blocked(issue) {
+            if is_out_of_scope(issue) {
                 continue;
             }
             let reasons = pr_linear_reasons(pr, issue);
@@ -511,11 +510,8 @@ fn select_suivant_candidates<'a>(
     let mut candidates = Vec::new();
     for issue in &dataset.issues {
         if track_for_issue(config, issue) != Some(track_index)
+            || issue.state_type != IssueState::Unstarted
             || is_blocked(issue)
-            || !matches!(
-                issue.state_type,
-                IssueState::Triage | IssueState::Backlog | IssueState::Unstarted
-            )
         {
             continue;
         }
@@ -589,13 +585,12 @@ fn compare_event_at(left: &str, right: &str) -> std::cmp::Ordering {
 const fn linear_reason_rank(reason: LinearReason) -> usize {
     match reason {
         LinearReason::MergedIssueIncomplete => 0,
-        LinearReason::OpenIssueNotStarted => 1,
-        LinearReason::StartedWithoutBranchOrPr => 2,
-        LinearReason::StartedStale => 3,
-        LinearReason::MissingProject => 4,
-        LinearReason::MissingLabel => 5,
-        LinearReason::MissingPriority => 6,
-        LinearReason::OpenPrWithoutIssue => 7,
+        LinearReason::StartedWithoutBranchOrPr => 1,
+        LinearReason::StartedStale => 2,
+        LinearReason::MissingProject => 3,
+        LinearReason::MissingLabel => 4,
+        LinearReason::MissingPriority => 5,
+        LinearReason::OpenPrWithoutIssue => 6,
     }
 }
 

--- a/daily-routine/src/rules.rs
+++ b/daily-routine/src/rules.rs
@@ -182,7 +182,7 @@ pub fn build_report(config: &Config, dataset: &Dataset, today_days: i64) -> Repo
 
     add_review_items(&pull_requests, &mut items, &mut warnings);
     add_retour_items(&pull_requests, &mut items, &mut warnings);
-    add_linear_items(
+    let reported = add_linear_items(
         config,
         dataset,
         &pull_requests,
@@ -190,7 +190,7 @@ pub fn build_report(config: &Config, dataset: &Dataset, today_days: i64) -> Repo
         &mut items,
         &mut warnings,
     );
-    add_suivant_items(config, dataset, &mut items, &mut warnings);
+    add_suivant_items(config, dataset, &reported, &mut items, &mut warnings);
 
     items.sort_by(|left, right| {
         left.category
@@ -284,6 +284,7 @@ fn add_retour_items(
     }
 }
 
+/// Returns the identifiers, upper-cased, of the issues this section reports.
 fn add_linear_items(
     config: &Config,
     dataset: &Dataset,
@@ -291,7 +292,7 @@ fn add_linear_items(
     today_days: i64,
     items: &mut Vec<ReportItem>,
     warnings: &mut Vec<Warning>,
-) {
+) -> HashSet<String> {
     let has_correlated_pr = pull_requests
         .iter()
         .filter(|scoped| scoped.selection.is_some())
@@ -409,7 +410,9 @@ fn add_linear_items(
         }
     }
 
+    let reported = issue_items.keys().cloned().collect();
     items.extend(issue_items.into_values().map(|item| item.report_item));
+    reported
 }
 
 struct LinearIssueItem {
@@ -471,6 +474,7 @@ fn add_issue_linear_reasons(
 fn add_suivant_items(
     config: &Config,
     dataset: &Dataset,
+    reported: &HashSet<String>,
     items: &mut Vec<ReportItem>,
     warnings: &mut Vec<Warning>,
 ) {
@@ -478,7 +482,8 @@ fn add_suivant_items(
         if track.teams.is_empty() {
             continue;
         }
-        let candidates = select_suivant_candidates(config, dataset, track_index, warnings);
+        let candidates =
+            select_suivant_candidates(config, dataset, track_index, reported, warnings);
 
         items.extend(candidates.into_iter().map(|(issue, _)| ReportItem {
             category: Category::Suivant,
@@ -497,6 +502,7 @@ fn select_suivant_candidates<'a>(
     config: &Config,
     dataset: &'a Dataset,
     track_index: usize,
+    reported: &HashSet<String>,
     warnings: &mut Vec<Warning>,
 ) -> Vec<(&'a Issue, Timestamp)> {
     if config
@@ -512,6 +518,7 @@ fn select_suivant_candidates<'a>(
         if track_for_issue(config, issue) != Some(track_index)
             || issue.state_type != IssueState::Unstarted
             || is_blocked(issue)
+            || reported.contains(&issue.identifier.to_ascii_uppercase())
         {
             continue;
         }

--- a/daily-routine/src/rules/report_tests.rs
+++ b/daily-routine/src/rules/report_tests.rs
@@ -7,8 +7,8 @@ use crate::model::{
 use crate::util::days_from_civil;
 
 #[test]
-fn pull_request_rules_cover_merged_and_open_discrepancies() {
-    let mut issue = issue("ABC-1", IssueState::Backlog, "2026-08-10T09:00:00Z");
+fn only_a_merged_pull_request_carries_a_discrepancy_of_its_own() {
+    let mut issue = issue("ABC-1", IssueState::Unstarted, "2026-08-10T09:00:00Z");
     let mut pr = pull_request(1, PullRequestState::Merged, false);
 
     assert_eq!(
@@ -17,17 +17,52 @@ fn pull_request_rules_cover_merged_and_open_discrepancies() {
     );
 
     pr.state = PullRequestState::Open;
-    assert_eq!(
-        pr_linear_reasons(&pr, &issue),
-        [LinearReason::OpenIssueNotStarted]
-    );
+    assert!(pr_linear_reasons(&pr, &issue).is_empty());
 
-    issue.state_type = IssueState::Unstarted;
+    issue.state_type = IssueState::Started;
     assert!(pr_linear_reasons(&pr, &issue).is_empty());
 
     issue.state_type = IssueState::Completed;
     pr.state = PullRequestState::Merged;
     assert!(pr_linear_reasons(&pr, &issue).is_empty());
+}
+
+#[test]
+fn issues_outside_todo_and_in_progress_leave_the_report() {
+    let config = config(3);
+    let states = [
+        IssueState::Triage,
+        IssueState::Backlog,
+        IssueState::Completed,
+        IssueState::Canceled,
+    ];
+    let issues = states
+        .into_iter()
+        .enumerate()
+        .map(|(index, state_type)| {
+            let mut issue = issue(&format!("ABC-{index}"), state_type, "2026-08-08T09:00:00Z");
+            issue.project = None;
+            issue.labels.clear();
+            issue.priority = 0;
+            issue.branch_name.clear();
+            issue
+        })
+        .collect::<Vec<_>>();
+    let mut merged = pull_request(1, PullRequestState::Merged, false);
+    merged.title = "Ship ABC-0".to_owned();
+
+    let report = build_report(
+        &config,
+        &dataset(vec![merged], issues),
+        days_from_civil(2026, 8, 11),
+    );
+
+    assert!(
+        report.items.is_empty(),
+        "neither a metadata gap nor a merged pull request revives an issue out of scope: {:?}",
+        references(&report.items.iter().collect::<Vec<_>>())
+    );
+    assert!(report.warnings.is_empty());
 }
 
 #[test]
@@ -223,14 +258,15 @@ fn correlation_is_case_insensitive_and_any_scoped_pr_satisfies_started_issues() 
 #[test]
 fn correlated_review_prs_emit_issue_rules_but_not_ticketless_pr_rules() {
     let config = config(2);
-    let backlog = issue("ABC-5", IssueState::Backlog, "2026-08-08T09:00:00Z");
+    let mut correlated_issue = issue("ABC-5", IssueState::Unstarted, "2026-08-08T09:00:00Z");
+    correlated_issue.labels.clear();
     let mut correlated = pull_request(5, PullRequestState::Open, true);
     correlated.title = "Review ABC-5".to_owned();
     let ticketless = pull_request(6, PullRequestState::Open, true);
 
     let report = build_report(
         &config,
-        &dataset(vec![ticketless, correlated], vec![backlog]),
+        &dataset(vec![ticketless, correlated], vec![correlated_issue]),
         days_from_civil(2026, 8, 11),
     );
 
@@ -241,7 +277,7 @@ fn correlated_review_prs_emit_issue_rules_but_not_ticketless_pr_rules() {
             .find(|item| item.reference == "ABC-5")
             .unwrap()
             .reasons,
-        [LinearReason::OpenIssueNotStarted]
+        [LinearReason::MissingLabel]
     );
     assert!(linear.iter().all(|item| item.reference != "#6"));
 }
@@ -249,16 +285,16 @@ fn correlated_review_prs_emit_issue_rules_but_not_ticketless_pr_rules() {
 #[test]
 fn linear_items_consolidate_reasons_and_pull_requests_by_issue() {
     let config = config(2);
-    let mut issue = issue("ABC-7", IssueState::Backlog, "2026-08-08T09:00:00Z");
+    let mut issue = issue("ABC-7", IssueState::Started, "2026-08-08T09:00:00Z");
     issue.project = None;
     issue.labels.clear();
     issue.priority = 0;
-    let mut first = pull_request(7, PullRequestState::Open, false);
+    let mut first = pull_request(7, PullRequestState::Merged, false);
     first.title = "ABC-7 first".to_owned();
-    first.created_at = "2026-08-01T09:00:00.355Z".to_owned();
-    let mut second = pull_request(8, PullRequestState::Open, false);
+    first.updated_at = "2026-08-01T09:00:00.355Z".to_owned();
+    let mut second = pull_request(8, PullRequestState::Merged, false);
     second.body = "Related to ABC-7".to_owned();
-    second.created_at = "2026-08-01T09:00:00Z".to_owned();
+    second.updated_at = "2026-08-01T09:00:00Z".to_owned();
     let no_ticket = pull_request(9, PullRequestState::Open, false);
 
     let report = build_report(
@@ -278,7 +314,7 @@ fn linear_items_consolidate_reasons_and_pull_requests_by_issue() {
     assert_eq!(
         issue_item.reasons,
         [
-            LinearReason::OpenIssueNotStarted,
+            LinearReason::MergedIssueIncomplete,
             LinearReason::MissingProject,
             LinearReason::MissingLabel,
             LinearReason::MissingPriority,
@@ -306,9 +342,9 @@ fn pr_discrepancy_uses_the_repository_track_when_the_issue_team_differs() {
         teams: vec!["XYZ".to_owned()],
         repos: Vec::new(),
     });
-    let mut issue = issue("XYZ-1", IssueState::Backlog, "2026-08-08T09:00:00Z");
+    let mut issue = issue("XYZ-1", IssueState::Started, "2026-08-08T09:00:00Z");
     issue.team_key = "XYZ".to_owned();
-    let mut pr = pull_request(1, PullRequestState::Open, false);
+    let mut pr = pull_request(1, PullRequestState::Merged, false);
     pr.title = "Ship XYZ-1".to_owned();
 
     let report = build_report(
@@ -321,7 +357,7 @@ fn pr_discrepancy_uses_the_repository_track_when_the_issue_team_differs() {
     assert_eq!(linear.len(), 1);
     assert_eq!(linear[0].reference, "XYZ-1");
     assert_eq!(linear[0].track_index, 0);
-    assert_eq!(linear[0].reasons, [LinearReason::OpenIssueNotStarted]);
+    assert_eq!(linear[0].reasons, [LinearReason::MergedIssueIncomplete]);
 }
 
 #[test]
@@ -332,10 +368,10 @@ fn pr_discrepancy_overrides_the_track_of_consolidated_issue_reasons() {
         teams: vec!["XYZ".to_owned()],
         repos: Vec::new(),
     });
-    let mut issue = issue("XYZ-1", IssueState::Backlog, "2026-08-08T09:00:00Z");
+    let mut issue = issue("XYZ-1", IssueState::Started, "2026-08-08T09:00:00Z");
     issue.team_key = "XYZ".to_owned();
     issue.priority = 0;
-    let mut pr = pull_request(1, PullRequestState::Open, false);
+    let mut pr = pull_request(1, PullRequestState::Merged, false);
     pr.title = "Ship XYZ-1".to_owned();
 
     let report = build_report(
@@ -350,7 +386,7 @@ fn pr_discrepancy_overrides_the_track_of_consolidated_issue_reasons() {
     assert_eq!(
         linear[0].reasons,
         [
-            LinearReason::OpenIssueNotStarted,
+            LinearReason::MergedIssueIncomplete,
             LinearReason::MissingPriority,
         ]
     );
@@ -369,18 +405,18 @@ fn oldest_pr_event_deterministically_owns_a_consolidated_discrepancy() {
         teams: vec!["OTH".to_owned()],
         repos: vec![repo(Provider::Github, "owner/other", true)],
     });
-    let mut issue = issue("XYZ-1", IssueState::Backlog, "2026-08-08T09:00:00Z");
+    let mut issue = issue("XYZ-1", IssueState::Started, "2026-08-08T09:00:00Z");
     issue.team_key = "XYZ".to_owned();
-    let mut newer = pull_request(1, PullRequestState::Open, false);
+    let mut newer = pull_request(1, PullRequestState::Merged, false);
     newer.title = "Ship XYZ-1 from the primary repository".to_owned();
-    newer.created_at = "2026-08-06T09:00:00Z".to_owned();
-    let mut older = pull_request(2, PullRequestState::Open, false);
+    newer.updated_at = "2026-08-06T09:00:00Z".to_owned();
+    let mut older = pull_request(2, PullRequestState::Merged, false);
     older.key.repo = RepoKey {
         provider: Provider::Github,
         path: "owner/other".to_owned(),
     };
     older.title = "Ship XYZ-1 from the other repository".to_owned();
-    older.created_at = "2026-08-05T09:00:00Z".to_owned();
+    older.updated_at = "2026-08-05T09:00:00Z".to_owned();
 
     for pull_requests in [
         vec![newer.clone(), older.clone()],
@@ -416,7 +452,8 @@ fn linear_scope_keeps_drafts_but_excludes_no_linear_and_teamless_tracks() {
     draft.draft = true;
     draft.title = "Draft ABC-1".to_owned();
     draft.destination = "stack/base".to_owned();
-    let backlog = issue("ABC-1", IssueState::Backlog, "2026-08-09T09:00:00Z");
+    let mut correlated_issue = issue("ABC-1", IssueState::Unstarted, "2026-08-09T09:00:00Z");
+    correlated_issue.labels.clear();
     let mut renovate = pull_request(2, PullRequestState::Open, false);
     renovate.branch = "renovate/serde".to_owned();
     let mut no_linear = pull_request(3, PullRequestState::Open, false);
@@ -433,13 +470,16 @@ fn linear_scope_keeps_drafts_but_excludes_no_linear_and_teamless_tracks() {
 
     let report = build_report(
         &config,
-        &dataset(vec![draft, renovate, no_linear, teamless], vec![backlog]),
+        &dataset(
+            vec![draft, renovate, no_linear, teamless],
+            vec![correlated_issue],
+        ),
         days_from_civil(2026, 8, 11),
     );
 
     let linear = category_items(&report.items, Category::Linear);
     assert_eq!(references(&linear), ["ABC-1"]);
-    assert_eq!(linear[0].reasons, [LinearReason::OpenIssueNotStarted]);
+    assert_eq!(linear[0].reasons, [LinearReason::MissingLabel]);
     assert_eq!(
         references(&category_items(&report.items, Category::Retour)),
         ["#4"]
@@ -449,7 +489,7 @@ fn linear_scope_keeps_drafts_but_excludes_no_linear_and_teamless_tracks() {
 #[test]
 fn linear_correlation_excludes_issues_from_unconfigured_teams() {
     let config = config(2);
-    let mut unconfigured = issue("ABC-1", IssueState::Backlog, "2026-08-09T09:00:00Z");
+    let mut unconfigured = issue("ABC-1", IssueState::Unstarted, "2026-08-09T09:00:00Z");
     unconfigured.team_key = "OUTSIDE".to_owned();
     let mut pr = pull_request(1, PullRequestState::Open, false);
     pr.title = "Ship ABC-1".to_owned();
@@ -475,7 +515,7 @@ fn the_limit_keeps_the_oldest_items_of_each_section_and_warns_about_the_rest() {
             "2026-08-02T09:00:00Z",
         ])
         .map(|(identifier, updated_at)| {
-            let mut issue = issue(identifier, IssueState::Backlog, updated_at);
+            let mut issue = issue(identifier, IssueState::Unstarted, updated_at);
             issue.labels = Vec::new();
             issue
         })
@@ -512,7 +552,7 @@ fn the_limit_keeps_the_oldest_items_of_each_section_and_warns_about_the_rest() {
 #[test]
 fn the_limit_leaves_a_report_it_does_not_truncate_untouched() {
     let config = config(0);
-    let mut issue = issue("ABC-1", IssueState::Backlog, "2026-08-04T09:00:00Z");
+    let mut issue = issue("ABC-1", IssueState::Unstarted, "2026-08-04T09:00:00Z");
     issue.labels = Vec::new();
     let mut report = build_report(
         &config,
@@ -554,9 +594,9 @@ fn blocked_issues_leave_the_discrepancy_list() {
 #[test]
 fn blocked_issues_drop_their_pull_request_discrepancies_too() {
     let config = config(0);
-    let mut blocked = issue("ABC-1", IssueState::Backlog, "2026-08-08T09:00:00Z");
+    let mut blocked = issue("ABC-1", IssueState::Started, "2026-08-08T09:00:00Z");
     blocked.blockers = vec!["ABC-9".to_owned()];
-    let mut pr = pull_request(1, PullRequestState::Open, false);
+    let mut pr = pull_request(1, PullRequestState::Merged, false);
     pr.title = "Ship ABC-1".to_owned();
 
     let report = build_report(
@@ -567,17 +607,17 @@ fn blocked_issues_drop_their_pull_request_discrepancies_too() {
 
     assert!(
         category_items(&report.items, Category::Linear).is_empty(),
-        "an open PR on a blocked issue reports no discrepancy either"
+        "a merged PR on a blocked issue reports no discrepancy either"
     );
 }
 
 #[test]
 fn blocked_issues_never_become_next_candidates() {
     let config = config(2);
-    let mut blocked = issue("ABC-1", IssueState::Backlog, "2026-08-10T09:00:00Z");
+    let mut blocked = issue("ABC-1", IssueState::Unstarted, "2026-08-10T09:00:00Z");
     blocked.priority = 1;
     blocked.blockers = vec!["ABC-9".to_owned()];
-    let mut ready = issue("ABC-2", IssueState::Backlog, "2026-08-09T09:00:00Z");
+    let mut ready = issue("ABC-2", IssueState::Unstarted, "2026-08-09T09:00:00Z");
     ready.priority = 2;
     let mut lower = issue("ABC-3", IssueState::Unstarted, "2026-08-08T09:00:00Z");
     lower.priority = 3;
@@ -604,13 +644,13 @@ fn suivant_selects_by_linear_priority_then_sorts_chronologically() {
         teams: vec!["XYZ".to_owned()],
         repos: Vec::new(),
     });
-    let mut newest_priority_one = issue("ABC-1", IssueState::Triage, "2026-08-10T09:00:00Z");
+    let mut newest_priority_one = issue("ABC-1", IssueState::Unstarted, "2026-08-10T09:00:00Z");
     newest_priority_one.priority = 1;
-    let mut oldest_priority_one = issue("ABC-2", IssueState::Backlog, "2026-08-09T09:00:00Z");
+    let mut oldest_priority_one = issue("ABC-2", IssueState::Unstarted, "2026-08-09T09:00:00Z");
     oldest_priority_one.priority = 1;
     let mut priority_two = issue("ABC-3", IssueState::Unstarted, "2026-08-01T09:00:00Z");
     priority_two.priority = 2;
-    let mut zero = issue("ABC-4", IssueState::Backlog, "2026-07-01T09:00:00Z");
+    let mut zero = issue("ABC-4", IssueState::Unstarted, "2026-07-01T09:00:00Z");
     zero.priority = 0;
     let completed = issue("ABC-5", IssueState::Completed, "2026-06-01T09:00:00Z");
     let canceled = issue("ABC-6", IssueState::Canceled, "2026-06-01T09:00:00Z");
@@ -647,15 +687,15 @@ fn suivant_selects_by_linear_priority_then_sorts_chronologically() {
 #[test]
 fn suivant_selection_precedes_chronological_output_order() {
     let config = config(5);
-    let mut priority_one = issue("ABC-1", IssueState::Triage, "2026-08-05T09:00:00Z");
+    let mut priority_one = issue("ABC-1", IssueState::Unstarted, "2026-08-05T09:00:00Z");
     priority_one.priority = 1;
-    let mut priority_two = issue("ABC-2", IssueState::Backlog, "2026-08-04T09:00:00Z");
+    let mut priority_two = issue("ABC-2", IssueState::Unstarted, "2026-08-04T09:00:00Z");
     priority_two.priority = 2;
     let mut priority_three = issue("ABC-3", IssueState::Unstarted, "2026-08-03T09:00:00Z");
     priority_three.priority = 3;
-    let mut priority_four = issue("ABC-4", IssueState::Triage, "2026-08-02T09:00:00Z");
+    let mut priority_four = issue("ABC-4", IssueState::Unstarted, "2026-08-02T09:00:00Z");
     priority_four.priority = 4;
-    let mut no_priority = issue("ABC-0", IssueState::Backlog, "2026-08-01T09:00:00Z");
+    let mut no_priority = issue("ABC-0", IssueState::Unstarted, "2026-08-01T09:00:00Z");
     no_priority.priority = 0;
     let dataset = dataset(
         Vec::new(),
@@ -790,7 +830,7 @@ fn invalid_required_timestamps_omit_items_and_add_contextual_warnings() {
     invalid_no_ticket.created_at = "2026-08-11T99:00:00Z".to_owned();
     let mut invalid_linear = issue("ABC-1", IssueState::Started, "2026-08-11T99:00:00Z");
     invalid_linear.branch_name.clear();
-    let invalid_next = issue("ABC-2", IssueState::Backlog, "2026-08-11");
+    let invalid_next = issue("ABC-2", IssueState::Unstarted, "2026-08-11");
     let source_warning = Warning {
         categories: vec![Category::Review],
         message: "provider partial result".to_owned(),

--- a/daily-routine/src/rules/report_tests.rs
+++ b/daily-routine/src/rules/report_tests.rs
@@ -66,6 +66,32 @@ fn issues_outside_todo_and_in_progress_leave_the_report() {
 }
 
 #[test]
+fn a_reported_issue_does_not_also_become_a_next_candidate() {
+    let config = config(1);
+    let mut reported = issue("ABC-1", IssueState::Unstarted, "2026-08-08T09:00:00Z");
+    reported.priority = 1;
+    reported.labels.clear();
+    let mut clean = issue("ABC-2", IssueState::Unstarted, "2026-08-09T09:00:00Z");
+    clean.priority = 3;
+
+    let report = build_report(
+        &config,
+        &dataset(Vec::new(), vec![reported, clean]),
+        days_from_civil(2026, 8, 11),
+    );
+
+    assert_eq!(
+        references(&category_items(&report.items, Category::Linear)),
+        ["ABC-1"]
+    );
+    assert_eq!(
+        references(&category_items(&report.items, Category::Suivant)),
+        ["ABC-2"],
+        "the discrepancy already names ABC-1, and its slot goes to the next actionable candidate"
+    );
+}
+
+#[test]
 fn issue_rules_cover_started_staleness_and_missing_metadata() {
     let mut issue = issue("ABC-1", IssueState::Started, "2026-08-03T09:00:00Z");
     issue.branch_name.clear();
@@ -709,7 +735,7 @@ fn suivant_selection_precedes_chronological_output_order() {
     );
     let mut warnings = Vec::new();
 
-    let selected = select_suivant_candidates(&config, &dataset, 0, &mut warnings);
+    let selected = select_suivant_candidates(&config, &dataset, 0, &HashSet::new(), &mut warnings);
 
     assert_eq!(
         selected
@@ -723,7 +749,13 @@ fn suivant_selection_precedes_chronological_output_order() {
     let report = build_report(&config, &dataset, days_from_civil(2026, 8, 11));
     assert_eq!(
         references(&category_items(&report.items, Category::Suivant)),
-        ["ABC-0", "ABC-4", "ABC-3", "ABC-2", "ABC-1"]
+        ["ABC-4", "ABC-3", "ABC-2", "ABC-1"],
+        "selection ranks the priority-less ABC-0 last, and the report proposes it as a \
+         discrepancy to fix instead of as work to pick up"
+    );
+    assert_eq!(
+        references(&category_items(&report.items, Category::Linear)),
+        ["ABC-0"]
     );
 }
 

--- a/daily-routine/src/self_check.rs
+++ b/daily-routine/src/self_check.rs
@@ -14,7 +14,8 @@ use std::io::{self, Write};
 pub fn run() -> io::Result<()> {
     check_config_parsing();
     check_correlation();
-    check_six_linear_rules();
+    check_linear_rules();
+    check_actionable_scope();
     check_track_attachment();
     check_requires_linear();
     check_requires_linear_report();
@@ -62,7 +63,7 @@ fn check_correlation() {
     );
 }
 
-fn check_six_linear_rules() {
+fn check_linear_rules() {
     let mut issue = issue("ALP-42", IssueState::Started);
     let mut pull_request = pull_request(
         Provider::Github,
@@ -76,13 +77,8 @@ fn check_six_linear_rules() {
     );
 
     pull_request.state = PullRequestState::Open;
-    issue.state_type = IssueState::Backlog;
-    assert_eq!(
-        pr_linear_reasons(&pull_request, &issue),
-        [LinearReason::OpenIssueNotStarted]
-    );
+    assert!(pr_linear_reasons(&pull_request, &issue).is_empty());
 
-    issue.state_type = IssueState::Started;
     issue.branch_name.clear();
     issue.updated_at = "2026-08-01T08:00:00Z".to_owned();
     issue.project = None;
@@ -192,11 +188,41 @@ fn check_requires_linear_report() {
     );
 }
 
+fn check_actionable_scope() {
+    let mut done = issue("ALP-40", IssueState::Completed);
+    done.labels.clear();
+    let mut backlog = issue("ALP-41", IssueState::Backlog);
+    backlog.labels.clear();
+    let mut todo = issue("ALP-42", IssueState::Unstarted);
+    todo.labels.clear();
+
+    let report = build_report(
+        &config(),
+        &Dataset {
+            pull_requests: Vec::new(),
+            issues: vec![done, backlog, todo],
+            warnings: Vec::new(),
+        },
+        days_from_civil(2026, 8, 11),
+    );
+
+    assert_eq!(
+        report
+            .items
+            .iter()
+            .filter(|item| item.category == Category::Linear)
+            .map(|item| item.reference.as_str())
+            .collect::<Vec<_>>(),
+        ["ALP-42"],
+        "only Todo and In Progress issues are reported"
+    );
+}
+
 fn check_blocked_issues() {
-    let mut blocked = issue("ALP-42", IssueState::Backlog);
+    let mut blocked = issue("ALP-42", IssueState::Unstarted);
     blocked.labels.clear();
     blocked.blockers = vec!["ALP-41".to_owned()];
-    let ready = issue("ALP-43", IssueState::Backlog);
+    let ready = issue("ALP-43", IssueState::Unstarted);
 
     let report = build_report(
         &config(),
@@ -229,7 +255,7 @@ fn check_limit() {
             "2026-08-02T08:00:00Z",
         ])
         .map(|(identifier, updated_at)| {
-            let mut issue = issue(identifier, IssueState::Backlog);
+            let mut issue = issue(identifier, IssueState::Unstarted);
             issue.labels.clear();
             issue.updated_at = updated_at.to_owned();
             issue

--- a/daily-routine/src/self_check.rs
+++ b/daily-routine/src/self_check.rs
@@ -210,11 +210,10 @@ fn check_actionable_scope() {
         report
             .items
             .iter()
-            .filter(|item| item.category == Category::Linear)
-            .map(|item| item.reference.as_str())
+            .map(|item| (item.reference.as_str(), item.category))
             .collect::<Vec<_>>(),
-        ["ALP-42"],
-        "only Todo and In Progress issues are reported"
+        [("ALP-42", Category::Linear)],
+        "only Todo and In Progress issues are reported, and never twice"
     );
 }
 

--- a/docs/superpowers/specs/2026-08-11-daily-routine-design.md
+++ b/docs/superpowers/specs/2026-08-11-daily-routine-design.md
@@ -156,10 +156,11 @@ including rule 1 on a merged pull request: it cannot be acted on today, so its m
 when it becomes actionable. The exclusion applies to issues only; an uncorrelated pull request under
 rule 5 has no issue to be blocked by.
 
-`SUIVANT` considers `unstarted` issues that no unresolved blocker holds. Per track, it selects at
+`SUIVANT` considers `unstarted` issues that no unresolved blocker holds and that `LINEAR` does not
+already report, so one ticket never occupies two lines of the same report. Per track, it selects at
 most `next_count` by Linear priority (`1` through `4`, then `0`) and oldest `updatedAt` as a
-tie-breaker, so a blocked candidate frees its slot for the next actionable one. The selected items
-are then merged into the category's chronological output order.
+tie-breaker, so a blocked or already reported candidate frees its slot for the next actionable one.
+The selected items are then merged into the category's chronological output order.
 
 Within every category, report items use their rule-specific event time and sort oldest first, with
 track configuration order and stable reference as deterministic tie-breakers.
@@ -191,9 +192,10 @@ from collection failures.
 
 `--self-check` runs assertions over hard-coded fixtures without reading configuration or invoking a
 CLI. It covers title/branch/absent correlation, the five `LINEAR` rules, the out-of-scope state
-exclusion, mono-track and shared-repo attachment, ticketless attachment, `requires_linear = false`,
-the blocked-issue exclusion, the `--limit` truncation and its warning, report ordering,
-configuration parsing/defaults, `days_from_civil`, and percent encoding of an accented title.
+exclusion and the single-line-per-ticket guarantee, mono-track and shared-repo attachment,
+ticketless attachment, `requires_linear = false`, the blocked-issue exclusion, the `--limit`
+truncation and its warning, report ordering, configuration parsing/defaults, `days_from_civil`, and
+percent encoding of an accented title.
 
 Development follows red-green-refactor around the pure rules before provider orchestration. Final
 verification is `cargo fmt --check`, `cargo clippy -- -D warnings`, `daily-routine --self-check`, a

--- a/docs/superpowers/specs/2026-08-11-daily-routine-design.md
+++ b/docs/superpowers/specs/2026-08-11-daily-routine-design.md
@@ -130,18 +130,23 @@ thread, an open Bitbucket task, or GitHub `CHANGES_REQUESTED`. Multiple signals 
 event time is the oldest qualifying comment or task time, falling back to the pull-request update
 time when only `CHANGES_REQUESTED` supplies the signal.
 
-`LINEAR` implements all six discrepancies:
+Only the two Linear columns holding today's work are in scope: `unstarted` (Todo) and `started`
+(In Progress). An issue in `triage`, `backlog`, `completed`, or `canceled` produces no report item
+at all, whichever rule it would otherwise trigger — a metadata gap on a shelved or finished ticket
+is not work for today. Correlation itself stays unfiltered, so an out-of-scope issue still attaches
+its pull request to the right track and still spares that pull request rule 5.
+
+`LINEAR` implements all five discrepancies:
 
 1. a merged correlated pull request whose issue is not `completed`;
-2. an open correlated pull request whose issue is `backlog` or `triage`;
-3. a `started` issue with neither a non-empty Linear `branchName` nor any correlated scoped pull
+2. a `started` issue with neither a non-empty Linear `branchName` nor any correlated scoped pull
    request;
-4. a `started` issue whose `updatedAt` age is greater than `stale_days`;
-5. an assigned issue missing a project, any label, or a non-zero priority;
-6. an open pull request with no configured Linear identifier when its selected repository
+3. a `started` issue whose `updatedAt` age is greater than `stale_days`;
+4. an in-scope assigned issue missing a project, any label, or a non-zero priority;
+5. an open pull request with no configured Linear identifier when its selected repository
    declaration has `requires_linear = true`.
 
-`renovate/*` branches are exempt only from rule 6. Draft authored pull requests remain subject to
+`renovate/*` branches are exempt only from rule 5. Draft authored pull requests remain subject to
 all `LINEAR` rules. Destination branches do not affect any rule. Multiple discrepancies for the same
 ticket or pull request are consolidated into one Things item with multiple reasons in terminal
 output.
@@ -149,12 +154,12 @@ output.
 An issue held by an unresolved blocker leaves `LINEAR` entirely, whichever rule it triggers,
 including rule 1 on a merged pull request: it cannot be acted on today, so its metadata is repaired
 when it becomes actionable. The exclusion applies to issues only; an uncorrelated pull request under
-rule 6 has no issue to be blocked by.
+rule 5 has no issue to be blocked by.
 
-`SUIVANT` considers `triage`, `backlog`, and `unstarted` issues that no unresolved blocker holds.
-Per track, it selects at most `next_count` by Linear priority (`1` through `4`, then `0`) and oldest
-`updatedAt` as a tie-breaker, so a blocked candidate frees its slot for the next actionable one. The
-selected items are then merged into the category's chronological output order.
+`SUIVANT` considers `unstarted` issues that no unresolved blocker holds. Per track, it selects at
+most `next_count` by Linear priority (`1` through `4`, then `0`) and oldest `updatedAt` as a
+tie-breaker, so a blocked candidate frees its slot for the next actionable one. The selected items
+are then merged into the category's chronological output order.
 
 Within every category, report items use their rule-specific event time and sort oldest first, with
 track configuration order and stable reference as deterministic tie-breakers.
@@ -185,10 +190,10 @@ from collection failures.
 ## Verification
 
 `--self-check` runs assertions over hard-coded fixtures without reading configuration or invoking a
-CLI. It covers title/branch/absent correlation, the six `LINEAR` rules, mono-track and shared-repo
-attachment, ticketless attachment, `requires_linear = false`, the blocked-issue exclusion, the
-`--limit` truncation and its warning, report ordering, configuration parsing/defaults,
-`days_from_civil`, and percent encoding of an accented title.
+CLI. It covers title/branch/absent correlation, the five `LINEAR` rules, the out-of-scope state
+exclusion, mono-track and shared-repo attachment, ticketless attachment, `requires_linear = false`,
+the blocked-issue exclusion, the `--limit` truncation and its warning, report ordering,
+configuration parsing/defaults, `days_from_civil`, and percent encoding of an accented title.
 
 Development follows red-green-refactor around the pure rules before provider orchestration. Final
 verification is `cargo fmt --check`, `cargo clippy -- -D warnings`, `daily-routine --self-check`, a

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -49,12 +49,16 @@ set -g mouse on
 # default statusbar colors
 set -g status-style fg=white,bg=black
 set-option -g status-style fg=black,bg=default
+# The Claude Code native launcher execs a binary named after its version, so a
+# pane running an agent reports "2.1.228" as its current command.
+set-option -g @agent_dots '#{P:#{?#{m/r:^[0-9]+\.[0-9]+\.[0-9]+$,#{pane_current_command}},▪,▫}}'
+
 # default window title colors
 set-window-option -g window-status-style fg=yellow,bg=default
-set-window-option -g window-status-format '• #I #W'
+set-window-option -g window-status-format '#I#{E:@agent_dots} #{b:pane_current_path}'
 # active window title colors
 set-window-option -g window-status-current-style fg=orange,bg=default
-set-window-option -g window-status-current-format '■ [#W]'
+set-window-option -g window-status-current-format '■ #I#{E:@agent_dots} [#{b:pane_current_path}]'
 # pane border
 # set -g pane-active-border-style "bg=default fg=yellow"
 
@@ -63,7 +67,8 @@ set-option -g status-right-length 96
 set-option -g status-left ""
 set-option -g status-right " #S "
 set-option -g automatic-rename on
-set-option -g status-interval 10
+set-option -g automatic-rename-format '#{?#{m/r:^[0-9]+\.[0-9]+\.[0-9]+$,#{pane_current_command}},claude,#{pane_current_command}}'
+set-option -g status-interval 2
 set-option -g status-justify "right"
 set-option -g status-position bottom
 


### PR DESCRIPTION
## Why

The routine turned every assigned Linear issue into a Things task as soon as its metadata was
incomplete, without ever looking at its state. Two symptoms, both observed on live data:

- a ticket closed weeks ago and simply missing a label came back every morning as work for today;
- a ticket sitting in the backlog produced **two** Things tasks — one `[LINEAR]` (repair the
  metadata) and one `[SUIVANT]` (pick it up) — with no way to tell which one to act on.

## What changed

**Commit 1 — scope.** Only the two Linear columns holding today's work are in scope: `unstarted`
(Todo) and `started` (In Progress). An issue in `triage`, `backlog`, `completed` or `canceled`
produces no report item at all, whichever rule it would trigger. Correlation itself stays
unfiltered, so an out-of-scope issue still attaches its pull request to the right track and still
spares that pull request the ticketless-PR rule.

`SUIVANT` accordingly draws from `unstarted` only. The open-PR-with-issue-not-started rule
(`LinearReason::OpenIssueNotStarted`) becomes unreachable under that scope and is removed: `LINEAR`
now implements five discrepancies, not six.

**Commit 2 — one line per ticket.** An issue `LINEAR` already reports no longer competes as a
`SUIVANT` candidate; its slot goes to the next actionable one, exactly as a blocked issue's does.

The design spec is updated in the same commits. `docs/superpowers/plans/` is left untouched — it is
a dated execution record, not a description of current behaviour.

## Deliberate loss

A merged pull request on a `canceled` issue no longer surfaces: rule 1 needs an in-scope issue.
Rare, but real — flagging it rather than hiding it.

## Verification

macOS 25.5.0, crate's own toolchain, on each commit separately:

- `cargo test` — 164 tests green (159 unit + 5 CLI)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `daily-routine --self-check` — ok

Dry run against live data (`--no-things`): every reported issue verified `unstarted` or `started`
through the API, the two tickets described above gone, and no reference appearing in two sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzXsShxN2YrtwVWwyv2QWq