### PR TITLE
fix(daily-routine): install initial configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,9 +252,14 @@ ${BREW_BIN}/bkt:
 	brew install avivsinai/tap/bitbucket-cli
 
 .PHONY: daily-routine
-daily-routine: rust ${DEPLOY_LINK} | ${LOCAL_BIN}
+daily-routine: rust ${DEPLOY_LINK} | ${LOCAL_BIN} ~/.config/daily-routine/config.toml
 	cd ${DOTFILES_PATH}/tooling/daily-routine && ${BREW_BIN}/cargo build --release
 	${DEPLOY_LINK} ${DOTFILES_PATH}/daily-routine/target/release/daily-routine ${DOTFILES_PATH}/tooling/daily-routine/target/release/daily-routine ${LOCAL_BIN}/daily-routine
+~/.config/daily-routine: | ~/.config
+	mkdir -p "$@"
+~/.config/daily-routine/config.toml: | ~/.config/daily-routine ${DOTFILES_PATH}/tooling/daily-routine/config.example.toml
+	test ! -e "$@" && test ! -L "$@"
+	install -m 600 "${DOTFILES_PATH}/tooling/daily-routine/config.example.toml" "$@"
 
 .PHONY: docker
 docker: brew lazydocker /Applications/Orbstack.app

--- a/tooling/deploy-link-test
+++ b/tooling/deploy-link-test
@@ -146,6 +146,26 @@ env HOME="$test_home" make -f "$repository/Makefile" DOTFILES_PATH="$repository"
 after=$(ls -di "$test_home/.zshrc" | awk '{print $1}')
 [[ $before == "$after" ]] || fail "Make relinked the current destination"
 
+case_root=$test_root/daily_routine_config
+test_home=$case_root/home
+config_file=$test_home/.config/daily-routine/config.toml
+mkdir -p "$test_home"
+env HOME="$test_home" make -f "$repository/Makefile" DOTFILES_PATH="$repository" "$config_file"
+cmp -s "$repository/tooling/daily-routine/config.example.toml" "$config_file" || fail "daily-routine example was not copied"
+[[ $(LC_ALL=C ls -l "$config_file" | cut -c 1-10) == -rw------- ]] || fail "daily-routine configuration mode is not 0600"
+
+printf 'local configuration\n' >"$config_file"
+before=$(ls -di "$config_file" | awk '{print $1}')
+env HOME="$test_home" make -f "$repository/Makefile" DOTFILES_PATH="$repository" "$config_file"
+after=$(ls -di "$config_file" | awk '{print $1}')
+[[ $before == "$after" ]] || fail "daily-routine configuration was replaced"
+[[ $(cat "$config_file") == "local configuration" ]] || fail "daily-routine configuration changed"
+
+rm "$config_file"
+ln -s "$case_root/missing" "$config_file"
+assert_failure env HOME="$test_home" make -f "$repository/Makefile" DOTFILES_PATH="$repository" "$config_file"
+assert_link "$config_file" "$case_root/missing"
+
 case_root=$test_root/codex_hook
 test_home=$case_root/home
 hooks_file=$test_home/.codex/hooks.json


### PR DESCRIPTION
Fixes #66

## Summary

- install the example as `~/.config/daily-routine/config.toml` when no configuration exists
- create it with mode `0600` and never rebuild it after local customization
- refuse and preserve a dangling destination symlink
- cover creation, permissions, idempotence, and symlink refusal in the deployment suite

The copied example uses placeholder organizations and still needs customization before provider collection is useful.

## Verification

macOS 26.5.2, arm64, GNU Make 3.81:

- `bash -n tooling/deploy-link-test`
- `tooling/deploy-link-test`
- fresh and existing configuration plans with `HOME=<temporary> make -n daily-routine`
- `git diff --check`

ShellCheck is unavailable locally and was not installed from the worktree; the existing fail-closed CI gate runs it on the modified executable. The deployment workflow covers the suite on macOS and Ubuntu, and the macOS smoke workflow runs `make all` twice.

The 813-line `Makefile` remains cohesive as the canonical installer under ADR-001; splitting it is outside this focused fix.

Comments added: none.
