### PR TITLE
fix(tmux): bootstrap TPM on setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -747,11 +747,15 @@ ${BREW_BIN}/starship:
 	fi
 
 .PHONY: tmux
-tmux: brew ${BREW_BIN}/tmux ~/.tmux.conf
+tmux: brew ${BREW_BIN}/tmux ~/.tmux.conf ~/.tmux/plugins/tpm/tpm
 ${BREW_BIN}/tmux:
 	brew install tmux
 ~/.tmux.conf: ${DOTFILES_PATH}/tmux/.tmux.conf
 	ln -s ${DOTFILES_PATH}/tmux/.tmux.conf ~/.tmux.conf
+~/.tmux/plugins:
+	mkdir -p $@
+~/.tmux/plugins/tpm/tpm: | ~/.tmux/plugins
+	git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 
 .PHONY: brew
 brew: ${BREW_BIN}/brew


### PR DESCRIPTION
## Summary
- make the tmux setup target bootstrap TPM in its expected plugin directory
- preserve prefix+I as the installation flow for the remaining tmux plugins

## Test plan
- verify the dry-run plans the clone when TPM is absent
- verify the dry-run skips the clone when TPM already exists
- parse the target with GNU Make 3.81 using make -n -B tmux
- run git show --check