### PR TITLE
feat(arnes): diagnose agent instructions

### DIFF
--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -6,4 +6,34 @@ agents:
     scopes: [user, project]
   - id: codex
     scopes: [user, project]
-resources: []
+resources:
+  - id: claude-user-instructions
+    kind: instructions
+    agent: claude
+    scope: user
+    source: { root: repository, path: harness/AGENTS.md }
+    destination: { root: home, path: .claude/CLAUDE.md }
+  - id: claude-user-soul
+    kind: instructions
+    agent: claude
+    scope: user
+    source: { root: repository, path: harness/SOUL.md }
+    destination: { root: home, path: .claude/SOUL.md }
+  - id: claude-user-preferences
+    kind: instructions
+    agent: claude
+    scope: user
+    source: { root: repository, path: harness/USER.md }
+    destination: { root: home, path: .claude/USER.md }
+  - id: claude-project-instructions
+    kind: instructions
+    agent: claude
+    scope: project
+    source: { root: repository, path: AGENTS.md }
+    destination: { root: repository, path: CLAUDE.md }
+  - id: codex-user-instructions
+    kind: instructions
+    agent: codex
+    scope: user
+    source: { root: repository, path: harness/AGENTS.md }
+    destination: { root: home, path: .codex/AGENTS.md }

--- a/tooling/arnes/src/instructions.rs
+++ b/tooling/arnes/src/instructions.rs
@@ -1,0 +1,58 @@
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Manifest, Scope};
+
+mod checks;
+mod includes;
+mod projection;
+
+pub fn diagnose(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    let combinations = manifest
+        .combinations()
+        .filter(|(candidate, _)| agent.is_none_or(|agent| agent == *candidate))
+        .filter(|(_, candidate)| scope.is_none_or(|scope| scope == *candidate))
+        .collect::<Vec<_>>();
+
+    if combinations.is_empty() {
+        return vec![unsupported(agent, scope)];
+    }
+
+    combinations
+        .into_iter()
+        .flat_map(|(agent, scope)| {
+            let resources = manifest
+                .instruction_resources()
+                .filter(|resource| resource.agent == agent && resource.scope == scope)
+                .collect::<Vec<_>>();
+            let Some(kind) = projection::kind(agent, scope) else {
+                return vec![unsupported(Some(agent), Some(scope))];
+            };
+            if resources.is_empty() {
+                return vec![unsupported(Some(agent), Some(scope))];
+            }
+            resources
+                .iter()
+                .map(|resource| projection::diagnose(roots, resource, &resources, kind))
+                .collect()
+        })
+        .collect()
+}
+
+fn unsupported(agent: Option<Agent>, scope: Option<Scope>) -> Diagnostic {
+    let subject = match (agent, scope) {
+        (Some(agent), Some(scope)) => format!("{agent} {scope} instruction projection"),
+        (Some(agent), None) => format!("{agent} instruction projection"),
+        (None, Some(scope)) => format!("{scope} instruction scope"),
+        (None, None) => "instruction projections".to_owned(),
+    };
+    Diagnostic::new(
+        "instructions",
+        State::Unsupported,
+        format!("{subject} is not declared or supported"),
+    )
+}

