### PR TITLE
fix(skills): stop creating re-review tickets

### DIFF
--- a/.agents/skills/merge-verdict/SKILL.md
+++ b/.agents/skills/merge-verdict/SKILL.md
@@ -7,7 +7,7 @@ description: >
   "look at this PR".
 compatibility: >
   Authenticated `gh` (GitHub) or `bkt` (Bitbucket) CLI, plus an issue tracker CLI (`linear`,
-  `gh issue create`) for the traceability step.
+  `gh issue create`) when a blocking defect needs a fix ticket.
 metadata:
   category: dev
 ---
@@ -79,12 +79,14 @@ first, unless the request explicitly says to post directly.
    bounded; a mechanism that can lose or corrupt data blocks even when the author disagrees. A
    style, naming or structure preference never blocks: label it non-blocking, or drop it.
 
-6. **Trace and publish.** Open a fix ticket and a re-review ticket, and link the initial review if
-   one exists. Write one general comment from `assets/verdict-template.md`, prefixed with the
-   idempotency marker `<!-- merge-verdict:<pr>:<head-sha> -->` — not a rain of inline comments.
-   Search the existing comments for that marker first: a verdict carrying the same `<pr>:<sha>` is
-   updated in place, never duplicated. Re-read before publishing — past about thirty lines,
-   non-blocking remarks are posing as blockers. On GitHub, _changes required_ is published with
+6. **Trace and publish.** Open or reuse a fix ticket for blocking defects, and link the initial
+   verdict if one exists. Never open a ticket solely to request or record a re-review: the new
+   head-specific verdict comment is that record. Write one general comment from
+   `assets/verdict-template.md`, prefixed with the idempotency marker
+   `<!-- merge-verdict:<pr>:<head-sha> -->` — not a rain of inline comments. Search the existing
+   comments for that marker first: a verdict carrying the same `<pr>:<sha>` is updated in place,
+   never duplicated. Re-read before publishing — past about thirty lines, non-blocking remarks are
+   posing as blockers. On GitHub, _changes required_ is published with
    `gh pr review --request-changes`, the native state, unless you authored the PR: GitHub refuses it
    there, and Bitbucket has no reliable equivalent at all. Whenever that native state is
    unavailable, the comment _is_ the verdict and its closing sentence carries the whole enforcement
@@ -103,6 +105,9 @@ first, unless the request explicitly says to post directly.
 - **A stale marker updated instead of superseded** — the SHA in the marker going stale on the next
   push is the point. Same `<pr>:<sha>` → update that comment; different SHA → publish a new verdict
   and leave the old one as the record of what was judged.
+- **A re-review ticket opened for traceability** — it duplicates the head-specific verdict and adds
+  tracker noise without tracking a defect. Link the previous verdict, publish the new SHA marker,
+  and reserve tickets for blocking defects.
 - **"Approved with reservations" used to avoid a disagreement** — that state is a claim that the
   consequence is bounded. If you cannot state the bound, the verdict is _changes required_.
 - **A missing feature reported as an omission** — an absent regulatory or business control is either
@@ -125,6 +130,7 @@ first, unless the request explicitly says to post directly.
 - Never open a review that is not anchored on a head SHA.
 - Never leave a limit of the evidence implicit; the barrier's gaps belong in the verdict text.
 - Never publish two verdicts for the same `<pr>:<sha>`; update the existing comment instead.
+- Never create a ticket solely to request, schedule or record a re-review.
 - Never publish without confirmation, unless the request explicitly says to post directly.
 
 ## References

--- a/.agents/skills/merge-verdict/assets/verdict-template.md
+++ b/.agents/skills/merge-verdict/assets/verdict-template.md
@@ -28,7 +28,6 @@ the ones that would change a reviewer's decision, drop the rest: past three, the
 second review competing with the verdict for attention. Drop it entirely rather than pad it.>
 
 Fix: <url>                REQUIRED when the verdict blocks
-Re-review: <url>          REQUIRED when the verdict blocks
 Initial review: <url>     REQUIRED when a previous verdict exists on this PR
 
 <Closing sentence — REQUIRED, one line, executable:
@@ -41,7 +40,7 @@ PR on GitHub — the same line says that this comment is the only thing holding 
 
 ## Filled example
 
-A *changes required* verdict. Every identifier and figure below is invented — a committed skill must
+A _changes required_ verdict. Every identifier and figure below is invented — a committed skill must
 carry nothing from the repositories it was exercised on. The example is English because these files
 are; a real verdict is written in the language of its PR. Note what the barrier paragraph does: it
 gives numbers, then immediately spends a sentence dismantling its own green.
@@ -67,8 +66,7 @@ the blockers above.
 Non-blocking: the documented 409/412 codes no longer match the real behavior.
 
 Fix: https://tracker.example/ISSUE-158
