### PR TITLE
fix(make): resolve dotfiles path from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ BRAIN_PATH?=$(HOME)/Library/Mobile Documents/com~apple~CloudDocs/Brain
 APP_BIN:=/Applications
 SCRAPLING_IMAGE?=pyd4vinci/scrapling
 CLOAKBROWSER_IMAGE?=cloakhq/cloakbrowser:0.5.3
-# DOTFILES_PATH should be ~/.dotfiles when installed normally
-DOTFILES_PATH:=$(shell pwd)
+DOTFILES_PATH:=$(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 DEPLOY_LINK:=${DOTFILES_PATH}/tooling/deploy-link
 # SKIP_PAID_APPS: set to 1 to skip paid Mac App Store apps (useful for CI)
 SKIP_PAID_APPS?=0

--- a/tooling/deploy-link-test
+++ b/tooling/deploy-link-test
@@ -132,6 +132,12 @@ grep -q 'readlink is required' "$test_root/stderr" || fail "missing readlink was
 case_root=$test_root/make_integration
 test_home=$case_root/home
 mkdir -p "$test_home"
+(
+  cd "$case_root"
+  env HOME="$test_home" make -f "$repository/Makefile" "$test_home/.tmux.conf"
+)
+assert_link "$test_home/.tmux.conf" "$repository/home/.tmux.conf"
+rm "$test_home/.tmux.conf"
 unexpected_source=$case_root/unexpected
 mkdir "$unexpected_source"
 ln -s "$unexpected_source" "$test_home/.zshrc"


### PR DESCRIPTION
## Description

- Derive `DOTFILES_PATH` from the loaded Makefile instead of the caller working directory.
- Cover `make -f` from outside the repository by asserting the real deployed symlink.

## Useful Links

- Closes #76

## How to Test

- `bash -n tooling/deploy-link-test`
- `tooling/deploy-link-test`
- `make -n all SKIP_PAID_APPS=1`

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes