### PR TITLE
perf(ci): parallelize changed smoke targets

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install ShellCheck
-        run: brew install jq shellcheck
+        run: brew install actionlint jq shellcheck
+
+      - name: Lint workflows
+        run: actionlint
 
       - name: Lint shell scripts
         run: |
@@ -110,6 +113,7 @@ jobs:
 
           tooling/agent-handoff-test
           tooling/upgrade-test
+          tooling/ci-smoke-targets-test
           echo "✅ Shell scripts OK"
 
   cspell:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,47 @@
 name: Smoke tests
-on: [push]
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
+  select:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.targets.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Select install targets
+        id: targets
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
+            # Advisory only: push to main still enforces the default installation.
+            targets=$(tooling/ci-smoke-targets "$BASE_SHA" "$GITHUB_SHA")
+          else
+            targets='["all"]'
+          fi
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+
   build:
-    runs-on: macOS-latest
+    needs: select
+    if: needs.select.outputs.targets != '[]'
+    name: Install ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.select.outputs.targets) }}
+    runs-on: macos-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v5
-    - name: Execute full install
-      run: |
-        make all SKIP_PAID_APPS=1
-        make all SKIP_PAID_APPS=1
+      - uses: actions/checkout@v5
+
+      - name: Execute install twice
+        run: |
+          make trust-taps "${{ matrix.target }}" SKIP_PAID_APPS=1
+          make trust-taps "${{ matrix.target }}" SKIP_PAID_APPS=1

--- a/docs/adr/023-ci-lint-et-installation.md
+++ b/docs/adr/023-ci-lint-et-installation.md
@@ -19,16 +19,21 @@ la configuration CSpell avec son dictionnaire. `test-fish.yml` exécute les
 tests Fish sur les deux systèmes lorsque les fichiers couverts changent.
 `test-rust.yml` vérifie le formatage, exécute Clippy et les tests de
 `tooling/daily-routine` sur macOS. `test-deployment.yml` attaque la migration
-des liens sur macOS et Linux. `test.yml` exécute deux fois l'installation
-complète sur un runner macOS, apps payantes exclues (`SKIP_PAID_APPS`) et
-cibles Docker ignorées en l'absence de daemon (`DOCKER_OR_SKIP`).
+des liens sur macOS et Linux. Sur `main`, `test.yml` exécute deux fois
+l'installation par défaut sur un runner macOS. Sur une pull request,
+`ci-smoke-targets` repère les blocs `.PHONY` modifiés et les exécute sur des
+runners macOS isolés et parallèles. Une sélection ambiguë ou un changement de
+l'infrastructure d'installation retombe sur `all`. Les apps payantes sont
+exclues (`SKIP_PAID_APPS`) et les cibles Docker ignorées en l'absence de daemon
+(`DOCKER_OR_SKIP`).
 
 ## Conséquences
 
-- Le `Makefile` est vérifié en continu, pas seulement lors d'une
-  réinstallation.
-- Le test d'installation est long, d'où les timeouts relevés à plusieurs
-  reprises dans l'historique.
+- Le chemin par défaut reste vérifié après chaque intégration dans `main` ; la
+  sélection des pull requests n'est qu'une accélération anticipée.
+- Le temps d'une pull request devient proportionnel à ses cibles modifiées,
+  avec une durée murale bornée par la cible la plus lente lorsqu'il y en a
+  plusieurs.
 - La CI impose des garde-fous au `Makefile` (approbation des taps, absence de
   daemon Docker) qui n'ont pas d'utilité sur un poste réel.
 
@@ -38,3 +43,5 @@ cibles Docker ignorées en l'absence de daemon (`DOCKER_OR_SKIP`).
   anodin.
 - Test d'installation dans une VM locale : plus lent, non déclenché
   automatiquement.
+- `make -j` sur un runner unique : Homebrew, `/Applications` et `$HOME`
+  constituent un état partagé impropre à des installations concurrentes.