--- a/tooling/arnes/src/instructions/checks.rs
+++ b/tooling/arnes/src/instructions/checks.rs
@@ -1,0 +1,163 @@
+use super::includes::{IncludeError, parent_within, resolves_within, same_file};
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{InstructionResource, Scope};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+pub fn expected_link(
+    destination: &Path,
+    source: &Path,
+    root: &Path,
+    subject: &str,
+) -> Result<(), Diagnostic> {
+    if !parent_within(destination, root) {
+        return Err(outside_destination(subject, destination));
+    }
+    let metadata = fs::symlink_metadata(destination).map_err(|error| match error.kind() {
+        ErrorKind::NotFound => destination_error(subject, destination, State::Drift, "is missing"),
+        _ => destination_error(subject, destination, State::Error, "could not be read"),
+    })?;
+    if !metadata.file_type().is_symlink() {
+        return Err(wrong_link(subject, destination));
+    }
+    if !same_file(destination, source) {
+        return Err(wrong_link(subject, destination));
+    }
+    Ok(())
+}
+
+pub fn expected_file(destination: &Path, root: &Path, subject: &str) -> Result<(), Diagnostic> {
+    let metadata = fs::symlink_metadata(destination).map_err(|error| match error.kind() {
+        ErrorKind::NotFound => destination_error(subject, destination, State::Drift, "is missing"),
+        _ => destination_error(subject, destination, State::Error, "could not be read"),
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(destination_error(
+            subject,
+            destination,
+            State::Drift,
+            "is not a regular file",
+        ));
+    }
+    if !resolves_within(destination, root) {
+        return Err(outside_destination(subject, destination));
+    }
+    Ok(())
+}
+
+pub fn include_diagnostic(subject: &str, error: IncludeError, default: State) -> Diagnostic {
+    let (state, message) = match error {
+        IncludeError::Missing(path) => (default, format!("include {} is missing", path.display())),
+        IncludeError::MissingLink(path) => (
+            State::Drift,
+            format!("include {} is missing", path.display()),
+        ),
+        IncludeError::WrongLink(path) => (
+            State::Drift,
+            format!("include {} has the wrong symlink target", path.display()),
+        ),
+        IncludeError::NotFile(path) => (State::Error, format!("{} is not a file", path.display())),
+        IncludeError::Unreadable(path) => (
+            State::Error,
+            format!("{} could not be read", path.display()),
+        ),
+        IncludeError::Escapes(path) => (
+            State::Error,
+            format!("include {path} escapes its instruction root"),
+        ),
+        IncludeError::OutsideRoot(path) => (
+            State::Error,
+            format!("{} resolves outside its instruction root", path.display()),
+        ),
+        IncludeError::Cycle(path) => (
+            State::Error,
+            format!("include cycle reaches {}", path.display()),
+        ),
+    };
+    Diagnostic::new("instructions", state, format!("{subject}: {message}"))
+}
+
+pub fn source_diagnostic(subject: &str, error: IncludeError) -> Diagnostic {
+    let message = match error {
+        IncludeError::Missing(path) | IncludeError::MissingLink(path) => {
+            format!("source {} is missing", path.display())
+        }
+        IncludeError::NotFile(path) => format!("source {} is not a file", path.display()),
+        IncludeError::Unreadable(path) => format!("source {} could not be read", path.display()),
+        IncludeError::WrongLink(path) => {
+            format!("source {} has an unsupported symlink", path.display())
+        }
+        IncludeError::Escapes(path) => format!("source include {path} escapes the repository"),
+        IncludeError::OutsideRoot(path) => {
+            format!("source {} resolves outside the repository", path.display())
+        }
+        IncludeError::Cycle(path) => {
+            format!("source include cycle reaches {}", path.display())
+        }
+    };
+    Diagnostic::new(
+        "instructions",
+        State::Error,
+        format!("{subject}: {message}"),
+    )
+}
+
+pub fn destination(roots: &Roots, resource: &InstructionResource<'_>) -> PathBuf {
+    match resource.scope {
+        Scope::User => roots.home().join(resource.destination),
+        Scope::Project => roots.repository().join(resource.destination),
+    }
+}
+
+pub fn destination_label(resource: &InstructionResource<'_>) -> String {
+    match resource.scope {
+        Scope::User => format!("~/{}", resource.destination.display()),
+        Scope::Project => resource.destination.display().to_string(),
+    }
+}
+
+pub fn relative(path: &Path, roots: &Roots) -> String {
+    path.strip_prefix(roots.home())
+        .map(|path| format!("~/{}", path.display()))
+        .or_else(|_| {
+            path.strip_prefix(roots.repository())
+                .map(|path| path.display().to_string())
+        })
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
+pub fn healthy(subject: &str, destination: String) -> Diagnostic {
+    Diagnostic::new(
+        "instructions",
+        State::Healthy,
+        format!("{subject} destination {destination} is current"),
+    )
+}
+
+fn wrong_link(subject: &str, destination: &Path) -> Diagnostic {
+    destination_error(
+        subject,
+        destination,
+        State::Drift,
+        "has the wrong symlink target",
+    )
+}
+
+fn outside_destination(subject: &str, destination: &Path) -> Diagnostic {
+    destination_error(
+        subject,
+        destination,
+        State::Error,
+        "resolves outside its declared root",
+    )
+}
+
+fn destination_error(subject: &str, path: &Path, state: State, reason: &str) -> Diagnostic {
+    Diagnostic::new(
+        "instructions",
+        state,
+        format!("{subject} destination {} {reason}", path.display()),
+    )
+}

--- a/tooling/arnes/src/instructions/includes.rs
+++ b/tooling/arnes/src/instructions/includes.rs
@@ -1,0 +1,174 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Component, Path, PathBuf};
+
+mod parser;
+
+use parser::imports;
+pub use parser::{leading_imports, without_leading_imports};
+
+pub struct Resolver {
+    root: PathBuf,
+    alias_root: PathBuf,
+    aliases: HashMap<PathBuf, PathBuf>,
+}
+
+pub struct Graph {
+    visited: HashSet<PathBuf>,
+}
+
+#[derive(Debug)]
+pub enum IncludeError {
+    Missing(PathBuf),
+    MissingLink(PathBuf),
+    WrongLink(PathBuf),
+    NotFile(PathBuf),
+    Unreadable(PathBuf),
+    Escapes(String),
+    OutsideRoot(PathBuf),
+    Cycle(PathBuf),
+}
+
+impl Resolver {
+    pub fn new(root: &Path) -> Self {
+        Self::with_aliases(root, root, [])
+    }
+
+    pub fn with_aliases(
+        root: &Path,
+        alias_root: &Path,
+        aliases: impl IntoIterator<Item = (PathBuf, PathBuf)>,
+    ) -> Self {
+        Self {
+            root: root.to_owned(),
+            alias_root: alias_root.to_owned(),
+            aliases: aliases.into_iter().collect(),
+        }
+    }
+
+    pub fn walk(&self, path: &Path) -> Result<Graph, IncludeError> {
+        let mut active = HashSet::new();
+        let mut visited = HashSet::new();
+        self.visit(path, &mut active, &mut visited)?;
+        Ok(Graph { visited })
+    }
+
+    pub fn read(&self, path: &Path) -> Result<String, IncludeError> {
+        self.load(path).map(|(_, contents)| contents)
+    }
+
+    pub fn resolve(&self, parent: &Path, include: &str) -> Result<PathBuf, IncludeError> {
+        let mut path = parent.to_owned();
+        for component in Path::new(include).components() {
+            match component {
+                Component::CurDir => {}
+                Component::Normal(part) => path.push(part),
+                Component::ParentDir if path != self.root => {
+                    path.pop();
+                }
+                _ => return Err(IncludeError::Escapes(include.to_owned())),
+            }
+        }
+        if path.starts_with(&self.root) {
+            Ok(path)
+        } else {
+            Err(IncludeError::Escapes(include.to_owned()))
+        }
+    }
+
+    fn visit(
+        &self,
+        path: &Path,
+        active: &mut HashSet<PathBuf>,
+        visited: &mut HashSet<PathBuf>,
+    ) -> Result<(), IncludeError> {
+        if visited.contains(path) {
+            return Ok(());
+        }
+        let (identity, contents) = self.load(path)?;
+        if !active.insert(identity.clone()) {
+            return Err(IncludeError::Cycle(path.to_owned()));
+        }
+        for include in imports(&contents) {
+            let included = self.resolve(path.parent().unwrap_or(&self.root), &include)?;
+            self.visit(&included, active, visited)?;
+        }
+        active.remove(&identity);
+        visited.insert(path.to_owned());
+        Ok(())
+    }
+
+    fn load(&self, path: &Path) -> Result<(PathBuf, String), IncludeError> {
+        if let Some(source) = self.aliases.get(path) {
+            if !parent_within(path, &self.root) {
+                return Err(IncludeError::OutsideRoot(path.to_owned()));
+            }
+            let metadata = fs::symlink_metadata(path).map_err(|error| match error.kind() {
+                ErrorKind::NotFound => IncludeError::MissingLink(path.to_owned()),
+                _ => IncludeError::Unreadable(path.to_owned()),
+            })?;
+            if !metadata.file_type().is_symlink() {
+                return Err(IncludeError::WrongLink(path.to_owned()));
+            }
+            if !same_file(path, source) {
+                return Err(IncludeError::WrongLink(path.to_owned()));
+            }
+            return load_regular(source, &self.alias_root);
+        }
+        load_regular(path, &self.root)
+    }
+}
+
+impl Graph {
+    pub fn contains(&self, path: &Path) -> bool {
+        self.visited.contains(path)
+    }
+}
+
+pub fn read_regular(path: &Path, root: &Path) -> Result<String, IncludeError> {
+    load_regular(path, root).map(|(_, contents)| contents)
+}
+
+fn load_regular(path: &Path, root: &Path) -> Result<(PathBuf, String), IncludeError> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| match error.kind() {
+        ErrorKind::NotFound => IncludeError::Missing(path.to_owned()),
+        _ => IncludeError::Unreadable(path.to_owned()),
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(IncludeError::NotFile(path.to_owned()));
+    }
+    let identity = canonical_within(path, root)?;
+    let contents =
+        fs::read_to_string(path).map_err(|_| IncludeError::Unreadable(path.to_owned()))?;
+    Ok((identity, contents))
+}
+
+fn canonical_within(path: &Path, root: &Path) -> Result<PathBuf, IncludeError> {
+    let root = fs::canonicalize(root).map_err(|_| IncludeError::Unreadable(root.to_owned()))?;
+    let path = fs::canonicalize(path).map_err(|_| IncludeError::Unreadable(path.to_owned()))?;
+    if path.starts_with(root) {
+        Ok(path)
+    } else {
+        Err(IncludeError::OutsideRoot(path))
+    }
+}
+
+pub fn same_file(link: &Path, source: &Path) -> bool {
+    match (fs::canonicalize(link), fs::canonicalize(source)) {
+        (Ok(link), Ok(source)) => link == source,
+        _ => false,
+    }
+}
+
+pub fn parent_within(path: &Path, root: &Path) -> bool {
+    path.parent()
+        .is_some_and(|parent| resolves_within(parent, root))
+}
+
+pub fn resolves_within(path: &Path, root: &Path) -> bool {
+    match (fs::canonicalize(path), fs::canonicalize(root)) {
+        (Ok(path), Ok(root)) => path.starts_with(root),
+        _ => false,
+    }
+}

