### PR TITLE
fix(skills): close five merge-verdict gaps found in execution

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -14,7 +14,7 @@ This directory is the single source of truth for reusable agent skills.
 | Skill               | Description |
 | ------------------- | ----------- |
 | `enforcement-code`  | Write code whose purpose is to refuse something: hook, guard, validator, permission check, lint rule, CI gate. |
-| `merge-verdict`     | Deliver a merge verdict on another author's pull request. |
+| `merge-verdict`     | Deliver a merge verdict on an open pull request, yours or another author's. |
 | `neovim`            | Maintain this repository's Neovim and LazyVim configuration. |
 | `scripts`           | Create and maintain portable Bash scripts in this repository. |
 

--- a/.agents/skills/merge-verdict/SKILL.md
+++ b/.agents/skills/merge-verdict/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: merge-verdict
 description: >
-  Deliver a merge verdict on another author's pull request. Use when asked to review a PR, whether
-  it is safe to merge or should be approved, for a blocking review, or to re-review after fixes.
-  Make sure to use it whenever a merge decision is at stake, even if the request only says "look at
-  this PR".
+  Deliver a merge verdict on an open pull request, yours or another author's. Use when asked to
+  review a PR, whether it is safe to merge or approve, for a blocking review, or a re-review after
+  fixes. Make sure to use it whenever a merge decision is at stake, even if the request only says
+  "look at this PR".
 compatibility: >
   Authenticated `gh` (GitHub) or `bkt` (Bitbucket) CLI, plus an issue tracker CLI (`linear`,
   `gh issue create`) for the traceability step.
@@ -24,8 +24,9 @@ stay implicit is the failure this skill exists to prevent — a verdict is only 
 admits it did not test.
 
 Not for re-reading your own diff before committing: that is `code-review` and
-`superpowers:verification-before-completion`. This skill judges someone else's pull request and
-engages a decision the team will act on.
+`superpowers:verification-before-completion`. This skill judges an open pull request and engages a
+decision the team will act on. That the PR is your own changes nothing about the verdict, only about
+how it is enforced — see phase 6, since GitHub refuses a blocking review on your own PR.
 
 ## Usage
 
@@ -48,7 +49,9 @@ first, unless the request explicitly says to post directly.
    wins over those raw commands. If the PR is stacked on another unmerged PR, say so and make
    retargeting after the parent merges part of the verdict: the diff you are reading is not the diff
    that will land on the integration branch. A review not anchored on a named SHA is invalid, and
-   the marker in phase 6 is what makes that anchoring visible to the next reader.
+   the marker in phase 6 is what makes that anchoring visible to the next reader. When the request
+   anticipates a PR that is not open yet, poll until it exists and anchor on it; reviewing the
+   branch instead is a review of something the team has not proposed to merge.
 
 2. **Understand before judging.** Read the PR description, the design documents it cites, and the
    whole diff. Restate the invariant the code claims to hold, in one sentence. Producing a blocking
@@ -61,11 +64,13 @@ first, unless the request explicitly says to post directly.
 
 4. **Run the barrier, then declare its holes.** Run lint, typecheck and tests the way the project
    runs them — including inside a container when the project requires it, since numbers from the
-   wrong runner are not evidence for this head. Report counts: builds, errors, warnings against the
-   project's threshold, tests passed over tests run. Then enumerate what the barrier does not reach:
-   sequential tests say nothing about a race, jsdom nothing about a browser, an in-memory database
-   nothing about PostgreSQL, one platform nothing about the others. If nothing exercises the changed
-   code, that absence is the review's first finding, not a reason to announce green.
+   wrong runner are not evidence for this head. Read the CI configuration to find the gate that
+   actually blocks the merge before running anything: it is often not the package script of the same
+   name. Report counts: builds, errors, warnings against the project's threshold, tests passed over
+   tests run. Then enumerate what the barrier does not reach: sequential tests say nothing about a
+   race, jsdom nothing about a browser, an in-memory database nothing about PostgreSQL, one platform
+   nothing about the others. If nothing exercises the changed code, that absence is the review's
+   first finding, not a reason to announce green.
 
 5. **Return a verdict.** Exactly one of *changes required*, *approved with reservations*,
    *approved*. Each blocking finding carries its named mechanism and its lift criterion — what must
@@ -79,8 +84,10 @@ first, unless the request explicitly says to post directly.
    Search the existing comments for that marker first: a verdict carrying the same `<pr>:<sha>` is
    updated in place, never duplicated. Re-read before publishing — past about thirty lines,
    non-blocking remarks are posing as blockers. On GitHub, *changes required* is published with
