### PR TITLE
fix(make): exclude personal apps from default setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,7 @@ all: \
 	extra \
 	terminal \
 	work \
-	utils \
-	personal
+	utils
 
 .PHONY: extra
 extra: \


### PR DESCRIPTION
## Description

Remove `personal` from the dependencies of `all`.

## Useful Links

- Closes #72

## How to Test

- `make -n all SKIP_PAID_APPS=1`
- `git diff --check origin/main...HEAD`

## Known documentation mismatch

ADR-001 and ADR-023 still describe `all` as the complete installation path; they are intentionally unchanged to keep this fix to the requested Makefile line.

## Checklist

- [x] Changes have been tested locally
- [ ] Documentation has been updated if necessary — intentionally left out of scope
- [x] No breaking changes (or documented if necessary)