--- a/tooling/arnes/src/instructions/includes/parser.rs
+++ b/tooling/arnes/src/instructions/includes/parser.rs
@@ -1,0 +1,88 @@
+pub fn imports(contents: &str) -> Vec<String> {
+    let mut fence = None;
+    contents
+        .lines()
+        .flat_map(|line| {
+            if let Some((marker, length)) = fence_marker(line) {
+                match fence {
+                    Some((open, minimum)) if marker == open && length >= minimum => fence = None,
+                    None => fence = Some((marker, length)),
+                    _ => {}
+                }
+                return Vec::new();
+            }
+            if fence.is_some() {
+                Vec::new()
+            } else {
+                imports_in_line(line)
+            }
+        })
+        .collect()
+}
+
+pub fn leading_imports(contents: &str) -> Vec<String> {
+    contents
+        .lines()
+        .filter(|line| line.starts_with('@'))
+        .flat_map(imports_in_line)
+        .collect()
+}
+
+pub fn without_leading_imports(contents: &str) -> String {
+    contents
+        .split_inclusive('\n')
+        .filter(|line| !line.starts_with('@'))
+        .collect()
+}
+
+fn imports_in_line(line: &str) -> Vec<String> {
+    let bytes = line.as_bytes();
+    let mut imports = Vec::new();
+    let mut index = 0;
+    let mut code_ticks = None;
+
+    while index < bytes.len() {
+        if bytes[index] == b'`' {
+            let length = bytes[index..]
+                .iter()
+                .take_while(|byte| **byte == b'`')
+                .count();
+            match code_ticks {
+                Some(open) if open == length => code_ticks = None,
+                None => code_ticks = Some(length),
+                _ => {}
+            }
+            index += length;
+            continue;
+        }
+        if bytes[index] != b'@'
+            || code_ticks.is_some()
+            || index > 0 && bytes[index - 1].is_ascii_alphanumeric()
+        {
+            index += 1;
+            continue;
+        }
+        let start = index + 1;
+        let mut end = start;
+        while end < bytes.len()
+            && (bytes[end].is_ascii_alphanumeric() || b"./_~-".contains(&bytes[end]))
+        {
+            end += 1;
+        }
+        if end > start {
+            imports.push(line[start..end].to_owned());
+        }
+        index = end.max(index + 1);
+    }
+    imports
+}
+
+fn fence_marker(line: &str) -> Option<(u8, usize)> {
+    let bytes = line.trim_start().as_bytes();
+    let marker = *bytes.first()?;
+    if !matches!(marker, b'`' | b'~') {
+        return None;
+    }
+    let length = bytes.iter().take_while(|byte| **byte == marker).count();
+    (length >= 3).then_some((marker, length))
+}

