### PR TITLE
docs(install): state macOS-only support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -97,6 +97,17 @@ jobs:
 
           printf '%s\n' "$scripts"
           printf '%s\n' "$scripts" | xargs -I{} shellcheck --severity=error {}
+
+          if output=$(/bin/bash -c 'uname() { printf "%s\n" Linux; }; source install.sh' 2>&1); then
+            non_darwin_status=0
+          else
+            non_darwin_status=$?
+          fi
+          printf '%s\n' "$output"
+          test "$non_darwin_status" -eq 1
+          printf '%s\n' "$output" \
+            | grep -Fx 'This installer supports macOS only; Linux and GitHub Codespaces are unsupported.'
+
           tooling/agent-handoff-test
           echo "✅ Shell scripts OK"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dotfiles
 
+These dotfiles support macOS only. Linux, containers, and GitHub Codespaces are unsupported.
+
 ## Install
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 if [[ "$(uname -s)" != "Darwin" ]]
 then
-  echo "This installer runs only on OSX"
+  echo "This installer supports macOS only; Linux and GitHub Codespaces are unsupported."
   exit 1
 fi
 


### PR DESCRIPTION
## Description

- document macOS as the only supported installation target
- clarify the non-macOS installer error for Linux and GitHub Codespaces
- keep the existing fail-fast behavior because the Makefile remains macOS-specific
- enforce the non-Darwin exit status and diagnostic in the Shell scripts CI job

Closes #73

## Useful Links

- Issue: #73
- ADR-001: macOS workstation installer
- ADR-002: Homebrew and mas as package sources

## How to Test

- /bin/bash -n install.sh
- simulate uname=Linux and verify exit 1 plus the explicit unsupported-platform message
- prettier --check README.md .github/workflows/lint.yml
- git diff --check
- make -n all SKIP_PAID_APPS=1

Environment: macOS 15 arm64, Bash 3.2. Linux and GitHub Codespaces were not exercised because this PR explicitly declares them unsupported. ShellCheck and the simulated non-Darwin runtime assertion run in macOS CI.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (existing unsupported behavior is unchanged)