-   `gh pr review --request-changes`, the native state; Bitbucket has no reliable equivalent, so
-   there the comment *is* the verdict and its closing sentence carries the whole enforcement.
+   `gh pr review --request-changes`, the native state, unless you authored the PR: GitHub refuses it
+   there, and Bitbucket has no reliable equivalent at all. Whenever that native state is
+   unavailable, the comment *is* the verdict and its closing sentence carries the whole enforcement
+   — say so in the verdict, so the reader knows nothing mechanical is holding the merge button.
 
 ## Gotchas
 
@@ -102,11 +109,16 @@ first, unless the request explicitly says to post directly.
   absence.
 - **Numbers copied from the PR's own pipeline** — a green pipeline is context for phase 1, never the
   barrier of phase 4. The barrier is what you ran, authenticated, on the head you checked out.
+- **The package script mistaken for the CI gate** — the repository's `lint` script may walk the whole
+  tree while the pipeline lints only the changed files. Its count then measures a backlog that
+  predates the head under review, and reporting it as the barrier drowns the diff in noise. Take the
+  command from the CI configuration, and name in the verdict which one you ran.
 
 ## Constraints
 
 - Never approve without having executed the barrier on the exact head under review.
 - Never write "everything is green": report counts, or report that nothing ran.
+- Never report a count from a command the pipeline does not run; name the gate you executed.
 - Never publish a blocking finding without a named failure mechanism and a lift criterion.
 - Never block on style, naming or structure preference; label it non-blocking.
 - Never open a review that is not anchored on a head SHA.

--- a/.agents/skills/merge-verdict/assets/verdict-template.md
+++ b/.agents/skills/merge-verdict/assets/verdict-template.md
@@ -23,8 +23,9 @@ the verdict is "approved".>
 and give counts, never adjectives. Then, in the same paragraph, REQUIRED: what this evidence does
 not cover. The verdict is invalid without that second half.>
 
-<Non-blocking remarks — one line each, each prefixed "Non-blocking:". Drop the section rather
-than pad it.>
+<Non-blocking remarks — three lines at most, one per remark, each prefixed "Non-blocking:". Keep
+the ones that would change a reviewer's decision, drop the rest: past three, the section is a
+second review competing with the verdict for attention. Drop it entirely rather than pad it.>
 
 Fix: <url>                REQUIRED when the verdict blocks
 Re-review: <url>          REQUIRED when the verdict blocks
@@ -33,7 +34,9 @@ Initial review: <url>     REQUIRED when a previous verdict exists on this PR
 <Closing sentence — REQUIRED, one line, executable:
   changes required          → "Do not approve or merge this head."
   approved with reservations → "Mergeable once <criterion>."