--- a/tooling/arnes/src/instructions/projection.rs
+++ b/tooling/arnes/src/instructions/projection.rs
@@ -1,0 +1,143 @@
+use super::checks::{
+    destination, destination_label, expected_file, expected_link, healthy, include_diagnostic,
+    relative, source_diagnostic,
+};
+use super::includes::{self, Resolver};
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, InstructionResource, Scope};
+use std::fs;
+use std::path::Path;
+
+#[derive(Clone, Copy)]
+pub enum Projection {
+    Link,
+    Include,
+    Generated,
+}
+
+pub fn kind(agent: Agent, scope: Scope) -> Option<Projection> {
+    match (agent, scope) {
+        (Agent::Claude, Scope::User) => Some(Projection::Link),
+        (Agent::Claude, Scope::Project) => Some(Projection::Include),
+        (Agent::Codex, Scope::User) => Some(Projection::Generated),
+        _ => None,
+    }
+}
+
+pub fn diagnose(
+    roots: &Roots,
+    resource: &InstructionResource<'_>,
+    resources: &[InstructionResource<'_>],
+    projection: Projection,
+) -> Diagnostic {
+    let source = roots.repository().join(resource.source);
+    let destination = destination(roots, resource);
+    let subject = format!(
+        "{} {} instructions {}",
+        resource.agent, resource.scope, resource.id
+    );
+    let source_contents = match includes::read_regular(&source, roots.repository()) {
+        Ok(contents) => contents,
+        Err(error) => return source_diagnostic(&subject, error),
+    };
+
+    match projection {
+        Projection::Link => {
+            diagnose_link(roots, resource, resources, &source, &destination, &subject)
+        }
+        Projection::Include => diagnose_include(roots, &source, &destination, &subject),
+        Projection::Generated => {
+            diagnose_generated(roots, &source, &destination, &source_contents, &subject)
+        }
+    }
+}
+
+fn diagnose_link(
+    roots: &Roots,
+    resource: &InstructionResource<'_>,
+    resources: &[InstructionResource<'_>],
+    source: &Path,
+    destination: &Path,
+    subject: &str,
+) -> Diagnostic {
+    if let Err(diagnostic) = expected_link(destination, source, roots.home(), subject) {
+        return diagnostic;
+    }
+    let aliases = resources.iter().map(|candidate| {
+        (
+            roots.home().join(candidate.destination),
+            roots.repository().join(candidate.source),
+        )
+    });
+    let resolver = Resolver::with_aliases(roots.home(), roots.repository(), aliases);
+    match resolver.walk(destination) {
+        Ok(_) => healthy(subject, destination_label(resource)),
+        Err(error) => include_diagnostic(subject, error, State::Error),
+    }
+}
+
+fn diagnose_include(roots: &Roots, source: &Path, destination: &Path, subject: &str) -> Diagnostic {
+    if let Err(diagnostic) = expected_file(destination, roots.repository(), subject) {
+        return diagnostic;
+    }
+    let resolver = Resolver::new(roots.repository());
+    match resolver.walk(destination) {
+        Ok(graph) if graph.contains(source) => healthy(subject, relative(destination, roots)),
+        Ok(_) => Diagnostic::new(
+            "instructions",
+            State::Drift,
+            format!(
+                "{subject} does not include source {}",
+                relative(source, roots)
+            ),
+        ),
+        Err(error) => include_diagnostic(subject, error, State::Error),
+    }
+}
+
+fn diagnose_generated(
+    roots: &Roots,
+    source: &Path,
+    destination: &Path,
+    source_contents: &str,
+    subject: &str,
+) -> Diagnostic {
+    if let Err(diagnostic) = expected_file(destination, roots.home(), subject) {
+        return diagnostic;
+    }
+    let resolver = Resolver::new(roots.repository());
+    if let Err(error) = resolver.walk(source) {
+        return include_diagnostic(subject, error, State::Error);
+    }
+    let mut expected = includes::without_leading_imports(source_contents);
+    for include in includes::leading_imports(source_contents) {
+        let path = match resolver.resolve(source.parent().unwrap_or(roots.repository()), &include) {
+            Ok(path) => path,
+            Err(error) => return include_diagnostic(subject, error, State::Error),
+        };
+        match resolver.read(&path) {
+            Ok(contents) => expected.push_str(&contents),
+            Err(error) => return include_diagnostic(subject, error, State::Error),
+        }
+    }
+    match fs::read_to_string(destination) {
+        Ok(contents) if contents == expected => healthy(subject, relative(destination, roots)),
+        Ok(_) => Diagnostic::new(
+            "instructions",
+            State::Drift,
+            format!(
+                "{subject} generated file {} is stale",
+                relative(destination, roots)
+            ),
+        ),
+        Err(_) => Diagnostic::new(
+            "instructions",
+            State::Error,
+            format!(
+                "{subject} file {} could not be read",
+                relative(destination, roots)
+            ),
+        ),
+    }
+}

--- a/tooling/arnes/src/lib.rs
+++ b/tooling/arnes/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod diagnostic;
+pub mod instructions;
 pub mod manifest;
 pub mod roots;
 

--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -5,6 +5,7 @@ use std::process::ExitCode;
 use arnes::Roots;
 use arnes::config;
 use arnes::diagnostic::{Diagnostic, Report, State};
+use arnes::instructions;
 use arnes::manifest::{self, Agent, Scope};
 
 #[derive(Parser)]
@@ -68,6 +69,14 @@ fn main() -> ExitCode {
             Ok(roots) => diagnose_config(&roots, agent, scope),
             Err(error) => vec![Diagnostic::new("config", State::Error, error.to_string())],
         },
+        Some(Resource::Instructions) => match Roots::from_environment() {
+            Ok(roots) => diagnose_instructions(&roots, agent, scope),
+            Err(error) => vec![Diagnostic::new(
+                "instructions",
+                State::Error,
+                error.to_string(),
+            )],
+        },
         _ => Vec::new(),
     };
     let report = Report::new(diagnostics);
@@ -112,5 +121,20 @@ fn diagnose_config(roots: &Roots, agent: Option<Agent>, scope: Option<Scope>) ->
     match manifest::load(roots.home()) {
         Ok(manifest) => config::diagnose(roots, &manifest, agent, scope),
         Err(error) => vec![Diagnostic::new("config", State::Error, error.to_string())],
+    }
+}
+
+fn diagnose_instructions(
+    roots: &Roots,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    match manifest::load(roots.home()) {
+        Ok(manifest) => instructions::diagnose(roots, &manifest, agent, scope),
+        Err(error) => vec![Diagnostic::new(
+            "instructions",
+            State::Error,
+            error.to_string(),
+        )],
     }
 }

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -48,6 +48,28 @@ impl Manifest {
             .iter()
             .flat_map(|agent| agent.scopes.iter().map(move |scope| (agent.id, *scope)))
     }
