### PR TITLE
feat(arnes): diagnose agent configuration

### DIFF
--- a/tooling/arnes/Cargo.lock
+++ b/tooling/arnes/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_yaml_ng",
  "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -318,6 +319,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +371,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +441,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"

--- a/tooling/arnes/Cargo.toml
+++ b/tooling/arnes/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_path_to_error = "0.1"
 serde_json = "1.0"
 serde_yaml_ng = "0.10"
+toml = "1.1"
 
 [dev-dependencies]
 tempfile = "3.21"

--- a/tooling/arnes/src/config.rs
+++ b/tooling/arnes/src/config.rs
@@ -1,0 +1,236 @@
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Manifest, Scope};
+use std::fmt::{self, Display};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+
+#[derive(Clone, Copy)]
+enum ConfigFormat {
+    Json,
+    Toml,
+}
+
+impl Display for ConfigFormat {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Json => "JSON",
+            Self::Toml => "TOML",
+        })
+    }
+}
+
+struct Specification {
+    root: &'static str,
+    file: &'static str,
+    format: ConfigFormat,
+}
+
+pub fn diagnose(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    let combinations = manifest
+        .combinations()
+        .filter(|(candidate, _)| agent.is_none_or(|agent| agent == *candidate))
+        .filter(|(_, candidate)| scope.is_none_or(|scope| scope == *candidate))
+        .collect::<Vec<_>>();
+
+    if combinations.is_empty() {
+        return vec![Diagnostic::new(
+            "config",
+            State::Unsupported,
+            unsupported_message(agent, scope),
+        )];
+    }
+
+    combinations
+        .into_iter()
+        .map(|(agent, scope)| diagnose_one(roots, agent, scope))
+        .collect()
+}
+
+fn diagnose_one(roots: &Roots, agent: Agent, scope: Scope) -> Diagnostic {
+    let specification = specification(agent, scope);
+    let base = match scope {
+        Scope::User => roots.home(),
+        Scope::Project => roots.repository(),
+    };
+    let root = base.join(specification.root);
+    let root_label = match scope {
+        Scope::User => format!("~/{}", specification.root),
+        Scope::Project => specification.root.to_owned(),
+    };
+    let file = root.join(specification.file);
+    let file_label = format!("{root_label}/{}", specification.file);
+    let subject = format!("{agent} {scope} configuration");
+
+    if let Err(diagnostic) = check_root(&root, &subject, &root_label) {
+        return diagnostic;
+    }
+    let input = match read_file(&file, &subject, &file_label) {
+        Ok(input) => input,
+        Err(diagnostic) => return diagnostic,
+    };
+
+    match validate(&input, specification.format) {
+        Ok(()) => Diagnostic::new(
+            "config",
+            State::Healthy,
+            format!("{subject} file {file_label} is valid"),
+        ),
+        Err(ParseError::Malformed) => Diagnostic::new(
+            "config",
+            State::Error,
+            format!(
+                "{subject} file {file_label} contains malformed {}",
+                specification.format
+            ),
+        ),
+        Err(ParseError::WrongRoot) => Diagnostic::new(
+            "config",
+            State::Error,
+            format!(
+                "{subject} file {file_label} must contain a top-level {} object",
+                specification.format
+            ),
+        ),
+    }
+}
+
+fn check_root(root: &Path, subject: &str, root_label: &str) -> Result<(), Diagnostic> {
+    match fs::metadata(root) {
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return Err(Diagnostic::new(
+                "config",
+                State::Drift,
+                format!("{subject} root {root_label} is missing"),
+            ));
+        }
+        Err(_) => return Err(unreadable(subject, "root", root_label)),
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(Diagnostic::new(
+                "config",
+                State::Error,
+                format!("{subject} root {root_label} is not a directory"),
+            ));
+        }
+        Ok(_) => {}
+    }
+    if fs::read_dir(root).is_err() {
+        return Err(unreadable(subject, "root", root_label));
+    }
+    Ok(())
+}
+
+fn read_file(file: &Path, subject: &str, file_label: &str) -> Result<String, Diagnostic> {
+    match fs::metadata(file) {
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return Err(Diagnostic::new(
+                "config",
+                State::Drift,
+                format!("{subject} file {file_label} is missing"),
+            ));
+        }
+        Err(_) => return Err(unreadable(subject, "file", file_label)),
+        Ok(metadata) if !metadata.is_file() => {
+            return Err(Diagnostic::new(
+                "config",
+                State::Error,
+                format!("{subject} file {file_label} is not a file"),
+            ));
+        }
+        Ok(_) => {}
+    }
+    fs::read_to_string(file).map_err(|_| unreadable(subject, "file", file_label))
+}
+
+fn unreadable(subject: &str, kind: &str, path: &str) -> Diagnostic {
+    Diagnostic::new(
+        "config",
+        State::Error,
+        format!("{subject} {kind} {path} could not be read"),
+    )
+}
+
+enum ParseError {
+    Malformed,
+    WrongRoot,
+}
+
+fn validate(input: &str, format: ConfigFormat) -> Result<(), ParseError> {
+    match format {
+        ConfigFormat::Json => match serde_json::from_str::<serde_json::Value>(input) {
+            Ok(serde_json::Value::Object(_)) => Ok(()),
+            Ok(_) => Err(ParseError::WrongRoot),
+            Err(_) => Err(ParseError::Malformed),
+        },
+        ConfigFormat::Toml => match toml::from_str::<toml::Value>(input) {
+            Ok(toml::Value::Table(_)) => Ok(()),
+            Ok(_) => Err(ParseError::WrongRoot),
+            Err(_) => Err(ParseError::Malformed),
+        },
+    }
+}
+
+fn specification(agent: Agent, scope: Scope) -> Specification {
+    match (agent, scope) {
+        (Agent::Claude, _) => Specification {
+            root: ".claude",
+            file: "settings.json",
+            format: ConfigFormat::Json,
+        },
+        (Agent::Cursor, Scope::User) => Specification {
+            root: ".cursor",
+            file: "cli-config.json",
+            format: ConfigFormat::Json,
+        },
+        (Agent::Cursor, Scope::Project) => Specification {
+            root: ".cursor",
+            file: "cli.json",
+            format: ConfigFormat::Json,
+        },
+        (Agent::Codex, _) => Specification {
+            root: ".codex",
+            file: "config.toml",
+            format: ConfigFormat::Toml,
+        },
+    }
+}
+
+fn unsupported_message(agent: Option<Agent>, scope: Option<Scope>) -> String {
+    match (agent, scope) {
+        (Some(agent), Some(scope)) => {
+            format!("{agent} {scope} configuration is not declared in the manifest")
+        }
+        (Some(agent), None) => {
+            format!("{agent} configuration is not declared in the manifest")
+        }
+        (None, Some(scope)) => {
+            format!("{scope} configuration scope is not declared in the manifest")
+        }
+        (None, None) => "no configuration combinations are declared in the manifest".to_owned(),
+    }
+}
+
+impl Display for Agent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Claude => "claude",
+            Self::Cursor => "cursor",
+            Self::Codex => "codex",
+        })
+    }
+}
+
+impl Display for Scope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::User => "user",
+            Self::Project => "project",
+        })
+    }
+}

