### PR TITLE
feat(tmux): add session creation shortcut

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -4,6 +4,7 @@ unbind C-q
 
 # Setting the prefix from C-b to C-a
 set -g prefix C-a
+bind S command-prompt -p "New session:" "new-session -s '%%'"
 
 # Plugin manager for tmux 
 # You should press <prefix>+I to install plugins


### PR DESCRIPTION
## Summary

- add a prefix + Shift-S prompt to create and enter a named tmux session

## Verification

- `git diff --check`
- macOS, tmux 3.7b: verified the `prefix S` binding on the active server