### PR TITLE
ci(rust): run daily-routine checks

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -1,0 +1,20 @@
+name: Rust tests
+
+on:
+  push:
+    paths:
+      - daily-routine/**
+      - .github/workflows/test-rust.yml
+  pull_request:
+    paths:
+      - daily-routine/**
+      - .github/workflows/test-rust.yml
+
+jobs:
+  daily-routine:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: cargo fmt --manifest-path daily-routine/Cargo.toml --check
+      - run: cargo clippy --manifest-path daily-routine/Cargo.toml -- -D warnings
+      - run: cargo test --manifest-path daily-routine/Cargo.toml

--- a/docs/adr/023-ci-lint-et-installation.md
+++ b/docs/adr/023-ci-lint-et-installation.md
@@ -13,10 +13,13 @@ au pire moment.
 
 ## Décision
 
-Trois workflows GitHub Actions. `lint.yml` vérifie la syntaxe Fish
+Quatre workflows GitHub Actions. `lint.yml` vérifie la syntaxe Fish
 (`fish --no-execute`), le formatage (`fish_indent`), le Lua Neovim (`luacheck`)
 et les scripts shell (ShellCheck). `test-fish.yml` exécute les tests Fish sur
 macOS et Linux uniquement lorsque les fichiers qu'ils couvrent changent.
+`test-rust.yml` vérifie le formatage, exécute Clippy et les tests de
+`daily-routine` sur macOS uniquement lorsque les fichiers qu'ils couvrent
+changent.
 `test.yml` exécute l'installation complète sur un runner macOS, apps payantes
 exclues (`SKIP_PAID_APPS`) et cibles Docker ignorées en l'absence de daemon
 (`DOCKER_OR_SKIP`).


### PR DESCRIPTION
## Summary

- add a path-filtered Rust workflow for daily-routine
- gate formatting, Clippy warnings, and the full Cargo test suite
- update ADR 023 to record the separate Rust test workflow

## Verification

- YAML parsed successfully with Ruby Psych on local macOS
- git diff --check passed on local macOS
- Rust workflow passed on GitHub Actions macOS: fmt, Clippy, and 164 tests
- failure canary run 31738002349 failed at cargo test with 158 passed and 1 intentionally broken unit test before the temporary branch was removed
- local Cargo checks unavailable: Cargo is not installed in the local macOS environment

Closes #60