### PR TITLE
fix(fish): keep PATH entries unique

### DIFF
--- a/.github/workflows/test-fish.yml
+++ b/.github/workflows/test-fish.yml
@@ -13,8 +13,8 @@ on:
       - .github/workflows/test-fish.yml
 
 jobs:
-  git-cleanup:
-    name: Git cleanup (${{ matrix.os }})
+  fish:
+    name: Fish tests (${{ matrix.os }})
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]

--- a/.github/workflows/test-fish.yml
+++ b/.github/workflows/test-fish.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Test Git cleanup
         run: fish --no-config home/.config/fish/tests/git_cleanup_test.fish
+
+      - name: Test PATH idempotency
+        run: fish --no-config home/.config/fish/tests/path_test.fish

--- a/home/.config/fish/conf.d/homebrew.fish
+++ b/home/.config/fish/conf.d/homebrew.fish
@@ -1,11 +1,11 @@
 if test -d /opt/homebrew/bin
-    set -gx PATH /opt/homebrew/bin $PATH
+    fish_add_path --global --move --path /opt/homebrew/bin
 end
 
 if test -d /opt/homebrew/sbin
-    set -gx PATH /opt/homebrew/sbin $PATH
+    fish_add_path --global --move --path /opt/homebrew/sbin
 end
 
 if test -d /opt/homebrew/opt/gnu-sed/libexec/gnubin
-    set -gx PATH /opt/homebrew/opt/gnu-sed/libexec/gnubin $PATH
+    fish_add_path --global --move --path /opt/homebrew/opt/gnu-sed/libexec/gnubin
 end

--- a/home/.config/fish/conf.d/postgresql.fish
+++ b/home/.config/fish/conf.d/postgresql.fish
@@ -1,3 +1,3 @@
 if test -d (brew --prefix)/opt/postgresql@16
-    set -x PATH (brew --prefix)/opt/postgresql@16/bin $PATH
+    fish_add_path --global --move --path (brew --prefix)/opt/postgresql@16/bin
 end

--- a/home/.config/fish/conf.d/python.fish
+++ b/home/.config/fish/conf.d/python.fish
@@ -1,8 +1,7 @@
-# Python via Homebrew (évite l'appel lent à `brew --prefix`)
 # Apple Silicon
 if test -d /opt/homebrew/opt/python/libexec/bin
-    set -gx PATH /opt/homebrew/opt/python/libexec/bin $PATH
+    fish_add_path --global --move --path /opt/homebrew/opt/python/libexec/bin
     # Intel Mac
 else if test -d /usr/local/opt/python/libexec/bin
-    set -gx PATH /usr/local/opt/python/libexec/bin $PATH
+    fish_add_path --global --move --path /usr/local/opt/python/libexec/bin
 end

--- a/home/.config/fish/conf.d/ruby.fish
+++ b/home/.config/fish/conf.d/ruby.fish
@@ -1,3 +1,3 @@
 if test -n (brew --prefix ruby)
-    set -x PATH (brew --prefix ruby)/bin $PATH
+    fish_add_path --global --move --path (brew --prefix ruby)/bin
 end

--- a/home/.config/fish/conf.d/rust.fish
+++ b/home/.config/fish/conf.d/rust.fish
@@ -1,3 +1,3 @@
 if test -d ~/.cargo/bin
-    set -x PATH ~/.cargo/bin $PATH
+    fish_add_path --global --move --path ~/.cargo/bin
 end

--- a/home/.config/fish/conf.d/volta.fish
+++ b/home/.config/fish/conf.d/volta.fish
@@ -1,5 +1,5 @@
 # Initialize Volta
 if test -d ~/.volta
     export VOLTA_HOME="$HOME/.volta"
-    set -x PATH ~/.volta/bin $PATH
+    fish_add_path --global --move --path ~/.volta/bin
 end

--- a/home/.config/fish/config.fish
+++ b/home/.config/fish/config.fish
@@ -17,7 +17,7 @@ end
 
 # bun
 set --export BUN_INSTALL "$HOME/.bun"
-set --export PATH $BUN_INSTALL/bin $PATH
+fish_add_path --global --move --path $BUN_INSTALL/bin
 
 # zoxide - smarter cd command
 if type -q zoxide

--- a/home/.config/fish/tests/path_test.fish
+++ b/home/.config/fish/tests/path_test.fish
@@ -1,0 +1,59 @@
+function fail
+    echo "not ok - $argv" >&2
+    exit 1
+end
+
+set -g path_test_root (mktemp -d)
+test -n "$path_test_root"; and test -d "$path_test_root"
+or fail "mktemp did not create the test directory"
+
+function cleanup --on-event fish_exit
+    /bin/rm -rf -- "$path_test_root"
+    or echo "not ok - failed to remove $path_test_root" >&2
+end
+
+set -l config_root (path resolve (path dirname (status filename))/..)
+set -gx HOME "$path_test_root"
+/bin/mkdir -p "$HOME/.cargo/bin" "$HOME/.volta/bin" "$HOME/.bun/bin" \
+    "$HOME/homebrew/opt/postgresql@16/bin" "$HOME/homebrew/opt/ruby/bin"
+or fail "could not create test directories"
+set -gx PATH (path dirname (status fish-path))
+
+function brew
+    if test "$argv" = "--prefix ruby"
+        echo "$HOME/homebrew/opt/ruby"
+    else if test "$argv" = --prefix
+        echo "$HOME/homebrew"
+    else
+        return 1
+    end
+end
+
+function starship
+end
+
+function zoxide
+end
+
+set -l path_configs homebrew python postgresql ruby rust volta
+for pass in 1 2
+    for config in $path_configs
+        source "$config_root/conf.d/$config.fish"
+        or fail "could not source $config.fish"
+    end
+    source "$config_root/config.fish"
+    or fail "could not source config.fish"
+end
+
+set -l seen_path
+for entry in $PATH
+    contains -- "$entry" $seen_path; and fail "duplicate PATH entry: $entry"
+    set -a seen_path "$entry"
+end
+
+for expected in "$HOME/.cargo/bin" "$HOME/.volta/bin" "$HOME/.bun/bin" \
+    "$HOME/homebrew/opt/postgresql@16/bin" "$HOME/homebrew/opt/ruby/bin"
+    contains -- "$expected" $PATH; or fail "missing PATH entry: $expected"
+end
+
+echo "ok - PATH entries remain unique after repeated configuration"


### PR DESCRIPTION
## Description

- replace manual Fish `PATH` prepends with idempotent `fish_add_path --path` updates
- include the Bun prepend omitted from the issue while leaving `fish_user_paths` untouched
- add a repeated-configuration regression test to the macOS and Ubuntu Fish job

## Useful Links

- Closes #70

## How to Test

- `fish --no-config home/.config/fish/tests/path_test.fish`
- run Fish syntax and `fish_indent --check` across every tracked Fish file
- launch a Fish shell nested two levels deep and confirm `sort | uniq -d` prints nothing for `PATH`

Validated locally on Darwin 25.5.0 arm64 with Fish 4.8.1. The GitHub matrix covers macOS and Ubuntu.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)