-Re-review: https://tracker.example/ISSUE-159
-Initial review: https://tracker.example/ISSUE-155
+Initial review: https://forge.example/pull-requests/1042/comments/155
 
 Do not approve or merge this head.
 ```
@@ -81,4 +79,5 @@ Do not approve or merge this head.
 - The closing sentence tells the reader what to do, not how the reviewer feels.
 - The barrier paragraph names the command it ran, and that command is the one CI runs.
 - At most three non-blocking lines; a fourth means the section is competing with the verdict.
+- No re-review ticket or `Re-review:` slot; the head-specific verdict is the re-review record.
 - Total under about thirty lines. Past that, preferences have leaked into the blocking section.

--- a/.agents/skills/merge-verdict/references/cases.md
+++ b/.agents/skills/merge-verdict/references/cases.md
@@ -14,7 +14,7 @@ matter, the shape of the diff does.
 outside the transaction that performs the write, the retry loop wraps only the write, and no unique
 index backs the uniqueness the service checks in code. Unit tests exist and pass, sequentially.
 
-**Expected verdict:** *changes required*.
+**Expected verdict:** _changes required_.
 
 **Pass criteria**
 
@@ -22,9 +22,9 @@ index backs the uniqueness the service checks in code. Unit tests exist and pass
   first line.
 - At least one blocker is stated as an ordered sequence ending in a broken invariant — the
   out-of-transaction read, the stale retry, or the missing constraint. Failure classes 1, 2 and 3.
-- The barrier paragraph gives counts *and* states that the passing tests are sequential and therefore
+- The barrier paragraph gives counts _and_ states that the passing tests are sequential and therefore
   say nothing about the concurrent interleaving that motivates the blockers.
-- A fix ticket and a re-review ticket are linked.
+- A fix ticket is linked, and no ticket exists solely to request or record the re-review.
 - The closing sentence is "do not approve or merge this head" (in the PR's language). On Bitbucket
   this sentence is the entire enforcement; its absence fails the case even if everything else is
   right.
@@ -43,7 +43,7 @@ index backs the uniqueness the service checks in code. Unit tests exist and pass
 one regression test covering the reported input. A second input path reaches the same function and is
 not covered, and the error code the endpoint now returns is not documented.
 
-**Expected verdict:** *approved with reservations*.
+**Expected verdict:** _approved with reservations_.
 
 **Pass criteria**
 
@@ -66,19 +66,20 @@ not covered, and the error code the endpoint now returns is not documented.
 Both cases were run once, on 2026-08-11, phases 1 to 5 only — publication was deliberately not
 reached. A third run, on 2026-08-12, was a real review rather than a case, and went through phase 6.
 
-- **Case A**, on a Bitbucket PR (`bkt`), reached *changes required* as expected, on the three
+- **Case A**, on a Bitbucket PR (`bkt`), reached _changes required_ as expected, on the three
   mechanisms of classes 1, 2 and 3. Two lessons went back into the skill: the reported base was the
   integration branch while the branch was stacked — the opposite of what the Gotcha then claimed —
   and the run that mattered most was the first, which produced no verdict at all because the
   barrier could not install its dependencies. Refusing to rule from that is the skill working, and
   it is why phase 4 precedes phase 5.
-- **Case B**, on a GitHub PR (`gh`), ran end to end but produced *changes required* rather than the
+- **Case B**, on a GitHub PR (`gh`), ran end to end but produced _changes required_ rather than the
   expected reservations: the target held a measured mechanism that destroys an unversioned file and
   still reports success. The expectation was wrong about the target, not about the skill — the
-  *approved with reservations* path therefore remains unexercised.
+  _approved with reservations_ path therefore remains unexercised.
 - **Third run**, on GitHub, phases 1 to 6, first publication the skill has ever performed: a general
-  comment written through a body file, plus a fix ticket and a re-review ticket. Verdict *changes
-  required*, on classes 4 and 5 only. Five gaps came back into the skill. The requester was the
+  comment written through a body file, plus a fix ticket and the re-review ticket the procedure then
+  required. Verdict _changes required_, on classes 4 and 5 only. Five gaps came back into the skill.
+  The requester was the
   author, so GitHub refused the native blocking state and the comment had to carry the enforcement
   alone — a configuration the skill described only for Bitbucket. The head moved between the metadata
   read and the barrier, which phase 1's SHA anchoring caught, so the guard is now exercised rather
@@ -101,8 +102,8 @@ since the blocking case is assigned to Bitbucket. The third run attempted it and
 the account being the PR's author; that measures the refusal, not the success path. Run case A a
 second time on GitHub, on a PR the account did not write, or the enforcement path stays unverified.
 
-*Approved with reservations* has never been produced: both cases that reached a verdict landed on
-*changes required*. The state that requires stating a bound rather than forbidding a merge is
+_Approved with reservations_ has never been produced: both cases that reached a verdict landed on
+_changes required_. The state that requires stating a bound rather than forbidding a merge is
 therefore the least exercised part of the skill.
 
 Do not let the runs that went green imply either gap is covered: that is the same substitution of a


### PR DESCRIPTION
## Description

- Stop `merge-verdict` from opening a dedicated ticket for each re-review.
- Use the head-specific verdict comment and the previous verdict link for traceability.
- Keep fix tickets for blocking defects and align the template and execution cases.

## Useful Links

- Issue: N/A

## How to Test

- `prettier --check` and `cspell` on the three changed Markdown files
- Contract checks forbidding `Re-review:` ticket slots
- Fish syntax, formatting, and 12 Git wrapper scenarios
- ShellCheck on tracked shell scripts
- `cargo fmt --check`, `cargo clippy -- -D warnings`, and 164 Rust tests
- Three RED/GREEN skill scenarios covering GitHub, Bitbucket, and an author's own PR

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated
- [x] No breaking changes