+
+    pub fn instruction_resources(&self) -> impl Iterator<Item = InstructionResource<'_>> {
+        self.resources
+            .iter()
+            .filter(|resource| resource.kind == ResourceKind::Instructions)
+            .map(|resource| InstructionResource {
+                id: &resource.id,
+                agent: resource.agent,
+                scope: resource.scope,
+                source: &resource.source.path,
+                destination: &resource.destination.path,
+            })
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct InstructionResource<'a> {
+    pub id: &'a str,
+    pub agent: Agent,
+    pub scope: Scope,
+    pub source: &'a Path,
+    pub destination: &'a Path,
 }
 
 #[derive(Deserialize)]
@@ -61,8 +83,7 @@ struct AgentDeclaration {
 #[serde(deny_unknown_fields)]
 struct ResourceDeclaration {
     id: String,
-    #[serde(rename = "kind")]
-    _kind: ResourceKind,
+    kind: ResourceKind,
     agent: Agent,
     scope: Scope,
     source: RootedPath,
@@ -98,7 +119,7 @@ pub enum Scope {
     Project,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum ResourceKind {
     Config,

--- a/tooling/arnes/tests/instruction_adversarial.rs
+++ b/tooling/arnes/tests/instruction_adversarial.rs
@@ -1,0 +1,133 @@
+#[path = "support/instructions.rs"]
+pub mod instruction_support;
+pub mod support;
+
+use instruction_support::{configured_fixture, remove, run};
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+#[test]
+fn relative_symlinks_to_expected_sources_are_healthy() {
+    let fixture = configured_fixture();
+    for (source, destination) in [
+        ("AGENTS.md", "CLAUDE.md"),
+        ("SOUL.md", "SOUL.md"),
+        ("USER.md", "USER.md"),
+    ] {
+        let destination = fixture.home().join(".claude").join(destination);
+        remove(&destination);
+        symlink(
+            Path::new("../../repository/harness").join(source),
+            destination,
+        )
+        .unwrap();
+    }
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(stdout.matches("healthy instructions:").count(), 3);
+}
+
+#[test]
+fn source_paths_cannot_escape_through_intermediate_symlinks() {
+    let fixture = configured_fixture();
+    let outside = fixture.repository().parent().unwrap().join("outside");
+    fs::create_dir(&outside).unwrap();
+    fs::rename(
+        fixture.repository().join("harness"),
+        outside.join("harness"),
+    )
+    .unwrap();
+    symlink("../outside/harness", fixture.repository().join("harness")).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+
+    assert_eq!(code, 2);
+    assert!(stdout.contains("resolves outside the repository"));
+}
+
+#[test]
+fn destination_paths_cannot_escape_through_intermediate_symlinks() {
+    let fixture = configured_fixture();
+    let outside = fixture.home().parent().unwrap().join("outside-codex");
+    fs::rename(fixture.home().join(".codex"), &outside).unwrap();
+    symlink("../outside-codex", fixture.home().join(".codex")).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "codex",
+            "--scope",
+            "user",
+        ],
+    );
+
+    assert_eq!(code, 2);
+    assert!(stdout.contains("resolves outside its declared root"));
+}
+
+#[test]
+fn markdown_code_does_not_create_includes() {
+    let fixture = configured_fixture();
+    fixture.write_repository(
+        "harness/AGENTS.md",
+        "~~~text\n```\n@FENCED.md\n```\n~~~\n`@INLINE.md`\n``@DOUBLE.md``\n@SOUL.md\n@USER.md\nrules\n",
+    );
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(stdout.matches("healthy instructions:").count(), 3);
+}
+
+#[test]
+fn directory_symlink_aliases_cannot_mask_cycles() {
+    let fixture = configured_fixture();
+    symlink(".", fixture.repository().join("loop")).unwrap();
+    fixture.write_repository("CLAUDE.md", "@loop/CLAUDE.md\n");
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "project",
+        ],
+    );
+
+    assert_eq!(code, 2);
+    assert!(stdout.contains("include cycle"));
+}