--- a/tooling/arnes/src/lib.rs
+++ b/tooling/arnes/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod diagnostic;
 pub mod manifest;
 pub mod roots;

--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -3,8 +3,9 @@ use std::io;
 use std::process::ExitCode;
 
 use arnes::Roots;
+use arnes::config;
 use arnes::diagnostic::{Diagnostic, Report, State};
-use arnes::manifest;
+use arnes::manifest::{self, Agent, Scope};
 
 #[derive(Parser)]
 #[command(version, about = "Diagnose agent harness resources")]
@@ -41,19 +42,6 @@ enum Resource {
     Statusline,
 }
 
-#[derive(Clone, ValueEnum)]
-enum Agent {
-    Claude,
-    Cursor,
-    Codex,
-}
-
-#[derive(Clone, ValueEnum)]
-enum Scope {
-    User,
-    Project,
-}
-
 #[derive(Clone, Default, ValueEnum)]
 enum Format {
     #[default]
@@ -65,17 +53,22 @@ fn main() -> ExitCode {
     let Cli { command } = Cli::parse();
 
     let Command::Doctor {
-        resource, format, ..
+        resource,
+        agent,
+        scope,
+        format,
     } = command;
 
-    let diagnostics = if matches!(resource, None | Some(Resource::Manifest)) {
-        let diagnostic = match Roots::from_environment() {
-            Ok(roots) => diagnose_manifest(&roots),
-            Err(error) => Diagnostic::new("manifest", State::Error, error.to_string()),
-        };
-        vec![diagnostic]
-    } else {
-        Vec::new()
+    let diagnostics = match resource {
+        None | Some(Resource::Manifest) => match Roots::from_environment() {
+            Ok(roots) => vec![diagnose_manifest(&roots)],
+            Err(error) => vec![Diagnostic::new("manifest", State::Error, error.to_string())],
+        },
+        Some(Resource::Config) => match Roots::from_environment() {
+            Ok(roots) => diagnose_config(&roots, agent, scope),
+            Err(error) => vec![Diagnostic::new("config", State::Error, error.to_string())],
+        },
+        _ => Vec::new(),
     };
     let report = Report::new(diagnostics);
     let output = match format {
@@ -112,5 +105,12 @@ fn diagnose_manifest(roots: &Roots) -> Diagnostic {
     match manifest::load(roots.home()) {
         Ok(_) => Diagnostic::new("manifest", State::Healthy, "manifest is valid"),
         Err(error) => Diagnostic::new("manifest", State::Error, error.to_string()),
+    }
+}
+
+fn diagnose_config(roots: &Roots, agent: Option<Agent>, scope: Option<Scope>) -> Vec<Diagnostic> {
+    match manifest::load(roots.home()) {
+        Ok(manifest) => config::diagnose(roots, &manifest, agent, scope),
+        Err(error) => vec![Diagnostic::new("config", State::Error, error.to_string())],
     }
 }

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -1,3 +1,4 @@
+use clap::ValueEnum;
 use serde::Deserialize;
 use serde_yaml_ng::Value;
 use std::fmt::{self, Display};
@@ -41,6 +42,14 @@ pub struct Manifest {
     resources: Vec<ResourceDeclaration>,
 }
 
+impl Manifest {
+    pub fn combinations(&self) -> impl Iterator<Item = (Agent, Scope)> + '_ {
+        self.agents
+            .iter()
+            .flat_map(|agent| agent.scopes.iter().map(move |scope| (agent.id, *scope)))
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct AgentDeclaration {
@@ -74,17 +83,17 @@ enum PathRoot {
     Repository,
 }
 
-#[derive(Clone, Copy, Eq, Hash, PartialEq, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
-enum Agent {
+pub enum Agent {
     Claude,
     Cursor,
     Codex,
 }
 
-#[derive(Clone, Copy, Eq, Hash, PartialEq, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
-enum Scope {
+pub enum Scope {
     User,
     Project,
 }

--- a/tooling/arnes/tests/config.rs
+++ b/tooling/arnes/tests/config.rs
@@ -1,0 +1,270 @@
+mod support;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use support::Fixture;
+
+const ALL_AGENTS: &str = "version: 1
+agents:
+  - id: claude
+    scopes: [user, project]
+  - id: cursor
+    scopes: [user, project]
+  - id: codex
+    scopes: [user, project]
+resources: []
+";
+
+const CLAUDE_USER: &str = "version: 1
+agents:
+  - id: claude
+    scopes: [user]
+resources: []
+";
+
+fn configured_fixture() -> Fixture {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", ALL_AGENTS);
+    for path in [".claude/settings.json", ".cursor/cli-config.json"] {
+        fixture.write_home(path, r#"{"unknown": true}"#);
+    }
+    fixture.write_home(".codex/config.toml", "unknown = true\n");
+    for path in [".claude/settings.json", ".cursor/cli.json"] {
+        fixture.write_repository(path, r#"{"unknown": true}"#);
+    }
+    fixture.write_repository(".codex/config.toml", "unknown = true\n");
+    fixture
+}
+
+fn run(fixture: &Fixture, args: &[&str]) -> (i32, String, String) {
+    let output = fixture.command(args);
+    (
+        output.status.code().unwrap(),
+        String::from_utf8(output.stdout).unwrap(),
+        String::from_utf8(output.stderr).unwrap(),
+    )
+}
+
+#[test]
+fn all_declared_agent_configurations_accept_unknown_keys() {
+    let fixture = configured_fixture();
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "config"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(stdout.lines().count(), 6);
+    assert!(stderr.is_empty());
+    for expected in [
+        "healthy config: claude user",
+        "healthy config: claude project",
+        "healthy config: cursor user",
+        "healthy config: cursor project",
+        "healthy config: codex user",
+        "healthy config: codex project",
+    ] {
+        assert!(stdout.contains(expected), "missing {expected}: {stdout}");
+    }
+}
+
+#[test]
+fn agent_and_scope_filters_isolate_selected_configurations() {
+    let fixture = configured_fixture();
+    fixture.write_repository(".cursor/cli.json", "[");
+
+    for (args, expected_lines, expected) in [
+        (
+            vec!["doctor", "config", "--agent", "codex", "--scope", "user"],
+            1,
+            "healthy config: codex user",
+        ),
+        (
+            vec!["doctor", "config", "--agent", "claude"],
+            2,
+            "healthy config: claude project",
+        ),
+    ] {
+        let (code, stdout, stderr) = run(&fixture, &args);
+        assert_eq!(code, 0);
+        assert_eq!(stdout.lines().count(), expected_lines);
+        assert!(stdout.contains(expected), "{stdout}");
+        assert!(!stdout.contains("cursor"), "{stdout}");
+        assert!(stderr.is_empty());
+    }
+
+    let (code, stdout, _) = run(&fixture, &["doctor", "config", "--scope", "project"]);
+    assert_eq!(code, 2);
+    assert_eq!(stdout.lines().count(), 3);
+    assert!(stdout.contains("error config: cursor project"));
+    assert!(!stdout.contains("cursor user"));
+}
+
+#[test]
+fn missing_roots_and_files_are_drift() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", ALL_AGENTS);
+    let (code, stdout, _) = run(&fixture, &["doctor", "config"]);
+    assert_eq!(code, 1);
+    assert_eq!(stdout.matches("root ").count(), 6);
+    assert_eq!(stdout.matches("is missing").count(), 6);
+
+    for path in [".claude", ".cursor", ".codex"] {
+        fs::create_dir_all(fixture.home().join(path)).unwrap();
+        fs::create_dir_all(fixture.repository().join(path)).unwrap();
+    }
+    let (code, stdout, _) = run(&fixture, &["doctor", "config"]);
+    assert_eq!(code, 1);
+    assert_eq!(stdout.matches("file ").count(), 6);
+    assert_eq!(stdout.matches("is missing").count(), 6);
+}
+
+#[test]
+fn unreadable_and_invalid_paths_are_errors() {
+    let fixture = configured_fixture();
+    set_mode(&fixture.home().join(".claude"), 0o000);
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "config", "--agent", "claude", "--scope", "user"],
+    );
+    set_mode(&fixture.home().join(".claude"), 0o700);
+    assert_eq!(code, 2);
+    assert!(
+        stdout.contains("root ~/.claude could not be read"),
+        "{stdout}"
+    );
+
+    set_mode(&fixture.home().join(".cursor/cli-config.json"), 0o000);
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "config", "--agent", "cursor", "--scope", "user"],
+    );
+    set_mode(&fixture.home().join(".cursor/cli-config.json"), 0o600);
+    assert_eq!(code, 2);
+    assert!(stdout.contains("file ~/.cursor/cli-config.json could not be read"));
+
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", CLAUDE_USER);
+    fixture.write_home(".claude", "not a directory");
+    let (code, stdout, _) = run(&fixture, &["doctor", "config"]);
+    assert_eq!(code, 2);
+    assert!(stdout.contains("root ~/.claude is not a directory"));
+}
+
+#[test]
+fn malformed_formats_and_wrong_json_roots_are_errors() {
+    for (agent, scope, path, contents, expected) in [
+        (
+            "claude",
+            "user",
+            ".claude/settings.json",
+            "{",
+            "malformed JSON",
+        ),
+        (
+            "cursor",
+            "user",
+            ".cursor/cli-config.json",
+            "[]",
+            "top-level JSON object",
+        ),
+        (
+            "codex",
+            "user",
+            ".codex/config.toml",
+            "value = [",
+            "malformed TOML",
+        ),
+    ] {
+        let fixture = configured_fixture();
+        fixture.write_home(path, contents);
+        let (code, stdout, stderr) = run(
+            &fixture,
+            &["doctor", "config", "--agent", agent, "--scope", scope],
+        );
+        assert_eq!(code, 2);
+        assert!(stdout.contains(expected), "{stdout}");
+        assert!(stderr.is_empty());
+    }
+}
+
+#[test]
+fn non_files_and_non_utf8_files_are_errors() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", CLAUDE_USER);
+    fs::create_dir_all(fixture.home().join(".claude/settings.json")).unwrap();
+    let (code, stdout, _) = run(&fixture, &["doctor", "config"]);
+    assert_eq!(code, 2);
+    assert!(stdout.contains("file ~/.claude/settings.json is not a file"));
+
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", CLAUDE_USER);
+    fs::create_dir_all(fixture.home().join(".claude")).unwrap();
+    fs::write(fixture.home().join(".claude/settings.json"), [0xff]).unwrap();
+    let (code, stdout, _) = run(&fixture, &["doctor", "config"]);
+    assert_eq!(code, 2);
+    assert!(stdout.contains("file ~/.claude/settings.json could not be read"));
+}
+
+#[test]
+fn undeclared_filtered_combinations_are_unsupported() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", CLAUDE_USER);
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &["doctor", "config", "--agent", "codex", "--scope", "project"],
+    );
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout,
+        "unsupported config: codex project configuration is not declared in the manifest\n"
+    );
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn empty_manifests_are_explicitly_unsupported() {
+    for manifest in [
+        "version: 1\nagents: []\nresources: []\n",
+        "version: 1\nagents:\n  - id: claude\n    scopes: []\nresources: []\n",
+    ] {
+        let fixture = Fixture::new();
+        fixture.write_home(".arnes.yaml", manifest);
+        let (code, stdout, stderr) = run(&fixture, &["doctor", "config"]);
+
+        assert_eq!(code, 0);
+        assert_eq!(
+            stdout,
+            "unsupported config: no configuration combinations are declared in the manifest\n"
+        );
+        assert!(stderr.is_empty());
+    }
+}
+
+#[test]
+fn manifest_failures_fail_closed_as_config_errors() {
+    let fixture = Fixture::new();
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "config"]);
+
+    assert_eq!(code, 2);
+    assert_eq!(
+        stdout,
+        "error config: manifest: .arnes.yaml was not found\n"
+    );
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn config_doctor_is_read_only() {
+    let fixture = configured_fixture();
+    let before = fixture.snapshot();
+
+    let (code, _, _) = run(&fixture, &["doctor", "config"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(fixture.snapshot(), before);
+}
+
+fn set_mode(path: &std::path::Path, mode: u32) {
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(mode);
+    fs::set_permissions(path, permissions).unwrap();
+}


### PR DESCRIPTION
## Description

- add read-only `arnes doctor config` diagnostics for Claude, Cursor, and Codex user/project configuration roots
- isolate checks through `--agent` and `--scope`, reporting undeclared or empty manifest combinations as unsupported
- diagnose missing, unreadable, malformed, and wrong-type JSON/TOML configuration without validating nested resources or keys
- cover the behavior with isolated repository and `HOME` fixtures, including read-only snapshots

## Useful Links

- Closes #115
- Related to #111

## How to Test

On macOS 26.5 arm64:

```sh
cargo fmt --manifest-path tooling/arnes/Cargo.toml --check
cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features -- -D warnings
cargo test --manifest-path tooling/arnes/Cargo.toml --all-features
make -n arnes
```

GitHub Actions covers Ubuntu.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
