### PR TITLE
fix(make): make qovery target idempotent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,4 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Execute full install
-      run: make all SKIP_PAID_APPS=1
+      run: |
+        make all SKIP_PAID_APPS=1
+        make -q qovery-cli

--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,9 @@ ${BREW_BIN}/opencode:
 	@if [ "$(HAS_BREW_TRUST)" = "yes" ]; then brew trust --formula anomalyco/tap/opencode; fi
 	brew install anomalyco/tap/opencode
 
-qovery-cli:
+.PHONY: qovery-cli
+qovery-cli: /usr/local/bin/qovery
+/usr/local/bin/qovery:
 	# Homebrew version is outdated, use the upstream installer
 	curl -s https://get.qovery.com | bash
 


### PR DESCRIPTION
## Summary

- move the Qovery installer recipe behind the `/usr/local/bin/qovery` sentinel it creates
- keep `qovery-cli` as the phony public target required by ADR-001
- fail the macOS smoke test when `qovery-cli` has not converged after `make all`

The other observations from the original report are either already fixed on `main` (Hermes, Pi/Vibe, Feedmd), not evidence of a wrong sentinel (OpenCode), or currently converged (Calibre/WhatsApp).

## Verification

- `git diff --check`
- workflow YAML parsed with Ruby/Psych
- GNU Make 3.81 regression probe: old target exits 1 after the sentinel exists; new target exits 0
- missing-sentinel dry run still prints the upstream installer recipe
- actual full installation deferred to the macOS smoke workflow because repository policy forbids executing install targets from a worktree

Fixes #62