--- a/tooling/arnes/tests/instruction_failures.rs
+++ b/tooling/arnes/tests/instruction_failures.rs
@@ -1,0 +1,201 @@
+#[path = "support/instructions.rs"]
+pub mod instruction_support;
+pub mod support;
+
+use instruction_support::{configured_fixture, remove, replace_home_link, run};
+use std::fs;
+
+#[test]
+fn missing_sources_fail_closed_and_missing_destinations_drift() {
+    let fixture = configured_fixture();
+    remove(fixture.repository().join("harness/SOUL.md"));
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+    assert_eq!(code, 2);
+    assert!(stdout.contains("source"));
+    assert!(stdout.contains("harness/SOUL.md"));
+    assert!(stdout.contains("is missing"));
+
+    let fixture = configured_fixture();
+    remove(fixture.home().join(".claude/CLAUDE.md"));
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+    assert_eq!(code, 1);
+    assert!(stdout.contains("destination"));
+    assert!(stdout.contains("is missing"));
+
+    let fixture = configured_fixture();
+    remove(fixture.home().join(".claude/SOUL.md"));
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+    assert_eq!(code, 1);
+    assert!(stdout.contains("include"));
+    assert!(stdout.contains(".claude/SOUL.md"));
+    assert!(stdout.contains("is missing"));
+}
+
+#[test]
+fn wrong_symlink_targets_are_drift() {
+    let fixture = configured_fixture();
+    replace_home_link(&fixture, "harness/USER.md", ".claude/SOUL.md");
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+
+    assert_eq!(code, 1);
+    assert!(stdout.contains("wrong symlink target"));
+    assert!(stdout.contains(".claude/SOUL.md"));
+}
+
+#[test]
+fn missing_includes_and_cycles_are_errors() {
+    let fixture = configured_fixture();
+    fixture.write_repository("harness/AGENTS.md", "@MISSING.md\n");
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+    assert_eq!(code, 2);
+    assert!(stdout.contains("include"));
+    assert!(stdout.contains("MISSING.md"));
+    assert!(stdout.contains("is missing"));
+
+    let fixture = configured_fixture();
+    fixture.write_repository("harness/SOUL.md", "@CLAUDE.md\n");
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+    assert_eq!(code, 2);
+    assert!(stdout.contains("include cycle"));
+}
+
+#[test]
+fn includes_resolve_from_the_effective_destination() {
+    let fixture = configured_fixture();
+    let manifest = fs::read_to_string(fixture.home().join(".arnes.yaml")).unwrap();
+    fixture.write_home(
+        ".arnes.yaml",
+        &manifest.replace(".claude/SOUL.md", ".claude/nested/SOUL.md"),
+    );
+    remove(fixture.home().join(".claude/SOUL.md"));
+    instruction_support::link_home(&fixture, "harness/SOUL.md", ".claude/nested/SOUL.md");
+    fixture.write_repository("harness/AGENTS.md", "@nested/SOUL.md\n@USER.md\nrules\n");
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(stdout.matches("healthy instructions:").count(), 3);
+}
+
+#[test]
+fn includes_cannot_escape_their_fixture_root() {
+    let fixture = configured_fixture();
+    fixture.write_repository("harness/AGENTS.md", "@../../outside.md\n");
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+
+    assert_eq!(code, 2);
+    assert!(stdout.contains("escapes its instruction root"));
+}
+
+#[test]
+fn malformed_instruction_paths_fail_closed() {
+    let fixture = configured_fixture();
+    fs::create_dir(fixture.repository().join("harness/BROKEN.md")).unwrap();
+    fixture.write_repository("harness/AGENTS.md", "@BROKEN.md\n");
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "codex",
+            "--scope",
+            "user",
+        ],
+    );
+
+    assert_eq!(code, 2);
+    assert!(stdout.contains("is not a file"));
+}
+
+#[test]
+fn manifest_failures_fail_closed_as_instruction_errors() {
+    let fixture = support::Fixture::new();
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "instructions"]);
+
+    assert_eq!(code, 2);
+    assert_eq!(
+        stdout,
+        "error instructions: manifest: .arnes.yaml was not found\n"
+    );
+    assert!(stderr.is_empty());
+}

