### PR TITLE
feat(arnes): add shared doctor diagnostics

### DIFF
--- a/tooling/arnes/Cargo.lock
+++ b/tooling/arnes/Cargo.lock
@@ -57,10 +57,25 @@ name = "arnes"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "rustix",
  "serde",
+ "serde_json",
  "serde_path_to_error",
  "serde_yaml_ng",
+ "tempfile",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -115,6 +130,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +191,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +236,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -206,6 +291,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -250,6 +348,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,3 +392,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/tooling/arnes/Cargo.toml
+++ b/tooling/arnes/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+rustix = { version = "1.1", features = ["stdio"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_path_to_error = "0.1"
+serde_json = "1.0"
 serde_yaml_ng = "0.10"
+
+[dev-dependencies]
+tempfile = "3.21"

--- a/tooling/arnes/src/diagnostic.rs
+++ b/tooling/arnes/src/diagnostic.rs
@@ -1,0 +1,94 @@
+use serde::Serialize;
+use std::fmt::{self, Display};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum State {
+    Healthy,
+    Drift,
+    Unsupported,
+    Error,
+}
+
+impl Display for State {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Healthy => "healthy",
+            Self::Drift => "drift",
+            Self::Unsupported => "unsupported",
+            Self::Error => "error",
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct Diagnostic {
+    pub resource: String,
+    pub state: State,
+    pub message: String,
+}
+
+impl Diagnostic {
+    pub fn new(resource: impl Into<String>, state: State, message: impl Into<String>) -> Self {
+        Self {
+            resource: resource.into(),
+            state,
+            message: message.into(),
+        }
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} {}: {}",
+            self.state,
+            human_field(&self.resource),
+            human_field(&self.message)
+        )
+    }
+}
+
+fn human_field(value: &str) -> String {
+    value.replace('\r', "\\r").replace('\n', "\\n")
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct Report {
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl Report {
+    pub fn new(diagnostics: Vec<Diagnostic>) -> Self {
+        Self { diagnostics }
+    }
+
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+
+    pub fn exit_code(&self) -> u8 {
+        self.diagnostics
+            .iter()
+            .map(|diagnostic| match diagnostic.state {
+                State::Error => 2,
+                State::Drift => 1,
+                State::Healthy | State::Unsupported => 0,
+            })
+            .max()
+            .unwrap_or(0)
+    }
+
+    pub fn human(&self) -> String {
+        self.diagnostics
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    pub fn json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(&self.diagnostics)
+    }
+}

--- a/tooling/arnes/src/lib.rs
+++ b/tooling/arnes/src/lib.rs
@@ -1,1 +1,5 @@
+pub mod diagnostic;
 pub mod manifest;
+pub mod roots;
+
+pub use roots::Roots;

--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -1,6 +1,9 @@
 use clap::{Parser, Subcommand, ValueEnum};
-use std::path::PathBuf;
+use std::io;
+use std::process::ExitCode;
 
+use arnes::Roots;
+use arnes::diagnostic::{Diagnostic, Report, State};
 use arnes::manifest;
 
 #[derive(Parser)]
@@ -58,25 +61,56 @@ enum Format {
     Json,
 }
 
-fn main() {
+fn main() -> ExitCode {
     let Cli { command } = Cli::parse();
 
     let Command::Doctor {
         resource, format, ..
     } = command;
 
-    if matches!(resource, None | Some(Resource::Manifest)) {
-        let Some(home) = std::env::var_os("HOME") else {
-            eprintln!("HOME: environment variable is required");
-            std::process::exit(1);
+    let diagnostics = if matches!(resource, None | Some(Resource::Manifest)) {
+        let diagnostic = match Roots::from_environment() {
+            Ok(roots) => diagnose_manifest(&roots),
+            Err(error) => Diagnostic::new("manifest", State::Error, error.to_string()),
         };
-        if let Err(error) = manifest::load(&PathBuf::from(home)) {
-            eprintln!("{error}");
-            std::process::exit(1);
-        }
+        vec![diagnostic]
+    } else {
+        Vec::new()
+    };
+    let report = Report::new(diagnostics);
+    let output = match format {
+        Format::Human => report.human(),
+        Format::Json => report.json().expect("diagnostics are JSON serializable"),
+    };
+
+    if let Err(error) = write_output(&output) {
+        eprintln!("output: could not write diagnostics: {error}");
+        return ExitCode::from(2);
+    }
+    ExitCode::from(report.exit_code())
+}
+
+fn write_output(output: &str) -> io::Result<()> {
+    if output.is_empty() {
+        return Ok(());
     }
 
-    if matches!(format, Format::Json) {
-        println!("[]");
+    let output = format!("{output}\n");
+    let mut remaining = output.as_bytes();
+    while !remaining.is_empty() {
+        let written =
+            rustix::io::write(rustix::stdio::stdout(), remaining).map_err(io::Error::from)?;
+        if written == 0 {
+            return Err(io::Error::from(io::ErrorKind::WriteZero));
+        }
+        remaining = &remaining[written..];
+    }
+    Ok(())
+}
+
+fn diagnose_manifest(roots: &Roots) -> Diagnostic {
+    match manifest::load(roots.home()) {
+        Ok(_) => Diagnostic::new("manifest", State::Healthy, "manifest is valid"),
+        Err(error) => Diagnostic::new("manifest", State::Error, error.to_string()),
     }
 }

--- a/tooling/arnes/src/roots.rs
+++ b/tooling/arnes/src/roots.rs
@@ -1,0 +1,54 @@
+use std::env;
+use std::fmt::{self, Display};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Roots {
+    repository: PathBuf,
+    home: PathBuf,
+}
+
+impl Roots {
+    pub fn new(repository: impl Into<PathBuf>, home: impl Into<PathBuf>) -> Self {
+        Self {
+            repository: repository.into(),
+            home: home.into(),
+        }
+    }
+
+    pub fn from_environment() -> Result<Self, RootsError> {
+        let repository = env::current_dir()
+            .map_err(|_| RootsError("repository: current directory is unavailable"))?;
+        let home = env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or(RootsError("HOME: environment variable is required"))?;
+        if home.as_os_str().is_empty() {
+            return Err(RootsError("HOME: environment variable cannot be empty"));
+        }
+        if !home.is_absolute() {
+            return Err(RootsError(
+                "HOME: environment variable must be an absolute path",
+            ));
+        }
+        Ok(Self::new(repository, home))
+    }
+
+    pub fn repository(&self) -> &Path {
+        &self.repository
+    }
+
+    pub fn home(&self) -> &Path {
+        &self.home
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct RootsError(&'static str);
+
+impl Display for RootsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+impl std::error::Error for RootsError {}

--- a/tooling/arnes/tests/cli.rs
+++ b/tooling/arnes/tests/cli.rs
@@ -1,5 +1,8 @@
-use std::path::{Path, PathBuf};
+mod support;
+
+use std::path::Path;
 use std::process::{Command, Output};
+use support::Fixture;
 
 fn run(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_arnes"))
@@ -9,7 +12,7 @@ fn run(args: &[&str]) -> Output {
         .unwrap()
 }
 
-fn run_in_home(args: &[&str], home: &Path) -> Output {
+fn run_with_home(args: &[&str], home: &str) -> Output {
     Command::new(env!("CARGO_BIN_EXE_arnes"))
         .args(args)
         .env_clear()
@@ -18,8 +21,13 @@ fn run_in_home(args: &[&str], home: &Path) -> Output {
         .unwrap()
 }
 
-fn repository_home() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../home")
+fn manifest(name: &str) -> String {
+    std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/manifest")
+            .join(name),
+    )
+    .unwrap()
 }
 
 #[test]
@@ -66,34 +74,80 @@ fn doctor_accepts_shared_options_without_reading_the_environment() {
 }
 
 #[test]
-fn json_doctor_emits_an_empty_diagnostic_list() {
-    let output = run_in_home(&["doctor", "--format", "json"], &repository_home());
+fn json_doctor_emits_the_manifest_diagnostic() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("valid.yaml"));
+    let output = fixture.command(["doctor", "--format", "json"]);
 
     assert_eq!(output.status.code(), Some(0));
-    assert_eq!(String::from_utf8(output.stdout).unwrap(), "[]\n");
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "[\n  {\n    \"resource\": \"manifest\",\n    \"state\": \"healthy\",\n    \"message\": \"manifest is valid\"\n  }\n]\n"
+    );
     assert!(output.stderr.is_empty());
 }
 
 #[test]
 fn manifest_doctor_loads_from_the_injected_home() {
-    let output = run_in_home(&["doctor", "manifest"], &repository_home());
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("valid.yaml"));
+    let output = fixture.command(["doctor", "manifest"]);
 
     assert_eq!(output.status.code(), Some(0));
-    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "healthy manifest: manifest is valid\n"
+    );
     assert!(output.stderr.is_empty());
 }
 
 #[test]
 fn manifest_doctor_reports_invalid_manifests() {
-    let home = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/manifest/unsupported-version-home");
-    let output = run_in_home(&["doctor", "manifest"], &home);
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("unsupported-version.yaml"));
+    let output = fixture.command(["doctor", "manifest"]);
 
-    assert_eq!(output.status.code(), Some(1));
-    assert!(output.stdout.is_empty());
+    assert_eq!(output.status.code(), Some(2));
     assert_eq!(
-        String::from_utf8(output.stderr).unwrap(),
-        "version: unsupported version 2; expected 1\n"
+        String::from_utf8(output.stdout).unwrap(),
+        "error manifest: version: unsupported version 2; expected 1\n"
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn operational_failures_use_json_and_exit_two() {
+    let fixture = Fixture::new();
+    let output = fixture.command(["doctor", "manifest", "--format", "json"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "[\n  {\n    \"resource\": \"manifest\",\n    \"state\": \"error\",\n    \"message\": \"manifest: .arnes.yaml was not found\"\n  }\n]\n"
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn output_failures_exit_two_instead_of_passing_silently() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("valid.yaml"));
+    let output = Command::new("sh")
+        .args(["-c", "exec 1<\"$2\"; exec \"$1\" doctor manifest", "sh"])
+        .arg(env!("CARGO_BIN_EXE_arnes"))
+        .arg(fixture.home().join(".arnes.yaml"))
+        .current_dir(fixture.repository())
+        .env_clear()
+        .env("HOME", fixture.home())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .starts_with("output: could not write diagnostics:")
     );
 }
 
@@ -101,12 +155,46 @@ fn manifest_doctor_reports_invalid_manifests() {
 fn manifest_doctor_requires_home_without_reading_the_environment() {
     let output = run(&["doctor", "manifest"]);
 
-    assert_eq!(output.status.code(), Some(1));
-    assert!(output.stdout.is_empty());
+    assert_eq!(output.status.code(), Some(2));
     assert_eq!(
-        String::from_utf8(output.stderr).unwrap(),
-        "HOME: environment variable is required\n"
+        String::from_utf8(output.stdout).unwrap(),
+        "error manifest: HOME: environment variable is required\n"
     );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn manifest_doctor_rejects_home_paths_relative_to_the_repository() {
+    for (home, message) in [
+        ("", "HOME: environment variable cannot be empty"),
+        (
+            "fixture/home",
+            "HOME: environment variable must be an absolute path",
+        ),
+    ] {
+        let output = run_with_home(&["doctor", "manifest"], home);
+
+        assert_eq!(output.status.code(), Some(2));
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            format!("error manifest: {message}\n")
+        );
+        assert!(output.stderr.is_empty());
+    }
+}
+
+#[test]
+fn fixture_run_is_isolated_and_read_only() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("valid.yaml"));
+    fixture.write_home("private", "home sentinel");
+    fixture.write_repository("private", "repository sentinel");
+    let before = fixture.snapshot();
+
+    let output = fixture.command(["doctor", "manifest"]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(fixture.snapshot(), before);
 }
 
 #[test]

--- a/tooling/arnes/tests/diagnostic.rs
+++ b/tooling/arnes/tests/diagnostic.rs
@@ -1,0 +1,73 @@
+use arnes::diagnostic::{Diagnostic, Report, State};
+
+fn report() -> Report {
+    Report::new(vec![
+        Diagnostic::new("manifest", State::Healthy, "manifest is valid"),
+        Diagnostic::new(
+            "rules",
+            State::Unsupported,
+            "cursor does not expose native user rules",
+        ),
+        Diagnostic::new("skills", State::Drift, "destination is missing"),
+        Diagnostic::new("config", State::Error, "settings.json could not be read"),
+    ])
+}
+
+#[test]
+fn human_output_matches_the_exact_fixture() {
+    assert_eq!(
+        format!("{}\n", report().human()),
+        include_str!("fixtures/diagnostic/report.txt")
+    );
+}
+
+#[test]
+fn json_output_matches_the_exact_fixture() {
+    assert_eq!(
+        format!("{}\n", report().json().unwrap()),
+        include_str!("fixtures/diagnostic/report.json")
+    );
+}
+
+#[test]
+fn report_preserves_diagnostic_order() {
+    let report = report();
+    let resources = report
+        .diagnostics()
+        .iter()
+        .map(|diagnostic| diagnostic.resource.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(resources, ["manifest", "rules", "skills", "config"]);
+}
+
+#[test]
+fn human_output_keeps_each_diagnostic_on_one_line() {
+    let diagnostic = Diagnostic::new("skills\nconfig", State::Drift, "missing\r\ndestination");
+
+    assert_eq!(
+        diagnostic.to_string(),
+        "drift skills\\nconfig: missing\\r\\ndestination"
+    );
+}
+
+#[test]
+fn exit_codes_prioritize_errors_over_drift() {
+    for (states, expected) in [
+        (vec![], 0),
+        (vec![State::Healthy], 0),
+        (vec![State::Unsupported], 0),
+        (vec![State::Drift], 1),
+        (vec![State::Error], 2),
+        (vec![State::Error, State::Drift], 2),
+    ] {
+        let report = Report::new(
+            states
+                .into_iter()
+                .map(|state| Diagnostic::new("resource", state, "message"))
+                .collect(),
+        );
+
+        assert_eq!(report.exit_code(), expected);
+    }
+}

--- a/tooling/arnes/tests/fixtures/diagnostic/report.json
+++ b/tooling/arnes/tests/fixtures/diagnostic/report.json
@@ -1,0 +1,22 @@
+[
+  {
+    "resource": "manifest",
+    "state": "healthy",
+    "message": "manifest is valid"
+  },
+  {
+    "resource": "rules",
+    "state": "unsupported",
+    "message": "cursor does not expose native user rules"
+  },
+  {
+    "resource": "skills",
+    "state": "drift",
+    "message": "destination is missing"
+  },
+  {
+    "resource": "config",
+    "state": "error",
+    "message": "settings.json could not be read"
+  }
+]

--- a/tooling/arnes/tests/fixtures/diagnostic/report.txt
+++ b/tooling/arnes/tests/fixtures/diagnostic/report.txt
@@ -1,0 +1,4 @@
+healthy manifest: manifest is valid
+unsupported rules: cursor does not expose native user rules
+drift skills: destination is missing
+error config: settings.json could not be read

--- a/tooling/arnes/tests/roots.rs
+++ b/tooling/arnes/tests/roots.rs
@@ -1,0 +1,10 @@
+use arnes::Roots;
+use std::path::Path;
+
+#[test]
+fn repository_and_home_roots_are_injectable() {
+    let roots = Roots::new("fixture/repository", "fixture/home");
+
+    assert_eq!(roots.repository(), Path::new("fixture/repository"));
+    assert_eq!(roots.home(), Path::new("fixture/home"));
+}

--- a/tooling/arnes/tests/support/mod.rs
+++ b/tooling/arnes/tests/support/mod.rs
@@ -1,0 +1,170 @@
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Component;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+pub struct Fixture {
+    _root: TempDir,
+    repository: PathBuf,
+    home: PathBuf,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum SnapshotEntry {
+    Directory(u32),
+    File(Vec<u8>, u32),
+    Symlink(PathBuf),
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let repository = root.path().join("repository");
+        let home = root.path().join("home");
+        fs::create_dir(&repository).unwrap();
+        fs::create_dir(&home).unwrap();
+        Self {
+            _root: root,
+            repository,
+            home,
+        }
+    }
+
+    pub fn command<I, S>(&self, args: I) -> Output
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        Command::new(env!("CARGO_BIN_EXE_arnes"))
+            .args(args)
+            .current_dir(&self.repository)
+            .env_clear()
+            .env("HOME", &self.home)
+            .output()
+            .unwrap()
+    }
+
+    pub fn write_home(&self, path: impl AsRef<Path>, contents: &str) {
+        write(&fixture_path(&self.home, path), contents);
+    }
+
+    pub fn write_repository(&self, path: impl AsRef<Path>, contents: &str) {
+        write(&fixture_path(&self.repository, path), contents);
+    }
+
+    pub fn repository(&self) -> &Path {
+        &self.repository
+    }
+
+    pub fn home(&self) -> &Path {
+        &self.home
+    }
+
+    pub fn snapshot(&self) -> BTreeMap<PathBuf, SnapshotEntry> {
+        let mut files = BTreeMap::new();
+        collect_files(
+            &self.repository,
+            &self.repository,
+            Path::new("repository"),
+            &mut files,
+        );
+        collect_files(&self.home, &self.home, Path::new("home"), &mut files);
+        files
+    }
+}
+
+fn write(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+fn fixture_path(root: &Path, path: impl AsRef<Path>) -> PathBuf {
+    let path = path.as_ref();
+    assert!(
+        !path.as_os_str().is_empty()
+            && path
+                .components()
+                .all(|component| matches!(component, Component::Normal(_))),
+        "fixture path must stay within its root"
+    );
+    let mut destination = root.to_owned();
+    for component in path.components() {
+        destination.push(component);
+        if let Ok(metadata) = fs::symlink_metadata(&destination) {
+            assert!(
+                !metadata.file_type().is_symlink(),
+                "fixture path cannot traverse a symlink"
+            );
+        }
+    }
+    destination
+}
+
+fn collect_files(
+    root: &Path,
+    directory: &Path,
+    prefix: &Path,
+    files: &mut BTreeMap<PathBuf, SnapshotEntry>,
+) {
+    for entry in fs::read_dir(directory).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let relative = prefix.join(path.strip_prefix(root).unwrap());
+        let file_type = entry.file_type().unwrap();
+        if file_type.is_dir() {
+            files.insert(
+                relative,
+                SnapshotEntry::Directory(entry.metadata().unwrap().permissions().mode()),
+            );
+            collect_files(root, &path, prefix, files);
+        } else if file_type.is_symlink() {
+            files.insert(
+                relative,
+                SnapshotEntry::Symlink(fs::read_link(path).unwrap()),
+            );
+        } else {
+            files.insert(
+                relative,
+                SnapshotEntry::File(
+                    fs::read(path).unwrap(),
+                    entry.metadata().unwrap().permissions().mode(),
+                ),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Fixture;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    #[should_panic(expected = "fixture path must stay within its root")]
+    fn fixture_rejects_absolute_write_paths() {
+        Fixture::new().write_home("/outside", "contents");
+    }
+
+    #[test]
+    #[should_panic(expected = "fixture path must stay within its root")]
+    fn fixture_rejects_parent_write_paths() {
+        Fixture::new().write_repository("../outside", "contents");
+    }
+
+    #[test]
+    fn fixture_rejects_writes_through_symlinks() {
+        let fixture = Fixture::new();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), fixture.home.join("link")).unwrap();
+
+        let result = std::panic::catch_unwind(|| fixture.write_home("link/outside", "contents"));
+
+        assert!(result.is_err());
+        assert!(fs::read_dir(outside.path()).unwrap().next().is_none());
+    }
+}


### PR DESCRIPTION
## Description

- define healthy, drift, unsupported, and error diagnostics with exact human and JSON output
- preserve diagnostic order and aggregate exit codes as error 2, drift 1, and healthy/unsupported 0
- inject repository and HOME roots and provide confined, read-only temporary fixtures for resource checks
- fail closed on invalid roots, manifests, and diagnostic output failures

## Useful Links

- Closes #114
- Parent: #111

## How to Test

Verified on macOS arm64 with Rust 1.97.1:

- `cargo fmt --manifest-path tooling/arnes/Cargo.toml --check`
- `cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path tooling/arnes/Cargo.toml --all-features` (30 tests plus doctests)
- `git diff HEAD^ --check`
- `make -n arnes`

CI exercises the Rust checks on Ubuntu. Linux was not exercised locally.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation is tracked separately by #126
- [x] Reserved Doctor exit behavior is applied before a stable release

Comments added: none.