-  approved                   → "Approved on this head.">
+  approved                   → "Approved on this head."
+When the verdict blocks and the forge carries no native blocking state — Bitbucket, or your own
+PR on GitHub — the same line says that this comment is the only thing holding the merge.>
 ```
 
 ## Filled example
@@ -76,4 +79,6 @@ Do not approve or merge this head.
 - Every clause in the blocking paragraph names a sequence of steps, not a quality judgement.
 - The barrier paragraph contains digits, and a sentence saying what those digits do not prove.
 - The closing sentence tells the reader what to do, not how the reviewer feels.
+- The barrier paragraph names the command it ran, and that command is the one CI runs.
+- At most three non-blocking lines; a fourth means the section is competing with the verdict.
 - Total under about thirty lines. Past that, preferences have leaked into the blocking section.

--- a/.agents/skills/merge-verdict/evals/trigger-queries.json
+++ b/.agents/skills/merge-verdict/evals/trigger-queries.json
@@ -33,6 +33,11 @@
       "reason": "Merge decision at stake even though no review vocabulary is used"
     },
     {
+      "query": "Ma PR est ouverte, dis-moi si elle est fusionnable",
+      "should_activate": true,
+      "reason": "Own pull request, but open: the verdict is unchanged, only its enforcement differs"
+    },
+    {
       "query": "Relis mon diff avant que je commite",
       "should_activate": false,
       "reason": "Own diff before committing; that is code-review, not a merge verdict"

--- a/.agents/skills/merge-verdict/references/cases.md
+++ b/.agents/skills/merge-verdict/references/cases.md
@@ -63,8 +63,8 @@ not covered, and the error code the endpoint now returns is not documented.
 
 ## Execution record
 
-Both cases were run once, on 2026-08-11, phases 1 to 5 only. Publication was deliberately not
-reached, so nothing in phase 6 has ever executed.
+Both cases were run once, on 2026-08-11, phases 1 to 5 only — publication was deliberately not
+reached. A third run, on 2026-08-12, was a real review rather than a case, and went through phase 6.
 
 - **Case A**, on a Bitbucket PR (`bkt`), reached *changes required* as expected, on the three
   mechanisms of classes 1, 2 and 3. Two lessons went back into the skill: the reported base was the
@@ -76,17 +76,34 @@ reached, so nothing in phase 6 has ever executed.
   expected reservations: the target held a measured mechanism that destroys an unversioned file and
   still reports success. The expectation was wrong about the target, not about the skill — the
   *approved with reservations* path therefore remains unexercised.
+- **Third run**, on GitHub, phases 1 to 6, first publication the skill has ever performed: a general
+  comment written through a body file, plus a fix ticket and a re-review ticket. Verdict *changes
+  required*, on classes 4 and 5 only. Five gaps came back into the skill. The requester was the
+  author, so GitHub refused the native blocking state and the comment had to carry the enforcement
+  alone — a configuration the skill described only for Bitbucket. The head moved between the metadata
+  read and the barrier, which phase 1's SHA anchoring caught, so the guard is now exercised rather
+  than merely asserted. The repository-wide lint script and the pipeline's gate turned out to be
+  different commands over different file sets, and only the second measures the head. And the
+  non-blocking section grew until it rivalled the blocking one, which is where the three-line cap
+  comes from. Last, the request anticipated a PR that was not open yet, a case phase 1 assumed away.
 
-Neither case has yet validated: the marker's idempotent update, the duplicate-verdict guard,
-`gh pr review --request-changes`, or Bitbucket comment publication.
+Nothing has yet validated: the marker's idempotent update, the duplicate-verdict guard, or Bitbucket
+comment publication.
 
 Keep this record free of anything belonging to the reviewed repositories — no PR numbers, commit
 SHAs, branch names, build counts or defect details. A skill file is committed and published; the
 work it was exercised on usually is not.
 
-## Declared gap in these cases
+## Declared gaps in these cases
 
-`gh pr review --request-changes` — GitHub's native blocking state — is exercised by neither case, since
-the blocking case is assigned to Bitbucket. Either run case A a second time on GitHub, or record that
-the GitHub enforcement path is unverified. Do not let the two green cases imply that it is covered:
-that is the same substitution of a green for a guarantee that phase 4 exists to prevent.
+`gh pr review --request-changes` — GitHub's native blocking state — is exercised by neither case,
+since the blocking case is assigned to Bitbucket. The third run attempted it and GitHub refused,
+the account being the PR's author; that measures the refusal, not the success path. Run case A a
+second time on GitHub, on a PR the account did not write, or the enforcement path stays unverified.
+
+*Approved with reservations* has never been produced: both cases that reached a verdict landed on
+*changes required*. The state that requires stating a bound rather than forbidding a merge is
+therefore the least exercised part of the skill.
+
+Do not let the runs that went green imply either gap is covered: that is the same substitution of a
+green for a guarantee that phase 4 exists to prevent.

--- a/.agents/skills/merge-verdict/references/failure-classes.md
+++ b/.agents/skills/merge-verdict/references/failure-classes.md
@@ -112,6 +112,8 @@ boundary: when broken, they block. Classes 6 and 8 are usually reservations — 
 blocker only when a concrete consumer or a concrete input path makes the consequence unbounded, and
 say which one.
 
-Findings outside these eight classes are legitimate but non-blocking by default: report them in one
-line each, labelled non-blocking, or drop them. If the verdict runs past about thirty lines, that is
+Findings outside these eight classes are legitimate but non-blocking by default: report at most three
+of them, one line each, labelled non-blocking, or drop them. The cap is what stops the sweep from
+turning into a second review that competes with the verdict — rank them by whether they would change
+a reviewer's decision and keep the top three. If the verdict runs past about thirty lines, that is
 the symptom that preferences have crept into the blocking section.

--- a/.agents/skills/merge-verdict/references/forges.md
+++ b/.agents/skills/merge-verdict/references/forges.md
@@ -27,7 +27,7 @@ about. Look for it before falling back here.
 | Existing comments | `gh pr view <n> --json comments` | `bkt pr comments <n> --json` |
 | Publish | `gh pr comment <n> --body-file verdict.md` | `bkt pr comment <n> --text "$(cat verdict.md)"` |
 | Update | `gh api -X PATCH /repos/{owner}/{repo}/issues/comments/<id> -F body=@verdict.md` | `bkt api -X PUT /2.0/repositories/{ws}/{repo}/pullrequests/<n>/comments/<id> --input -` |
-| Enforceable verdict | `gh pr review <n> --request-changes --body-file verdict.md` | no reliable equivalent |
+| Enforceable verdict | `gh pr review <n> --request-changes --body-file verdict.md` — refused on your own PR | no reliable equivalent |
 
 `bkt` covers both Bitbucket Cloud and Data Center; the two differ on JSON shape and on some flags
 (`bkt pr comments --state` is Cloud-only). Verified against `gh` 2.97 and `bkt` as installed by this
@@ -106,3 +106,17 @@ Bitbucket has no equivalent an agent can set reliably — `bkt pr approve` exist
 not; declining a PR is a different act with a different meaning. There the comment **is** the
 verdict, which is why the closing sentence ("do not approve or merge this head") carries the whole
 enforcement and must never be softened or dropped.
+
+GitHub falls back to that same Bitbucket situation whenever the authenticated account authored the
+PR: it rejects the call with `Can not request changes on your own pull request`, and there is no
+flag around it. `gh pr view --json` exposes no `viewerDidAuthor` field (checked on `gh` 2.97), so
+compare the author against the token yourself, in phase 1 —
+
+```sh
+test "$(gh pr view 1042 --json author --jq .author.login)" = "$(gh api user --jq .login)" &&
+  echo "own PR: no native blocking state"
+```
+
+When it is your own PR, publish the comment alone and state inside the verdict that nothing
+mechanical holds the merge button. A blocking verdict whose reader believes the forge is enforcing
+it, while the forge is not, is worse than no verdict: it buys a false sense of a gate.


### PR DESCRIPTION
## Description

A real review run through the `merge-verdict` skill exposed five cases the skill did not describe.
Each change below names the case that produced it — none is a preference.

- **Author = reviewer.** GitHub refuses `gh pr review --request-changes` on your own PR, so the
  native blocking state the skill promised does not exist in that configuration. The comment carries
  the enforcement, as on Bitbucket, and the verdict now says so explicitly — a reader who believes
  the forge is holding the merge button, while it is not, is worse off than with no verdict.
  `gh pr view --json` exposes no `viewerDidAuthor` field on `gh` 2.97, so the check compares
  `author.login` against `gh api user`.
- **PR not open yet.** Phase 1 assumed the PR existed. It now polls until it does, rather than
  reviewing a branch nobody has proposed to merge.
- **CI gate versus package script.** The repository `lint` script and the pipeline's gate can be
  different commands over different file sets. Only the second measures the head under review; the
  first reports a backlog that predates it. Phase 4 now reads the CI configuration first, and the
  verdict names the command it ran.
- **Non-blocking remarks.** Capped at three, ranked by whether they would change a reviewer's
  decision. Seven of them turn the section into a second review competing with the verdict.
- **Execution record.** Third run logged in `references/cases.md`; the "never validated" list
  narrowed to the marker's idempotent update, the duplicate-verdict guard and Bitbucket publication;
  *approved with reservations* declared as never produced.

The skill's description widened to `an open pull request, yours or another author's` (305 chars),
with the `README.md` index row synced and one eval query added for the self-authored case. The
boundary with `code-review` is unchanged: re-reading your own diff before committing is still not
this skill.

## Useful Links

- Issue: none — the input was an execution record, not a ticket.

## How to Test

- `/skill-manager doctor merge-verdict` → PASS, content 10/10, no regression against the pre-change
  baseline (same result before and after).
- `cspell --config cspell.json` over the five changed skill files → 0 issues. The two unknown words
  reported in `.agents/skills/README.md` (`Slimmon`, `thangs`) sit on untouched lines.
- `python3 -c "import json; json.load(open('.agents/skills/merge-verdict/evals/trigger-queries.json'))"`
  → parses.
- `test "$(gh pr view <n> --json author --jq .author.login)" = "$(gh api user --jq .login)"` → the
  self-authorship check documented in `references/forges.md`, run against `gh` 2.97.

**What none of this covers.** No CI job lints markdown in this repository — `lint.yml` runs Fish,
Lua and ShellCheck only — so every check above was run by hand on macOS and nothing re-runs them.
The evals describe expected activation; nothing executes them. And the skill's own declared gaps are
untouched by this PR: the marker's idempotent update, the duplicate-verdict guard, Bitbucket
publication and `--request-changes` on another author's PR remain unexercised.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nx1Kuu713iQQcA75KfYxDr