--- a/tooling/arnes/tests/instructions.rs
+++ b/tooling/arnes/tests/instructions.rs
@@ -1,0 +1,149 @@
+#[path = "support/instructions.rs"]
+pub mod instruction_support;
+pub mod support;
+
+use instruction_support::{configured_fixture, run};
+use std::fs;
+use support::Fixture;
+
+#[test]
+fn supported_projections_are_healthy_and_native_projections_are_unsupported() {
+    let fixture = configured_fixture();
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "instructions"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(stdout.lines().count(), 8);
+    assert_eq!(stdout.matches("healthy instructions:").count(), 5);
+    assert_eq!(stdout.matches("unsupported instructions:").count(), 3);
+    for expected in [
+        "healthy instructions: claude user instructions claude-user-instructions",
+        "healthy instructions: claude user instructions claude-user-soul",
+        "healthy instructions: claude user instructions claude-user-preferences",
+        "healthy instructions: claude project instructions claude-project-instructions",
+        "unsupported instructions: cursor user instruction projection",
+        "unsupported instructions: cursor project instruction projection",
+        "healthy instructions: codex user instructions codex-user-instructions",
+        "unsupported instructions: codex project instruction projection",
+    ] {
+        assert!(stdout.contains(expected), "missing {expected}: {stdout}");
+    }
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn agent_and_scope_filters_isolate_projections() {
+    let fixture = configured_fixture();
+    fixture.write_home(".codex/AGENTS.md", "stale\n");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+    assert_eq!(code, 0);
+    assert_eq!(stdout.lines().count(), 3);
+    assert!(!stdout.contains("codex"));
+
+    let (code, stdout, _) = run(&fixture, &["doctor", "instructions", "--agent", "cursor"]);
+    assert_eq!(code, 0);
+    assert_eq!(stdout.matches("unsupported instructions:").count(), 2);
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "codex",
+            "--scope",
+            "project",
+        ],
+    );
+    assert_eq!(code, 0);
+    assert_eq!(stdout.lines().count(), 1);
+    assert!(stdout.contains("unsupported instructions: codex project"));
+}
+
+#[test]
+fn undeclared_filtered_combinations_are_unsupported() {
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user]\nresources: []\n",
+    );
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "instructions", "--agent", "codex"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout,
+        "unsupported instructions: codex instruction projection is not declared or supported\n"
+    );
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn codex_generated_content_must_match_declared_composition() {
+    let fixture = configured_fixture();
+    fixture.write_home(".codex/AGENTS.md", "rules\nsoul\nold user\n");
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "codex",
+            "--scope",
+            "user",
+        ],
+    );
+
+    assert_eq!(code, 1);
+    assert!(stdout.contains("generated file ~/.codex/AGENTS.md is stale"));
+}
+
+#[test]
+fn repository_agents_file_has_precedence_for_claude_project() {
+    let fixture = configured_fixture();
+    fixture.write_repository("CLAUDE.md", "See @harness/AGENTS.md instead.\n");
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "project",
+        ],
+    );
+
+    assert_eq!(code, 1);
+    assert!(stdout.contains("does not include source AGENTS.md"));
+}
+
+#[test]
+fn instructions_doctor_is_read_only() {
+    let fixture = configured_fixture();
+    let before = fixture.snapshot();
+
+    let (code, _, _) = run(&fixture, &["doctor", "instructions"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn doctor_without_resource_does_not_aggregate_instructions_yet() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.home().join(".codex/AGENTS.md")).unwrap();
+    let (code, stdout, _) = run(&fixture, &["doctor"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "healthy manifest: manifest is valid\n");
+}

--- a/tooling/arnes/tests/support/instructions.rs
+++ b/tooling/arnes/tests/support/instructions.rs
@@ -1,0 +1,88 @@
+use crate::support::Fixture;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+pub const MANIFEST: &str = "version: 1
+agents:
+  - id: claude
+    scopes: [user, project]
+  - id: cursor
+    scopes: [user, project]
+  - id: codex
+    scopes: [user, project]
+resources:
+  - id: claude-user-instructions
+    kind: instructions
+    agent: claude
+    scope: user
+    source: { root: repository, path: harness/AGENTS.md }
+    destination: { root: home, path: .claude/CLAUDE.md }
+  - id: claude-user-soul
+    kind: instructions
+    agent: claude
+    scope: user
+    source: { root: repository, path: harness/SOUL.md }
+    destination: { root: home, path: .claude/SOUL.md }
+  - id: claude-user-preferences
+    kind: instructions
+    agent: claude
+    scope: user
+    source: { root: repository, path: harness/USER.md }
+    destination: { root: home, path: .claude/USER.md }
+  - id: claude-project-instructions
+    kind: instructions
+    agent: claude
+    scope: project
+    source: { root: repository, path: AGENTS.md }
+    destination: { root: repository, path: CLAUDE.md }
+  - id: codex-user-instructions
+    kind: instructions
+    agent: codex
+    scope: user
+    source: { root: repository, path: harness/AGENTS.md }
+    destination: { root: home, path: .codex/AGENTS.md }
+";
+
+pub fn configured_fixture() -> Fixture {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", MANIFEST);
+    fixture.write_repository("harness/AGENTS.md", "@SOUL.md\n@USER.md\nrules\n");
+    fixture.write_repository("harness/SOUL.md", "soul\n");
+    fixture.write_repository("harness/USER.md", "user\n");
+    fixture.write_repository("AGENTS.md", "project rules\n");
+    fixture.write_repository("CLAUDE.md", "See @AGENTS.md for project rules.\n");
+    link_home(&fixture, "harness/AGENTS.md", ".claude/CLAUDE.md");
+    link_home(&fixture, "harness/SOUL.md", ".claude/SOUL.md");
+    link_home(&fixture, "harness/USER.md", ".claude/USER.md");
+    fixture.write_home(".codex/AGENTS.md", "rules\nsoul\nuser\n");
+    fixture
+}
+
+pub fn link_home(fixture: &Fixture, source: &str, destination: &str) {
+    let destination = fixture.home().join(destination);
+    fs::create_dir_all(destination.parent().unwrap()).unwrap();
+    symlink(
+        fs::canonicalize(fixture.repository().join(source)).unwrap(),
+        destination,
+    )
+    .unwrap();
+}
+
+pub fn replace_home_link(fixture: &Fixture, source: &str, destination: &str) {
+    fs::remove_file(fixture.home().join(destination)).unwrap();
+    link_home(fixture, source, destination);
+}
+
+pub fn run(fixture: &Fixture, args: &[&str]) -> (i32, String, String) {
+    let output = fixture.command(args);
+    (
+        output.status.code().unwrap(),
+        String::from_utf8(output.stdout).unwrap(),
+        String::from_utf8(output.stderr).unwrap(),
+    )
+}
+
+pub fn remove(path: impl AsRef<Path>) {
+    fs::remove_file(path).unwrap();
+}

--- a/tooling/arnes/tests/support/mod.rs
+++ b/tooling/arnes/tests/support/mod.rs
@@ -77,6 +77,12 @@ impl Fixture {
     }
 }
 
+impl Default for Fixture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn write(path: &Path, contents: &str) {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(path, contents).unwrap();


### PR DESCRIPTION
## Description

- add read-only instruction diagnostics for declared Claude and Codex projections
- resolve includes from effective locations, detect missing files and cycles, and reject path escapes
- validate exact symlink destinations, generated Codex AGENTS.md content, repository AGENTS.md precedence, filters, and unsupported Cursor/Codex native projections
- keep doctor without a resource unchanged for #123

Closes #117
Refs #111
Refs #61

## How to Test

- cargo fmt --manifest-path tooling/arnes/Cargo.toml --check
- cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features
- make -n arnes

Validated locally on macOS Darwin arm64 with Rust 1.97.1; Ubuntu is covered by CI.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)