--- a/tooling/ci-smoke-targets
+++ b/tooling/ci-smoke-targets
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+temporary_directory=
+
+fail() {
+  echo "ci-smoke-targets: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  [[ -z $temporary_directory ]] || rm -rf "$temporary_directory"
+}
+
+target_at_line() {
+  local makefile=$1
+  local line=$2
+
+  awk -v last_line="$line" '
+    NR > last_line { exit }
+    /^\.PHONY: / { target = $2 }
+    END { print target }
+  ' "$makefile"
+}
+
+classified_target_at_line() {
+  local makefile=$1
+  local line=$2
+  local content target rule_target
+  local assignment_pattern='^[[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*[?:+!]?='
+  local directive_pattern='^[[:space:]]*(-?include|sinclude|ifeq|ifneq|ifdef|ifndef|else|endif|define|endef|override|undefine|vpath)([[:space:](]|$)'
+
+  content=$(awk -v requested_line="$line" 'NR == requested_line { print; exit }' "$makefile")
+  target=$(target_at_line "$makefile" "$line")
+
+  if [[ $content =~ $assignment_pattern ]] || [[ $content =~ $directive_pattern ]]; then
+    printf 'all\n'
+    return
+  fi
+
+  rule_target=$(printf '%s\n' "$content" | sed -n 's/^\([A-Za-z0-9][A-Za-z0-9._-]*\):.*/\1/p')
+  if [[ -n $rule_target && $rule_target != "$target" ]]; then
+    printf 'all\n'
+    return
+  fi
+
+  printf '%s\n' "${target:-all}"
+}
+
+collect_range() {
+  local makefile=$1
+  local range=$2
+  local output=$3
+  local start count line target
+
+  range=${range#?}
+  start=${range%%,*}
+  if [[ $range == *,* ]]; then
+    count=${range#*,}
+  else
+    count=1
+  fi
+  [[ $start =~ ^[0-9]+$ && $count =~ ^[0-9]+$ ]] || fail "invalid diff range: $range"
+  ((count == 0)) && return
+
+  for ((line = start; line < start + count; line++)); do
+    target=$(classified_target_at_line "$makefile" "$line")
+    printf '%s\n' "$target" >> "$output"
+  done
+}
+
+collect_makefile_targets() {
+  local base=$1
+  local head=$2
+  local directory=$3
+  local old_makefile=$directory/Makefile.old
+  local new_makefile=$directory/Makefile.new
+  local ranges=$directory/ranges
+  local candidates=$directory/candidates
+  local old_range new_range target
+
+  git show "$base:Makefile" > "$old_makefile" || printf 'all\n' > "$candidates"
+  git show "$head:Makefile" > "$new_makefile" || printf 'all\n' > "$candidates"
+  [[ -s $candidates ]] && return
+
+  if ! awk 'NF != 2 || $1 != ".PHONY:" { exit 1 }' < <(grep '^\.PHONY:' "$new_makefile"); then
+    printf 'all\n' > "$candidates"
+    return
+  fi
+
+  git diff --no-ext-diff --unified=0 "$base" "$head" -- Makefile \
+    | awk '/^@@ / { print $2, $3 }' > "$ranges"
+  [[ -s $ranges ]] || fail "Makefile changed without readable diff ranges"
+
+  while read -r old_range new_range; do
+    collect_range "$old_makefile" "$old_range" "$candidates"
+    collect_range "$new_makefile" "$new_range" "$candidates"
+  done < "$ranges"
+
+  while read -r target; do
+    [[ $target =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+      printf 'all\n' > "$candidates"
+      return
+    }
+    grep -Fqx ".PHONY: $target" "$new_makefile" || {
+      printf 'all\n' > "$candidates"
+      return
+    }
+  done < "$candidates"
+}
+
+print_json() {
+  local candidates=$1
+  local targets=$2
+  local separator= target
+
+  if grep -qx all "$candidates"; then
+    printf '["all"]\n'
+    return
+  fi
+
+  sort -u "$candidates" > "$targets"
+  printf '['
+  while read -r target; do
+    printf '%s"%s"' "$separator" "$target"
+    separator=,
+  done < "$targets"
+  printf ']\n'
+}
+
+main() {
+  [[ $# == 2 ]] || fail "usage: ci-smoke-targets BASE HEAD"
+
+  local base=$1
+  local head=$2
+  local changed_paths candidates targets path
+  temporary_directory=$(mktemp -d)
+  changed_paths=$temporary_directory/changed-paths
+  candidates=$temporary_directory/candidates
+  targets=$temporary_directory/targets
+  trap cleanup EXIT
+
+  git rev-parse --verify "$base^{commit}" > /dev/null || fail "invalid base commit: $base"
+  git rev-parse --verify "$head^{commit}" > /dev/null || fail "invalid head commit: $head"
+  git diff --name-only --no-renames -z "$base...$head" > "$changed_paths"
+  [[ -s $changed_paths ]] || fail "the commit range contains no changes"
+
+  while IFS= read -r -d '' path; do
+    case $path in
+      Makefile)
+        collect_makefile_targets "$base" "$head" "$temporary_directory"
+        ;;
+      install.sh | .github/workflows/test.yml | tooling/ci-smoke-targets | tooling/deploy-link)
+        printf 'all\n' > "$candidates"
+        break
+        ;;
+    esac
+  done < "$changed_paths"
+
+  touch "$candidates"
+  print_json "$candidates" "$targets"
+}
+
+main "$@"

--- a/tooling/ci-smoke-targets-test
+++ b/tooling/ci-smoke-targets-test
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+selector=$repository/tooling/ci-smoke-targets
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+  echo "ci-smoke-targets-test: $*" >&2
+  exit 1
+}
+
+commit() {
+  git add -A
+  git commit -q -m "$1"
+}
+
+assert_output() {
+  local expected=$1
+  local git_repository=$2
+  local actual
+  shift 2
+  actual=$(cd "$git_repository" && "$selector" "$@") || fail "selector failed for $*"
+  [[ $actual == "$expected" ]] || fail "expected $expected, got $actual"
+}
+
+assert_failure() {
+  if "$@" > "$test_root/stdout" 2> "$test_root/stderr"; then
+    fail "command unexpectedly succeeded: $*"
+  fi
+}
+
+new_repository() {
+  local name=$1
+  local path=$test_root/$name
+
+  mkdir "$path"
+  git -C "$path" init -q
+  git -C "$path" config user.email ci@example.test
+  git -C "$path" config user.name CI
+  printf '%s\n' \
+    'SHARED=value' \
+    '.PHONY: all' \
+    'all: alpha beta' \
+    '.PHONY: alpha' \
+    'alpha:' \
+    $'\t@echo alpha' \
+    '.PHONY: beta' \
+    'beta:' \
+    $'\t@echo beta' > "$path/Makefile"
+  printf '%s\n' '#!/usr/bin/env bash' 'make all' > "$path/install.sh"
+  (
+    cd "$path"
+    commit initial
+  )
+  printf '%s\n' "$path"
+}
+
+assert_failure "$selector"
+assert_failure "$selector" missing missing
+
+case_root=$(new_repository unrelated)
+printf '%s\n' text > "$case_root/README.md"
+(
+  cd "$case_root"
+  commit docs
+)
+assert_output '[]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository one_target)
+sed -i.bak 's/echo alpha/echo changed-alpha/' "$case_root/Makefile"
+rm "$case_root/Makefile.bak"
+(
+  cd "$case_root"
+  commit alpha
+)
+assert_output '["alpha"]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository multiple_targets)
+sed -i.bak -e 's/echo alpha/echo changed-alpha/' -e 's/echo beta/echo changed-beta/' "$case_root/Makefile"
+rm "$case_root/Makefile.bak"
+(
+  cd "$case_root"
+  commit targets
+)
+assert_output '["alpha","beta"]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository shared_file)
+printf '%s\n' 'make all twice' >> "$case_root/install.sh"
+(
+  cd "$case_root"
+  commit installer
+)
+assert_output '["all"]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository shared_variable)
+sed -i.bak 's/SHARED=value/SHARED=changed/' "$case_root/Makefile"
+rm "$case_root/Makefile.bak"
+(
+  cd "$case_root"
+  commit variable
+)
+assert_output '["all"]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository nested_shared_variable)
+sed -i.bak '/^\.PHONY: beta/i\
+SHARED=changed' "$case_root/Makefile"
+rm "$case_root/Makefile.bak"
+(
+  cd "$case_root"
+  commit variable
+)
+assert_output '["all"]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository missing_phony)
+printf '%s\n' 'gamma:' $'\t@echo gamma' >> "$case_root/Makefile"
+(
+  cd "$case_root"
+  commit target
+)
+assert_output '["all"]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository deleted_target)
+sed -i.bak '/^\.PHONY: beta$/,$d' "$case_root/Makefile"
+rm "$case_root/Makefile.bak"
+(
+  cd "$case_root"
+  commit deletion
+)
+assert_output '["all"]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository renamed_installer)
+git -C "$case_root" mv install.sh setup.sh
+(
+  cd "$case_root"
+  commit rename
+)
+assert_output '["all"]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository invalid_phony)
+sed -i.bak 's/\.PHONY: alpha/.PHONY: alpha beta/' "$case_root/Makefile"
+rm "$case_root/Makefile.bak"
+(
+  cd "$case_root"
+  commit phony
+)
+assert_output '["all"]' "$case_root" HEAD^ HEAD
+
+case_root=$(new_repository empty_range)
+assert_failure bash -c 'cd "$1" && "$2" HEAD HEAD' bash "$case_root" "$selector"
+grep -q 'contains no changes' "$test_root/stderr" || fail "empty range failure was not reported"
+
+echo "ci-smoke-targets tests passed"


### PR DESCRIPTION
## Description

- run only the Make targets changed by pull requests
- execute independent targets on isolated macOS runners in parallel
- keep the full default install on `main` and fall back to `all` for ambiguous changes
- lint workflows with actionlint and regression-test target selection

## Useful Links

- Issue: none

## How to Test

- `tooling/ci-smoke-targets-test` on macOS with Bash 3.2
- the same selector tests in a Debian container
- ShellCheck with severity `error`
- actionlint 1.7.12
- Prettier and YAML parsing
- `make -n trust-taps all SKIP_PAID_APPS=1`
- `make -n trust-taps tmux SKIP_PAID_APPS=1`

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)