### PR TITLE
feat(arnes): diagnose installed skills

### DIFF
--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -37,3 +37,69 @@ resources:
     scope: user
     source: { root: repository, path: harness/AGENTS.md }
     destination: { root: home, path: .codex/AGENTS.md }
+  - id: claude-user-skill-handoff
+    kind: skills
+    agent: claude
+    scope: user
+    source: { root: repository, path: .agents/skills/handoff }
+    destination: { root: home, path: .claude/skills/handoff }
+  - id: claude-user-skill-enforcement-code
+    kind: skills
+    agent: claude
+    scope: user
+    source: { root: repository, path: .agents/skills/enforcement-code }
+    destination: { root: home, path: .claude/skills/enforcement-code }
+  - id: claude-user-skill-merge-verdict
+    kind: skills
+    agent: claude
+    scope: user
+    source: { root: repository, path: .agents/skills/merge-verdict }
+    destination: { root: home, path: .claude/skills/merge-verdict }
+  - id: cursor-user-skill-enforcement-code
+    kind: skills
+    agent: cursor
+    scope: user
+    source: { root: repository, path: .agents/skills/enforcement-code }
+    destination: { root: home, path: .cursor/skills/enforcement-code }
+  - id: cursor-user-skill-merge-verdict
+    kind: skills
+    agent: cursor
+    scope: user
+    source: { root: repository, path: .agents/skills/merge-verdict }
+    destination: { root: home, path: .cursor/skills/merge-verdict }
+  - id: codex-user-skill-handoff
+    kind: skills
+    agent: codex
+    scope: user
+    source: { root: repository, path: .agents/skills/handoff }
+    destination: { root: home, path: .agents/skills/handoff }
+  - id: codex-user-skill-enforcement-code
+    kind: skills
+    agent: codex
+    scope: user
+    source: { root: repository, path: .agents/skills/enforcement-code }
+    destination: { root: home, path: .agents/skills/enforcement-code }
+  - id: codex-user-skill-merge-verdict
+    kind: skills
+    agent: codex
+    scope: user
+    source: { root: repository, path: .agents/skills/merge-verdict }
+    destination: { root: home, path: .agents/skills/merge-verdict }
+  - id: claude-project-skills
+    kind: skills
+    agent: claude
+    scope: project
+    source: { root: repository, path: .agents/skills }
+    destination: { root: repository, path: .claude/skills }
+  - id: cursor-project-skills
+    kind: skills
+    agent: cursor
+    scope: project
+    source: { root: repository, path: .agents/skills }
+    destination: { root: repository, path: .cursor/skills }
+  - id: codex-project-skills
+    kind: skills
+    agent: codex
+    scope: project
+    source: { root: repository, path: .agents/skills }
+    destination: { root: repository, path: .codex/skills }

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -6,6 +6,21 @@ agents:
     scopes: [user, project]
   - id: codex
     scopes: [user, project]
+skills:
+  - slug: handoff
+    installations:
+      - { agent: claude, scope: user }
+      - { agent: codex, scope: user }
+  - slug: enforcement-code
+    installations:
+      - { agent: claude, scope: user }
+      - { agent: cursor, scope: user }
+      - { agent: codex, scope: user }
+  - slug: merge-verdict
+    installations:
+      - { agent: claude, scope: user }
+      - { agent: cursor, scope: user }
+      - { agent: codex, scope: user }
 resources:
   - id: claude-user-instructions
     kind: instructions
@@ -37,69 +52,45 @@ resources:
     scope: user
     source: { root: repository, path: harness/AGENTS.md }
     destination: { root: home, path: .codex/AGENTS.md }
-  - id: claude-user-skill-handoff
+  - id: claude-user-skills
     kind: skills
     agent: claude
     scope: user
-    source: { root: repository, path: .agents/skills/handoff }
-    destination: { root: home, path: .claude/skills/handoff }
-  - id: claude-user-skill-enforcement-code
-    kind: skills
-    agent: claude
-    scope: user
-    source: { root: repository, path: .agents/skills/enforcement-code }
-    destination: { root: home, path: .claude/skills/enforcement-code }
-  - id: claude-user-skill-merge-verdict
-    kind: skills
-    agent: claude
-    scope: user
-    source: { root: repository, path: .agents/skills/merge-verdict }
-    destination: { root: home, path: .claude/skills/merge-verdict }
-  - id: cursor-user-skill-enforcement-code
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/skills }
+  - id: cursor-user-skills
     kind: skills
     agent: cursor
     scope: user
-    source: { root: repository, path: .agents/skills/enforcement-code }
-    destination: { root: home, path: .cursor/skills/enforcement-code }
-  - id: cursor-user-skill-merge-verdict
-    kind: skills
-    agent: cursor
-    scope: user
-    source: { root: repository, path: .agents/skills/merge-verdict }
-    destination: { root: home, path: .cursor/skills/merge-verdict }
-  - id: codex-user-skill-handoff
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .cursor/skills }
+  - id: codex-user-skills
     kind: skills
     agent: codex
     scope: user
-    source: { root: repository, path: .agents/skills/handoff }
-    destination: { root: home, path: .agents/skills/handoff }
-  - id: codex-user-skill-enforcement-code
-    kind: skills
-    agent: codex
-    scope: user
-    source: { root: repository, path: .agents/skills/enforcement-code }
-    destination: { root: home, path: .agents/skills/enforcement-code }
-  - id: codex-user-skill-merge-verdict
-    kind: skills
-    agent: codex
-    scope: user
-    source: { root: repository, path: .agents/skills/merge-verdict }
-    destination: { root: home, path: .agents/skills/merge-verdict }
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .agents/skills }
   - id: claude-project-skills
     kind: skills
     agent: claude
     scope: project
+    layout: root
     source: { root: repository, path: .agents/skills }
     destination: { root: repository, path: .claude/skills }
   - id: cursor-project-skills
     kind: skills
     agent: cursor
     scope: project
+    layout: root
     source: { root: repository, path: .agents/skills }
     destination: { root: repository, path: .cursor/skills }
   - id: codex-project-skills
     kind: skills
     agent: codex
     scope: project
+    layout: root
     source: { root: repository, path: .agents/skills }
     destination: { root: repository, path: .codex/skills }

--- a/tooling/arnes/src/lib.rs
+++ b/tooling/arnes/src/lib.rs
@@ -3,5 +3,6 @@ pub mod diagnostic;
 pub mod instructions;
 pub mod manifest;
 pub mod roots;
+pub mod skills;
 
 pub use roots::Roots;

--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -7,6 +7,7 @@ use arnes::config;
 use arnes::diagnostic::{Diagnostic, Report, State};
 use arnes::instructions;
 use arnes::manifest::{self, Agent, Scope};
+use arnes::skills;
 
 #[derive(Parser)]
 #[command(version, about = "Diagnose agent harness resources")]
@@ -77,6 +78,10 @@ fn main() -> ExitCode {
                 error.to_string(),
             )],
         },
+        Some(Resource::Skills) => match Roots::from_environment() {
+            Ok(roots) => diagnose_skills(&roots, agent, scope),
+            Err(error) => vec![Diagnostic::new("skills", State::Error, error.to_string())],
+        },
         _ => Vec::new(),
     };
     let report = Report::new(diagnostics);
@@ -136,5 +141,12 @@ fn diagnose_instructions(
             State::Error,
             error.to_string(),
         )],
+    }
+}
+
+fn diagnose_skills(roots: &Roots, agent: Option<Agent>, scope: Option<Scope>) -> Vec<Diagnostic> {
+    match manifest::load(roots.home()) {
+        Ok(manifest) => skills::diagnose(roots, &manifest, agent, scope),
+        Err(error) => vec![Diagnostic::new("skills", State::Error, error.to_string())],
     }
 }

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -39,6 +39,8 @@ pub struct Manifest {
     #[serde(rename = "version")]
     _version: u64,
     agents: Vec<AgentDeclaration>,
+    #[serde(default)]
+    skills: Vec<SkillDeclaration>,
     resources: Vec<ResourceDeclaration>,
 }
 
@@ -62,17 +64,29 @@ impl Manifest {
             })
     }
 
-    pub fn skill_resources(&self) -> impl Iterator<Item = SkillResource<'_>> {
+    pub fn skill_projections(&self) -> impl Iterator<Item = SkillProjection<'_>> {
         self.resources
             .iter()
             .filter(|resource| resource.kind == ResourceKind::Skills)
-            .map(|resource| SkillResource {
+            .map(|resource| SkillProjection {
                 id: &resource.id,
                 agent: resource.agent,
                 scope: resource.scope,
+                layout: resource.layout.expect("skill projections have a layout"),
                 source: &resource.source.path,
                 destination: &resource.destination.path,
             })
+    }
+
+    pub fn installed_skills(&self, agent: Agent, scope: Scope) -> impl Iterator<Item = &str> {
+        self.skills
+            .iter()
+            .filter(move |skill| {
+                skill
+                    .installations
+                    .contains(&SkillInstallation { agent, scope })
+            })
+            .map(|skill| skill.slug.as_str())
     }
 }
 
@@ -86,12 +100,27 @@ pub struct InstructionResource<'a> {
 }
 
 #[derive(Clone, Copy)]
-pub struct SkillResource<'a> {
+pub struct SkillProjection<'a> {
     pub id: &'a str,
     pub agent: Agent,
     pub scope: Scope,
+    pub layout: SkillLayout,
     pub source: &'a Path,
     pub destination: &'a Path,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SkillDeclaration {
+    slug: String,
+    installations: Vec<SkillInstallation>,
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SkillInstallation {
+    agent: Agent,
+    scope: Scope,
 }
 
 #[derive(Deserialize)]
@@ -108,8 +137,16 @@ struct ResourceDeclaration {
     kind: ResourceKind,
     agent: Agent,
     scope: Scope,
+    layout: Option<SkillLayout>,
     source: RootedPath,
     destination: RootedPath,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillLayout {
+    Leaves,
+    Root,
 }
 
 #[derive(Clone, Eq, Hash, PartialEq, Deserialize)]

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -61,10 +61,32 @@ impl Manifest {
                 destination: &resource.destination.path,
             })
     }
+
+    pub fn skill_resources(&self) -> impl Iterator<Item = SkillResource<'_>> {
+        self.resources
+            .iter()
+            .filter(|resource| resource.kind == ResourceKind::Skills)
+            .map(|resource| SkillResource {
+                id: &resource.id,
+                agent: resource.agent,
+                scope: resource.scope,
+                source: &resource.source.path,
+                destination: &resource.destination.path,
+            })
+    }
 }
 
 #[derive(Clone, Copy)]
 pub struct InstructionResource<'a> {
+    pub id: &'a str,
+    pub agent: Agent,
+    pub scope: Scope,
+    pub source: &'a Path,
+    pub destination: &'a Path,
+}
+
+#[derive(Clone, Copy)]
+pub struct SkillResource<'a> {
     pub id: &'a str,
     pub agent: Agent,
     pub scope: Scope,

--- a/tooling/arnes/src/manifest/validation.rs
+++ b/tooling/arnes/src/manifest/validation.rs
@@ -3,6 +3,8 @@ use serde_yaml_ng::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path};
 
+mod skills;
+
 pub(super) fn validate_value(value: &Value) -> Result<(), ManifestError> {
     let mapping = value
         .as_mapping()
@@ -72,7 +74,8 @@ pub(super) fn validate(manifest: &Manifest) -> Result<(), ManifestError> {
         agents.insert(agent.id, scopes);
     }
 
-    validate_resources(&manifest.resources, &agents)
+    validate_resources(&manifest.resources, &agents)?;
+    skills::validate(&manifest.skills, &manifest.resources, &agents)
 }
 
 fn validate_resources(
@@ -81,6 +84,7 @@ fn validate_resources(
 ) -> Result<(), ManifestError> {
     let mut identifiers = HashMap::new();
     let mut destinations = HashMap::new();
+    let mut skill_projections = HashMap::new();
 
     for (index, resource) in resources.iter().enumerate() {
         let field = |name: &str| format!("resources[{index}].{name}");
@@ -106,6 +110,16 @@ fn validate_resources(
             ));
         }
         validate_resource_paths(resource, index)?;
+        validate_resource_layout(resource, index)?;
+        if resource.kind == super::ResourceKind::Skills
+            && let Some(previous) =
+                skill_projections.insert((resource.agent, resource.scope), index)
+        {
+            return Err(ManifestError::new(
+                field("agent"),
+                format!("duplicates resources[{previous}] skill projection"),
+            ));
+        }
         if let Some(previous) = destinations.insert(&resource.destination, index) {
             return Err(ManifestError::new(
                 field("destination"),
@@ -114,6 +128,23 @@ fn validate_resources(
         }
     }
     Ok(())
+}
+
+fn validate_resource_layout(
+    resource: &ResourceDeclaration,
+    index: usize,
+) -> Result<(), ManifestError> {
+    match (resource.kind, resource.layout) {
+        (super::ResourceKind::Skills, None) => Err(ManifestError::new(
+            format!("resources[{index}].layout"),
+            "skill projection layout is required",
+        )),
+        (super::ResourceKind::Skills, Some(_)) | (_, None) => Ok(()),
+        (_, Some(_)) => Err(ManifestError::new(
+            format!("resources[{index}].layout"),
+            "layout is only valid for skill projections",
+        )),
+    }
 }
 
 fn validate_resource_paths(

--- a/tooling/arnes/src/manifest/validation/skills.rs
+++ b/tooling/arnes/src/manifest/validation/skills.rs
@@ -1,0 +1,87 @@
+use super::super::{
+    Agent, ManifestError, ResourceDeclaration, ResourceKind, Scope, SkillDeclaration,
+    SkillInstallation, SkillLayout,
+};
+use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path};
+
+pub fn validate(
+    skills: &[SkillDeclaration],
+    resources: &[ResourceDeclaration],
+    agents: &HashMap<Agent, HashSet<Scope>>,
+) -> Result<(), ManifestError> {
+    let mut identifiers = HashSet::new();
+    for (skill_index, skill) in skills.iter().enumerate() {
+        let field = |name: &str| format!("skills[{skill_index}].{name}");
+        validate_slug(&field("slug"), &skill.slug)?;
+        if skill.installations.is_empty() {
+            return Err(ManifestError::new(
+                field("installations"),
+                "at least one leaf installation is required",
+            ));
+        }
+        if !identifiers.insert(&skill.slug) {
+            return Err(ManifestError::new(
+                field("slug"),
+                "duplicate skill identifier",
+            ));
+        }
+        let mut installations = HashSet::new();
+        for (index, installation) in skill.installations.iter().copied().enumerate() {
+            let field = format!("skills[{skill_index}].installations[{index}]");
+            validate_installation(&field, installation, agents, resources)?;
+            if !installations.insert(installation) {
+                return Err(ManifestError::new(field, "duplicate skill installation"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_installation(
+    field: &str,
+    installation: SkillInstallation,
+    agents: &HashMap<Agent, HashSet<Scope>>,
+    resources: &[ResourceDeclaration],
+) -> Result<(), ManifestError> {
+    let Some(scopes) = agents.get(&installation.agent) else {
+        return Err(ManifestError::new(
+            format!("{field}.agent"),
+            "agent is not declared",
+        ));
+    };
+    if !scopes.contains(&installation.scope) {
+        return Err(ManifestError::new(
+            format!("{field}.scope"),
+            "scope is not declared for this agent",
+        ));
+    }
+    let projected = resources.iter().any(|resource| {
+        resource.kind == ResourceKind::Skills
+            && resource.agent == installation.agent
+            && resource.scope == installation.scope
+            && resource.layout == Some(SkillLayout::Leaves)
+    });
+    if projected {
+        Ok(())
+    } else {
+        Err(ManifestError::new(field, "has no leaves skill projection"))
+    }
+}
+
+fn validate_slug(field: &str, slug: &str) -> Result<(), ManifestError> {
+    let path = Path::new(slug);
+    let mut components = path.components();
+    let valid = match (components.next(), components.next()) {
+        (Some(Component::Normal(component)), None) => path.as_os_str() == component,
+        _ => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(ManifestError::new(
+            field,
+            "must be one relative path component",
+        ))
+    }
+}

--- a/tooling/arnes/src/skills.rs
+++ b/tooling/arnes/src/skills.rs
@@ -1,0 +1,157 @@
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Manifest, Scope, SkillResource};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+mod discovery;
+mod paths;
+mod projection;
+mod references;
+
+struct Specification {
+    root: &'static str,
+    layout: Layout,
+}
+
+#[derive(Clone, Copy)]
+enum Layout {
+    Leaves,
+    Root,
+}
+
+pub fn diagnose(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    let combinations = manifest
+        .combinations()
+        .filter(|(candidate, _)| agent.is_none_or(|agent| agent == *candidate))
+        .filter(|(_, candidate)| scope.is_none_or(|scope| scope == *candidate))
+        .collect::<Vec<_>>();
+    if combinations.is_empty() {
+        return vec![unsupported(agent, scope)];
+    }
+    combinations
+        .into_iter()
+        .flat_map(|(agent, scope)| diagnose_one(roots, manifest, agent, scope))
+        .collect()
+}
+
+fn diagnose_one(roots: &Roots, manifest: &Manifest, agent: Agent, scope: Scope) -> Vec<Diagnostic> {
+    let specification = specification(agent, scope);
+    let resources = manifest
+        .skill_resources()
+        .filter(|resource| resource.agent == agent && resource.scope == scope)
+        .collect::<Vec<_>>();
+    if resources.is_empty() {
+        return vec![unsupported(Some(agent), Some(scope))];
+    }
+    let (supported, unsupported_resources): (Vec<_>, Vec<_>) = resources
+        .into_iter()
+        .partition(|resource| declaration_supported(resource, &specification));
+    let mut diagnostics = unsupported_resources
+        .into_iter()
+        .map(|resource| unsupported_resource(&resource))
+        .collect::<Vec<_>>();
+    match specification.layout {
+        Layout::Leaves => diagnostics.extend(diagnose_leaves(
+            roots,
+            agent,
+            scope,
+            &specification,
+            supported,
+        )),
+        Layout::Root => diagnostics.extend(
+            supported
+                .iter()
+                .flat_map(|resource| projection::root(roots, resource)),
+        ),
+    }
+    diagnostics
+}
+
+fn diagnose_leaves(
+    roots: &Roots,
+    agent: Agent,
+    scope: Scope,
+    specification: &Specification,
+    resources: Vec<SkillResource<'_>>,
+) -> Vec<Diagnostic> {
+    let declared = resources
+        .iter()
+        .map(|resource| resource.destination.to_owned())
+        .collect::<HashSet<PathBuf>>();
+    let mut diagnostics = resources
+        .iter()
+        .map(|resource| projection::leaf(roots, resource))
+        .collect::<Vec<_>>();
+    diagnostics.extend(discovery::unmanaged(
+        roots,
+        agent,
+        scope,
+        Path::new(specification.root),
+        &declared,
+    ));
+    diagnostics
+}
+
+fn declaration_supported(resource: &SkillResource<'_>, specification: &Specification) -> bool {
+    let source_root = Path::new(".agents/skills");
+    let destination_root = Path::new(specification.root);
+    match specification.layout {
+        Layout::Root => resource.source == source_root && resource.destination == destination_root,
+        Layout::Leaves => {
+            resource.source.parent() == Some(source_root)
+                && resource.destination.parent() == Some(destination_root)
+                && resource.source.file_name() == resource.destination.file_name()
+        }
+    }
+}
+
+fn specification(agent: Agent, scope: Scope) -> Specification {
+    let root = match (agent, scope) {
+        (Agent::Claude, Scope::User) => ".claude/skills",
+        (Agent::Cursor, Scope::User) => ".cursor/skills",
+        (Agent::Codex, Scope::User) => ".agents/skills",
+        (Agent::Claude, Scope::Project) => ".claude/skills",
+        (Agent::Cursor, Scope::Project) => ".cursor/skills",
+        (Agent::Codex, Scope::Project) => ".codex/skills",
+    };
+    let layout = match scope {
+        Scope::User => Layout::Leaves,
+        Scope::Project => Layout::Root,
+    };
+    Specification { root, layout }
+}
+
+fn unsupported(agent: Option<Agent>, scope: Option<Scope>) -> Diagnostic {
+    let subject = match (agent, scope) {
+        (Some(agent), Some(scope)) => format!("{agent} {scope} skill projection"),
+        (Some(agent), None) => format!("{agent} skill projections"),
+        (None, Some(scope)) => format!("{scope} skill scope"),
+        (None, None) => "skill projections".to_owned(),
+    };
+    Diagnostic::new(
+        "skills",
+        State::Unsupported,
+        format!("{subject} is not declared or supported"),
+    )
+}
+
+fn unsupported_resource(resource: &SkillResource<'_>) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        State::Unsupported,
+        format!(
+            "{} {} skill projection {} from {} to {} is unsupported",
+            resource.agent,
+            resource.scope,
+            resource.id,
+            resource.source.display(),
+            resource.destination.display()
+        ),
+    )
+}

--- a/tooling/arnes/src/skills.rs
+++ b/tooling/arnes/src/skills.rs
@@ -1,6 +1,6 @@
 use crate::Roots;
 use crate::diagnostic::{Diagnostic, State};
-use crate::manifest::{Agent, Manifest, Scope, SkillResource};
+use crate::manifest::{Agent, Manifest, Scope, SkillLayout, SkillProjection};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -8,17 +8,6 @@ mod discovery;
 mod paths;
 mod projection;
 mod references;
-
-struct Specification {
-    root: &'static str,
-    layout: Layout,
-}
-
-#[derive(Clone, Copy)]
-enum Layout {
-    Leaves,
-    Root,
-}
 
 pub fn diagnose(
     roots: &Roots,
@@ -41,90 +30,56 @@ pub fn diagnose(
 }
 
 fn diagnose_one(roots: &Roots, manifest: &Manifest, agent: Agent, scope: Scope) -> Vec<Diagnostic> {
-    let specification = specification(agent, scope);
     let resources = manifest
-        .skill_resources()
+        .skill_projections()
         .filter(|resource| resource.agent == agent && resource.scope == scope)
         .collect::<Vec<_>>();
     if resources.is_empty() {
         return vec![unsupported(Some(agent), Some(scope))];
     }
-    let (supported, unsupported_resources): (Vec<_>, Vec<_>) = resources
-        .into_iter()
-        .partition(|resource| declaration_supported(resource, &specification));
+    let (supported, unsupported_resources): (Vec<_>, Vec<_>) =
+        resources.into_iter().partition(declaration_supported);
     let mut diagnostics = unsupported_resources
         .into_iter()
         .map(|resource| unsupported_resource(&resource))
         .collect::<Vec<_>>();
-    match specification.layout {
-        Layout::Leaves => diagnostics.extend(diagnose_leaves(
-            roots,
-            agent,
-            scope,
-            &specification,
-            supported,
-        )),
-        Layout::Root => diagnostics.extend(
-            supported
-                .iter()
-                .flat_map(|resource| projection::root(roots, resource)),
-        ),
+    for resource in supported {
+        match resource.layout {
+            SkillLayout::Leaves => diagnostics.extend(diagnose_leaves(roots, manifest, &resource)),
+            SkillLayout::Root => diagnostics.extend(projection::root(roots, &resource)),
+        }
     }
     diagnostics
 }
 
 fn diagnose_leaves(
     roots: &Roots,
-    agent: Agent,
-    scope: Scope,
-    specification: &Specification,
-    resources: Vec<SkillResource<'_>>,
+    manifest: &Manifest,
+    resource: &SkillProjection<'_>,
 ) -> Vec<Diagnostic> {
-    let declared = resources
+    let skills = manifest
+        .installed_skills(resource.agent, resource.scope)
+        .collect::<Vec<_>>();
+    let declared = skills
         .iter()
-        .map(|resource| resource.destination.to_owned())
+        .map(|skill| resource.destination.join(*skill))
         .collect::<HashSet<PathBuf>>();
-    let mut diagnostics = resources
+    let mut diagnostics = skills
         .iter()
-        .map(|resource| projection::leaf(roots, resource))
+        .map(|skill| projection::leaf(roots, resource, skill))
         .collect::<Vec<_>>();
     diagnostics.extend(discovery::unmanaged(
         roots,
-        agent,
-        scope,
-        Path::new(specification.root),
+        resource.agent,
+        resource.scope,
+        resource.destination,
         &declared,
     ));
     diagnostics
 }
 
-fn declaration_supported(resource: &SkillResource<'_>, specification: &Specification) -> bool {
-    let source_root = Path::new(".agents/skills");
-    let destination_root = Path::new(specification.root);
-    match specification.layout {
-        Layout::Root => resource.source == source_root && resource.destination == destination_root,
-        Layout::Leaves => {
-            resource.source.parent() == Some(source_root)
-                && resource.destination.parent() == Some(destination_root)
-                && resource.source.file_name() == resource.destination.file_name()
-        }
-    }
-}
-
-fn specification(agent: Agent, scope: Scope) -> Specification {
-    let root = match (agent, scope) {
-        (Agent::Claude, Scope::User) => ".claude/skills",
-        (Agent::Cursor, Scope::User) => ".cursor/skills",
-        (Agent::Codex, Scope::User) => ".agents/skills",
-        (Agent::Claude, Scope::Project) => ".claude/skills",
-        (Agent::Cursor, Scope::Project) => ".cursor/skills",
-        (Agent::Codex, Scope::Project) => ".codex/skills",
-    };
-    let layout = match scope {
-        Scope::User => Layout::Leaves,
-        Scope::Project => Layout::Root,
-    };
-    Specification { root, layout }
+fn declaration_supported(resource: &SkillProjection<'_>) -> bool {
+    resource.source == Path::new(".agents/skills")
 }
 
 fn unsupported(agent: Option<Agent>, scope: Option<Scope>) -> Diagnostic {
@@ -141,7 +96,7 @@ fn unsupported(agent: Option<Agent>, scope: Option<Scope>) -> Diagnostic {
     )
 }
 
-fn unsupported_resource(resource: &SkillResource<'_>) -> Diagnostic {
+fn unsupported_resource(resource: &SkillProjection<'_>) -> Diagnostic {
     Diagnostic::new(
         "skills",
         State::Unsupported,

--- a/tooling/arnes/src/skills/discovery.rs
+++ b/tooling/arnes/src/skills/discovery.rs
@@ -1,0 +1,94 @@
+use super::paths::{canonical_within, label};
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Scope};
+use std::collections::HashSet;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+pub fn unmanaged(
+    roots: &Roots,
+    agent: Agent,
+    scope: Scope,
+    root: &Path,
+    declared: &HashSet<PathBuf>,
+) -> Vec<Diagnostic> {
+    let base = match scope {
+        Scope::User => roots.home(),
+        Scope::Project => roots.repository(),
+    };
+    let directory = base.join(root);
+    if fs::symlink_metadata(&directory).is_ok() && canonical_within(&directory, base).is_none() {
+        return vec![root_error(agent, scope, root, &directory)];
+    }
+    let names = match installations(&directory) {
+        Ok(names) => names,
+        Err(_) if missing(&directory) => return Vec::new(),
+        Err(reason) => return vec![read_error(agent, scope, root, reason)],
+    };
+    names
+        .into_iter()
+        .filter(|name| !declared.contains(&root.join(name)))
+        .map(|name| classify(&directory, agent, scope, root, &name))
+        .collect()
+}
+
+pub fn installations(directory: &Path) -> Result<Vec<PathBuf>, String> {
+    let unreadable = || format!("directory {} could not be read", directory.display());
+    let mut names = Vec::new();
+    for entry in fs::read_dir(directory).map_err(|_| unreadable())? {
+        let entry = entry.map_err(|_| unreadable())?;
+        let kind = entry.file_type().map_err(|_| unreadable())?;
+        if kind.is_dir() || kind.is_symlink() {
+            names.push(PathBuf::from(entry.file_name()));
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+fn classify(directory: &Path, agent: Agent, scope: Scope, root: &Path, name: &Path) -> Diagnostic {
+    let path = directory.join(name);
+    let broken = fs::symlink_metadata(&path)
+        .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        && !fs::metadata(&path).is_ok_and(|metadata| metadata.is_dir());
+    let classification = if broken { "broken" } else { "unmanaged" };
+    Diagnostic::new(
+        "skills",
+        State::Unsupported,
+        format!(
+            "{classification} {agent} {scope} skill {} at {}/{} is unmanaged and not Arnes-owned",
+            name.display(),
+            label(scope, root),
+            name.display()
+        ),
+    )
+}
+
+fn missing(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_err_and(|error| error.kind() == ErrorKind::NotFound)
+}
+
+fn root_error(agent: Agent, scope: Scope, root: &Path, directory: &Path) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        State::Error,
+        format!(
+            "broken {agent} {scope} skills root {}: directory {} escapes its scope root",
+            label(scope, root),
+            directory.display()
+        ),
+    )
+}
+
+fn read_error(agent: Agent, scope: Scope, root: &Path, reason: String) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        State::Error,
+        format!(
+            "broken {agent} {scope} skills root {}: {reason}",
+            label(scope, root)
+        ),
+    )
+}

--- a/tooling/arnes/src/skills/paths.rs
+++ b/tooling/arnes/src/skills/paths.rs
@@ -1,0 +1,36 @@
+use crate::Roots;
+use crate::manifest::Scope;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+pub fn canonical_within(path: &Path, root: &Path) -> Option<PathBuf> {
+    let root = fs::canonicalize(root).ok()?;
+    let path = fs::canonicalize(path).ok()?;
+    path.starts_with(&root).then_some(path)
+}
+
+pub fn ancestor_within(path: &Path, root: &Path) -> bool {
+    let mut ancestor = path;
+    while fs::symlink_metadata(ancestor).is_err_and(|error| error.kind() == ErrorKind::NotFound) {
+        let Some(parent) = ancestor.parent() else {
+            return false;
+        };
+        ancestor = parent;
+    }
+    canonical_within(ancestor, root).is_some()
+}
+
+pub fn destination(roots: &Roots, scope: Scope, path: &Path) -> PathBuf {
+    match scope {
+        Scope::User => roots.home().join(path),
+        Scope::Project => roots.repository().join(path),
+    }
+}
+
+pub fn label(scope: Scope, path: &Path) -> String {
+    match scope {
+        Scope::User => format!("~/{}", path.display()),
+        Scope::Project => path.display().to_string(),
+    }
+}

--- a/tooling/arnes/src/skills/projection.rs
+++ b/tooling/arnes/src/skills/projection.rs
@@ -2,21 +2,21 @@ use super::paths::{ancestor_within, canonical_within, destination, label};
 use super::references;
 use crate::Roots;
 use crate::diagnostic::{Diagnostic, State};
-use crate::manifest::{Scope, SkillResource};
+use crate::manifest::{Scope, SkillProjection};
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
-pub fn leaf(roots: &Roots, resource: &SkillResource<'_>) -> Diagnostic {
-    let name = resource.destination.file_name().unwrap().to_string_lossy();
+pub fn leaf(roots: &Roots, resource: &SkillProjection<'_>, name: &str) -> Diagnostic {
+    let installed = resource.destination.join(name);
     let subject = format!(
         "managed {} {} skill {name} at {}",
         resource.agent,
         resource.scope,
-        label(resource.scope, resource.destination)
+        label(resource.scope, &installed)
     );
-    let source = roots.repository().join(resource.source);
-    let destination = destination(roots, resource.scope, resource.destination);
+    let source = roots.repository().join(resource.source).join(name);
+    let destination = destination(roots, resource.scope, &installed);
     match expected_link(roots, resource.scope, &source, &destination, &subject)
         .and_then(|_| references::validate(&destination, &subject))
     {
@@ -25,7 +25,7 @@ pub fn leaf(roots: &Roots, resource: &SkillResource<'_>) -> Diagnostic {
     }
 }
 
-pub fn root(roots: &Roots, resource: &SkillResource<'_>) -> Vec<Diagnostic> {
+pub fn root(roots: &Roots, resource: &SkillProjection<'_>) -> Vec<Diagnostic> {
     let source = roots.repository().join(resource.source);
     let destination = destination(roots, resource.scope, resource.destination);
     let subject = format!(
@@ -49,7 +49,7 @@ pub fn root(roots: &Roots, resource: &SkillResource<'_>) -> Vec<Diagnostic> {
 
 fn root_skill(
     roots: &Roots,
-    resource: &SkillResource<'_>,
+    resource: &SkillProjection<'_>,
     source: &Path,
     destination: &Path,
     name: &Path,

--- a/tooling/arnes/src/skills/projection.rs
+++ b/tooling/arnes/src/skills/projection.rs
@@ -1,0 +1,168 @@
+use super::paths::{ancestor_within, canonical_within, destination, label};
+use super::references;
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Scope, SkillResource};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+pub fn leaf(roots: &Roots, resource: &SkillResource<'_>) -> Diagnostic {
+    let name = resource.destination.file_name().unwrap().to_string_lossy();
+    let subject = format!(
+        "managed {} {} skill {name} at {}",
+        resource.agent,
+        resource.scope,
+        label(resource.scope, resource.destination)
+    );
+    let source = roots.repository().join(resource.source);
+    let destination = destination(roots, resource.scope, resource.destination);
+    match expected_link(roots, resource.scope, &source, &destination, &subject)
+        .and_then(|_| references::validate(&destination, &subject))
+    {
+        Ok(()) => Diagnostic::new("skills", State::Healthy, format!("{subject} is current")),
+        Err(diagnostic) => diagnostic,
+    }
+}
+
+pub fn root(roots: &Roots, resource: &SkillResource<'_>) -> Vec<Diagnostic> {
+    let source = roots.repository().join(resource.source);
+    let destination = destination(roots, resource.scope, resource.destination);
+    let subject = format!(
+        "managed {} {} skills projection at {}",
+        resource.agent,
+        resource.scope,
+        label(resource.scope, resource.destination)
+    );
+    if let Err(diagnostic) = expected_link(roots, resource.scope, &source, &destination, &subject) {
+        return vec![diagnostic];
+    }
+    let entries = match super::discovery::installations(&source) {
+        Ok(entries) => entries,
+        Err(reason) => return vec![broken(&subject, State::Error, reason)],
+    };
+    entries
+        .into_iter()
+        .map(|name| root_skill(roots, resource, &source, &destination, &name))
+        .collect()
+}
+
+fn root_skill(
+    roots: &Roots,
+    resource: &SkillResource<'_>,
+    source: &Path,
+    destination: &Path,
+    name: &Path,
+) -> Diagnostic {
+    let source = source.join(name);
+    let installed = destination.join(name);
+    let subject = format!(
+        "managed {} {} skill {} at {}/{}",
+        resource.agent,
+        resource.scope,
+        name.display(),
+        label(resource.scope, resource.destination),
+        name.display()
+    );
+    let result = source_directory(&source, roots.repository(), &subject)
+        .and_then(|expected| same_target(&installed, &expected, &subject))
+        .and_then(|_| references::validate(&installed, &subject));
+    match result {
+        Ok(()) => Diagnostic::new("skills", State::Healthy, format!("{subject} is current")),
+        Err(diagnostic) => diagnostic,
+    }
+}
+
+fn expected_link(
+    roots: &Roots,
+    scope: Scope,
+    source: &Path,
+    destination: &Path,
+    subject: &str,
+) -> Result<(), Diagnostic> {
+    let expected = source_directory(source, roots.repository(), subject)?;
+    let boundary = match scope {
+        Scope::User => roots.home(),
+        Scope::Project => roots.repository(),
+    };
+    if !ancestor_within(destination.parent().unwrap_or(boundary), boundary) {
+        return Err(broken(
+            subject,
+            State::Error,
+            format!(
+                "destination {} escapes its scope root",
+                destination.display()
+            ),
+        ));
+    }
+    let metadata = fs::symlink_metadata(destination).map_err(|error| match error.kind() {
+        ErrorKind::NotFound => broken(
+            subject,
+            State::Drift,
+            format!("destination {} is missing", destination.display()),
+        ),
+        _ => broken(
+            subject,
+            State::Error,
+            format!("destination {} could not be read", destination.display()),
+        ),
+    })?;
+    if !metadata.file_type().is_symlink() {
+        return Err(broken(
+            subject,
+            State::Drift,
+            format!("destination {} is not a symlink", destination.display()),
+        ));
+    }
+    same_target(destination, &expected, subject)
+}
+
+fn source_directory(source: &Path, root: &Path, subject: &str) -> Result<PathBuf, Diagnostic> {
+    let metadata = fs::metadata(source).map_err(|error| {
+        let reason = if error.kind() == ErrorKind::NotFound {
+            "is missing"
+        } else {
+            "could not be read"
+        };
+        broken(
+            subject,
+            State::Error,
+            format!("source {} {reason}", source.display()),
+        )
+    })?;
+    if !metadata.is_dir() {
+        return Err(broken(
+            subject,
+            State::Error,
+            format!("source {} is not a directory", source.display()),
+        ));
+    }
+    canonical_within(source, root).ok_or_else(|| {
+        broken(
+            subject,
+            State::Error,
+            format!(
+                "source {} resolves outside the repository",
+                source.display()
+            ),
+        )
+    })
+}
+
+fn same_target(path: &Path, expected: &Path, subject: &str) -> Result<(), Diagnostic> {
+    match fs::canonicalize(path) {
+        Ok(actual) if actual == expected => Ok(()),
+        _ => Err(broken(
+            subject,
+            State::Drift,
+            format!(
+                "destination {} has the wrong symlink target",
+                path.display()
+            ),
+        )),
+    }
+}
+
+fn broken(subject: &str, state: State, reason: String) -> Diagnostic {
+    Diagnostic::new("skills", state, format!("broken {subject}: {reason}"))
+}

--- a/tooling/arnes/src/skills/references.rs
+++ b/tooling/arnes/src/skills/references.rs
@@ -1,0 +1,110 @@
+use crate::diagnostic::{Diagnostic, State};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+mod parser;
+
+use parser::local_references;
+
+pub fn validate(skill: &Path, subject: &str) -> Result<(), Diagnostic> {
+    let file = skill.join("SKILL.md");
+    let contents = read_skill(skill, &file, subject)?;
+    for reference in local_references(&contents) {
+        validate_reference(skill, &reference, subject)?;
+    }
+    Ok(())
+}
+
+fn read_skill(skill: &Path, file: &Path, subject: &str) -> Result<String, Diagnostic> {
+    let metadata = fs::metadata(file).map_err(|error| {
+        let (state, reason) = if error.kind() == std::io::ErrorKind::NotFound {
+            (State::Drift, "is missing")
+        } else {
+            (State::Error, "could not be read")
+        };
+        broken(subject, state, format!("{} {reason}", file.display()))
+    })?;
+    if !metadata.is_file() {
+        return Err(broken(
+            subject,
+            State::Error,
+            format!("{} is not a file", file.display()),
+        ));
+    }
+    ensure_within(file, skill, subject)?;
+    fs::read_to_string(file).map_err(|_| {
+        broken(
+            subject,
+            State::Error,
+            format!("{} could not be read", file.display()),
+        )
+    })
+}
+
+fn validate_reference(skill: &Path, reference: &Path, subject: &str) -> Result<(), Diagnostic> {
+    let path = resolve(skill, reference).ok_or_else(|| {
+        broken(
+            subject,
+            State::Error,
+            format!("local resource {} escapes its skill", reference.display()),
+        )
+    })?;
+    fs::metadata(&path).map_err(|error| {
+        let (state, reason) = if error.kind() == std::io::ErrorKind::NotFound {
+            (State::Drift, "is missing")
+        } else {
+            (State::Error, "could not be read")
+        };
+        broken(
+            subject,
+            state,
+            format!("local resource {} {reason}", reference.display()),
+        )
+    })?;
+    ensure_within(&path, skill, subject)
+}
+
+fn ensure_within(path: &Path, skill: &Path, subject: &str) -> Result<(), Diagnostic> {
+    let root = fs::canonicalize(skill).map_err(|_| {
+        broken(
+            subject,
+            State::Error,
+            format!("skill {} could not be resolved", skill.display()),
+        )
+    })?;
+    let resolved = fs::canonicalize(path).map_err(|_| {
+        broken(
+            subject,
+            State::Error,
+            format!("{} could not be resolved", path.display()),
+        )
+    })?;
+    if resolved.starts_with(root) {
+        Ok(())
+    } else {
+        Err(broken(
+            subject,
+            State::Error,
+            format!("{} resolves outside its skill", path.display()),
+        ))
+    }
+}
+
+fn resolve(root: &Path, reference: &Path) -> Option<PathBuf> {
+    let mut path = root.to_owned();
+    for component in reference.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => path.push(part),
+            Component::ParentDir if path != root => {
+                path.pop();
+            }
+            _ => return None,
+        }
+    }
+    Some(path)
+}
+
+fn broken(subject: &str, state: State, reason: String) -> Diagnostic {
+    Diagnostic::new("skills", state, format!("broken {subject}: {reason}"))
+}

--- a/tooling/arnes/src/skills/references/parser.rs
+++ b/tooling/arnes/src/skills/references/parser.rs
@@ -1,0 +1,165 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+pub fn local_references(contents: &str) -> BTreeSet<PathBuf> {
+    let visible = without_fenced_code(contents);
+    let mut references = markdown_targets(&visible)
+        .into_iter()
+        .filter_map(markdown_candidate)
+        .collect::<BTreeSet<_>>();
+    references.extend(resource_tokens(&visible).filter_map(token_candidate));
+    references
+}
+
+fn without_fenced_code(contents: &str) -> String {
+    let mut visible = String::new();
+    let mut fence = None;
+    for line in contents.lines() {
+        if let Some(marker) = fence_marker(line) {
+            match fence {
+                None => fence = Some(marker),
+                Some((character, length)) if marker.0 == character && marker.1 >= length => {
+                    fence = None;
+                }
+                Some(_) => {}
+            }
+        } else if fence.is_none() {
+            visible.push_str(line);
+            visible.push('\n');
+        }
+    }
+    visible
+}
+
+fn fence_marker(line: &str) -> Option<(char, usize)> {
+    let mut characters = line.trim_start().chars();
+    let character = characters.next()?;
+    if !matches!(character, '`' | '~') {
+        return None;
+    }
+    let length = 1 + characters
+        .take_while(|candidate| *candidate == character)
+        .count();
+    (length >= 3).then_some((character, length))
+}
+
+fn markdown_targets(contents: &str) -> Vec<String> {
+    let mut targets = Vec::new();
+    let mut search = 0;
+    while let Some(offset) = contents[search..].find("](") {
+        let start = search + offset + 2;
+        let Some((end, target)) = balanced_target(contents, start) else {
+            break;
+        };
+        targets.push(target);
+        search = end + 1;
+    }
+    targets
+}
+
+fn balanced_target(contents: &str, start: usize) -> Option<(usize, String)> {
+    let mut depth = 1;
+    let mut escaped = false;
+    for (offset, character) in contents[start..].char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match character {
+            '\\' => escaped = true,
+            '(' => depth += 1,
+            ')' if depth == 1 => {
+                let end = start + offset;
+                return Some((end, contents[start..end].to_owned()));
+            }
+            ')' => depth -= 1,
+            _ => {}
+        }
+    }
+    None
+}
+
+fn markdown_candidate(value: String) -> Option<PathBuf> {
+    let value = value.trim();
+    let value = if let Some(value) = value.strip_prefix('<') {
+        value.split_once('>')?.0
+    } else {
+        value.split_whitespace().next().unwrap_or(value)
+    };
+    relative_candidate(value).map(PathBuf::from)
+}
+
+fn resource_tokens(contents: &str) -> impl Iterator<Item = &str> {
+    contents
+        .split_whitespace()
+        .filter(|token| !token.contains("]("))
+        .map(trim_token)
+}
+
+fn trim_token(token: &str) -> &str {
+    token
+        .trim_matches(|character: char| {
+            matches!(
+                character,
+                '`' | '\'' | '"' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | ',' | ';'
+            )
+        })
+        .trim_end_matches(['.', ':'])
+}
+
+fn token_candidate(value: &str) -> Option<PathBuf> {
+    let value = relative_candidate(value)?;
+    let explicit = value.starts_with("./") || value.starts_with("../");
+    let resource = ["agents/", "assets/", "evals/", "references/", "scripts/"]
+        .iter()
+        .any(|prefix| value.starts_with(prefix));
+    (explicit || resource).then(|| Path::new(value).to_owned())
+}
+
+fn relative_candidate(value: &str) -> Option<&str> {
+    let value = value
+        .split('#')
+        .next()?
+        .trim_end_matches(|character: char| {
+            matches!(
+                character,
+                '`' | '\'' | '"' | ')' | ']' | '}' | '>' | ',' | ';' | '.' | ':'
+            )
+        });
+    if value.is_empty()
+        || value.starts_with(['/', '~', '#'])
+        || value.contains("://")
+        || value.starts_with("mailto:")
+    {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::local_references;
+    use std::path::PathBuf;
+
+    #[test]
+    fn extracts_relative_links_and_resource_tokens() {
+        let contents = "[root](guide.md) [nested](references/a(b).md) `scripts/run.sh`";
+
+        assert_eq!(
+            local_references(contents).into_iter().collect::<Vec<_>>(),
+            vec![
+                PathBuf::from("guide.md"),
+                PathBuf::from("references/a(b).md"),
+                PathBuf::from("scripts/run.sh")
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_external_and_fenced_examples() {
+        let contents = "[web](https://example.com/a.md) [anchor](#a)\n```sh\nscripts/no.sh\n```";
+
+        assert!(local_references(contents).is_empty());
+    }
+}

--- a/tooling/arnes/tests/cli.rs
+++ b/tooling/arnes/tests/cli.rs
@@ -64,12 +64,20 @@ fn version_succeeds() {
 
 #[test]
 fn doctor_accepts_shared_options_without_reading_the_environment() {
-    let output = run(&[
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        "version: 1\nagents:\n  - id: codex\n    scopes: [project]\nresources: []\n",
+    );
+    let output = fixture.command([
         "doctor", "skills", "--agent", "codex", "--scope", "project", "--format", "human",
     ]);
 
     assert_eq!(output.status.code(), Some(0));
-    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "unsupported skills: codex project skill projection is not declared or supported\n"
+    );
     assert!(output.stderr.is_empty());
 }
 
@@ -159,6 +167,18 @@ fn manifest_doctor_requires_home_without_reading_the_environment() {
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
         "error manifest: HOME: environment variable is required\n"
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn skills_doctor_requires_injected_home_without_fallback() {
+    let output = run(&["doctor", "skills"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "error skills: HOME: environment variable is required\n"
     );
     assert!(output.stderr.is_empty());
 }

--- a/tooling/arnes/tests/fixtures/manifest/aliased-skill-slug.yaml
+++ b/tooling/arnes/tests/fixtures/manifest/aliased-skill-slug.yaml
@@ -1,0 +1,17 @@
+version: 1
+agents:
+  - id: claude
+    scopes: [user]
+skills:
+  - slug: alpha
+    installations: [{ agent: claude, scope: user }]
+  - slug: alpha/.
+    installations: [{ agent: claude, scope: user }]
+resources:
+  - id: claude-user-skills
+    kind: skills
+    agent: claude
+    scope: user
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/skills }

--- a/tooling/arnes/tests/fixtures/manifest/duplicate-skill-installation.yaml
+++ b/tooling/arnes/tests/fixtures/manifest/duplicate-skill-installation.yaml
@@ -1,0 +1,17 @@
+version: 1
+agents:
+  - id: claude
+    scopes: [user]
+skills:
+  - slug: alpha
+    installations:
+      - { agent: claude, scope: user }
+      - { agent: claude, scope: user }
+resources:
+  - id: claude-user-skills
+    kind: skills
+    agent: claude
+    scope: user
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/skills }

--- a/tooling/arnes/tests/fixtures/manifest/duplicate-skill-projection.yaml
+++ b/tooling/arnes/tests/fixtures/manifest/duplicate-skill-projection.yaml
@@ -1,0 +1,20 @@
+version: 1
+agents:
+  - id: claude
+    scopes: [user]
+skills: []
+resources:
+  - id: claude-user-skills
+    kind: skills
+    agent: claude
+    scope: user
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/skills }
+  - id: claude-user-other-skills
+    kind: skills
+    agent: claude
+    scope: user
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/other-skills }

--- a/tooling/arnes/tests/fixtures/manifest/duplicate-skill.yaml
+++ b/tooling/arnes/tests/fixtures/manifest/duplicate-skill.yaml
@@ -1,0 +1,17 @@
+version: 1
+agents:
+  - id: claude
+    scopes: [user]
+skills:
+  - slug: alpha
+    installations: [{ agent: claude, scope: user }]
+  - slug: alpha
+    installations: [{ agent: claude, scope: user }]
+resources:
+  - id: claude-user-skills
+    kind: skills
+    agent: claude
+    scope: user
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/skills }

--- a/tooling/arnes/tests/fixtures/manifest/empty-skill-installations.yaml
+++ b/tooling/arnes/tests/fixtures/manifest/empty-skill-installations.yaml
@@ -1,0 +1,15 @@
+version: 1
+agents:
+  - id: claude
+    scopes: [user]
+skills:
+  - slug: alpha
+    installations: []
+resources:
+  - id: claude-user-skills
+    kind: skills
+    agent: claude
+    scope: user
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/skills }

--- a/tooling/arnes/tests/fixtures/manifest/invalid-skill-slug.yaml
+++ b/tooling/arnes/tests/fixtures/manifest/invalid-skill-slug.yaml
@@ -1,0 +1,15 @@
+version: 1
+agents:
+  - id: claude
+    scopes: [user]
+skills:
+  - slug: ../alpha
+    installations: [{ agent: claude, scope: user }]
+resources:
+  - id: claude-user-skills
+    kind: skills
+    agent: claude
+    scope: user
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/skills }

--- a/tooling/arnes/tests/fixtures/manifest/layout-on-instructions.yaml
+++ b/tooling/arnes/tests/fixtures/manifest/layout-on-instructions.yaml
@@ -1,0 +1,13 @@
+version: 1
+agents:
+  - id: claude
+    scopes: [user]
+skills: []
+resources:
+  - id: claude-user-instructions
+    kind: instructions
+    agent: claude
+    scope: user
+    layout: leaves
+    source: { root: repository, path: harness/AGENTS.md }
+    destination: { root: home, path: .claude/CLAUDE.md }

--- a/tooling/arnes/tests/fixtures/manifest/missing-skill-layout.yaml
+++ b/tooling/arnes/tests/fixtures/manifest/missing-skill-layout.yaml
@@ -1,0 +1,12 @@
+version: 1
+agents:
+  - id: claude
+    scopes: [user]
+skills: []
+resources:
+  - id: claude-user-skills
+    kind: skills
+    agent: claude
+    scope: user
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/skills }

--- a/tooling/arnes/tests/fixtures/manifest/skill-installation-on-root.yaml
+++ b/tooling/arnes/tests/fixtures/manifest/skill-installation-on-root.yaml
@@ -1,0 +1,15 @@
+version: 1
+agents:
+  - id: claude
+    scopes: [project]
+skills:
+  - slug: alpha
+    installations: [{ agent: claude, scope: project }]
+resources:
+  - id: claude-project-skills
+    kind: skills
+    agent: claude
+    scope: project
+    layout: root
+    source: { root: repository, path: .agents/skills }
+    destination: { root: repository, path: .claude/skills }

--- a/tooling/arnes/tests/manifest.rs
+++ b/tooling/arnes/tests/manifest.rs
@@ -121,7 +121,51 @@ fn inline_resource_contents_are_rejected_without_exposing_values() {
 
     assert_eq!(
         error,
-        "resources[0].content: resources[0]: unknown field `content`, expected one of `id`, `kind`, `agent`, `scope`, `source`, `destination` at line 10 column 5"
+        "resources[0].content: resources[0]: unknown field `content`, expected one of `id`, `kind`, `agent`, `scope`, `layout`, `source`, `destination` at line 10 column 5"
     );
     assert!(!error.contains("inline instruction text"));
+}
+
+#[test]
+fn skill_declarations_are_normalized_and_unambiguous() {
+    for (fixture, expected) in [
+        (
+            "duplicate-skill.yaml",
+            "skills[1].slug: duplicate skill identifier",
+        ),
+        (
+            "duplicate-skill-installation.yaml",
+            "skills[0].installations[1]: duplicate skill installation",
+        ),
+        (
+            "empty-skill-installations.yaml",
+            "skills[0].installations: at least one leaf installation is required",
+        ),
+        (
+            "duplicate-skill-projection.yaml",
+            "resources[1].agent: duplicates resources[0] skill projection",
+        ),
+        (
+            "invalid-skill-slug.yaml",
+            "skills[0].slug: must be one relative path component",
+        ),
+        (
+            "aliased-skill-slug.yaml",
+            "skills[1].slug: must be one relative path component",
+        ),
+        (
+            "layout-on-instructions.yaml",
+            "resources[0].layout: layout is only valid for skill projections",
+        ),
+        (
+            "missing-skill-layout.yaml",
+            "resources[0].layout: skill projection layout is required",
+        ),
+        (
+            "skill-installation-on-root.yaml",
+            "skills[0].installations[0]: has no leaves skill projection",
+        ),
+    ] {
+        assert_eq!(error(fixture), expected);
+    }
 }

--- a/tooling/arnes/tests/skill_adversarial.rs
+++ b/tooling/arnes/tests/skill_adversarial.rs
@@ -1,0 +1,133 @@
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use skill_support::{configured_fixture, link_home_relative, run};
+use std::fs;
+use std::os::unix::fs::symlink;
+
+#[test]
+fn relative_symlinks_to_declared_sources_are_managed() {
+    let fixture = configured_fixture();
+    let link = fixture.home().join(".claude/skills/alpha");
+    fs::remove_file(&link).unwrap();
+    link_home_relative(&fixture, ".agents/skills/alpha", ".claude/skills/alpha");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("healthy skills: managed claude user skill alpha"));
+}
+
+#[test]
+fn source_components_cannot_escape_the_repository() {
+    let fixture = configured_fixture();
+    let source = fixture.repository().join(".agents/skills/alpha");
+    let outside = fixture.repository().parent().unwrap().join("outside-alpha");
+    fs::rename(&source, &outside).unwrap();
+    symlink("../../../outside-alpha", source).unwrap();
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2);
+    assert!(stdout.contains("resolves outside the repository"));
+}
+
+#[test]
+fn destination_components_cannot_escape_home_or_trigger_outside_discovery() {
+    let fixture = configured_fixture();
+    let outside = fixture.home().parent().unwrap().join("outside-claude");
+    fs::create_dir_all(outside.join("skills/plugin-owned")).unwrap();
+    fs::remove_dir_all(fixture.home().join(".claude")).unwrap();
+    symlink("../outside-claude", fixture.home().join(".claude")).unwrap();
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2);
+    assert!(stdout.contains("escapes its scope root"));
+    assert!(!stdout.contains("plugin-owned"));
+}
+
+#[test]
+fn referenced_resource_symlinks_cannot_escape_the_effective_skill() {
+    let fixture = configured_fixture();
+    let references = fixture.repository().join(".agents/skills/alpha/references");
+    fs::remove_dir_all(&references).unwrap();
+    let outside = fixture.repository().join("outside-references");
+    fs::create_dir(&outside).unwrap();
+    fs::write(outside.join("guide.md"), "outside\n").unwrap();
+    symlink("../../../outside-references", references).unwrap();
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2);
+    assert!(stdout.contains("resolves outside its skill"));
+}
+
+#[test]
+fn non_local_markdown_targets_do_not_create_resource_findings() {
+    let fixture = configured_fixture();
+    fixture.write_repository(".agents/skills/alpha/guide(with-parentheses).md", "guide\n");
+    fixture.write_repository(
+        ".agents/skills/alpha/SKILL.md",
+        "[web](https://example.com/missing.md) [anchor](#missing) \
+         [absolute](/missing.md) [local](guide(with-parentheses).md) plain-missing.md\n\
+         ```sh\nscripts/fenced-example.sh\n```\n",
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(!stdout.contains("local resource"));
+}
+
+#[test]
+fn undeclared_aliases_of_managed_sources_remain_unmanaged() {
+    let fixture = configured_fixture();
+    let destination = fixture.home().join(".cursor/skills/plugin-owned");
+    symlink(
+        fixture.repository().join(".agents/skills/alpha"),
+        &destination,
+    )
+    .unwrap();
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("unmanaged cursor user skill plugin-owned"));
+    assert_eq!(stdout.matches("managed cursor user skill alpha").count(), 1);
+}
+
+#[test]
+fn expected_skill_roots_must_be_directories() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.home().join(".claude/skills/alpha")).unwrap();
+    fs::remove_dir(fixture.home().join(".claude/skills")).unwrap();
+    fs::write(fixture.home().join(".claude/skills"), "not a directory").unwrap();
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2);
+    assert!(stdout.contains("could not be read"));
+}

--- a/tooling/arnes/tests/skill_failures.rs
+++ b/tooling/arnes/tests/skill_failures.rs
@@ -1,0 +1,154 @@
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use skill_support::{configured_fixture, run};
+use std::fs;
+use std::os::unix::fs::symlink;
+
+#[test]
+fn missing_skills_and_projection_destinations_are_broken() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.home().join(".claude/skills/alpha")).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+    assert_eq!(code, 1);
+    assert!(stdout.contains("broken managed claude user skill alpha"));
+    assert!(stdout.contains("is missing"));
+
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.repository().join(".claude/skills")).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor", "skills", "--agent", "claude", "--scope", "project",
+        ],
+    );
+    assert_eq!(code, 1);
+    assert!(stdout.contains("broken managed claude project skills projection"));
+    assert!(stdout.contains("is missing"));
+}
+
+#[test]
+fn broken_and_incorrect_symlinks_are_drift() {
+    let fixture = configured_fixture();
+    let link = fixture.home().join(".cursor/skills/alpha");
+    fs::remove_file(&link).unwrap();
+    symlink(fixture.repository().join(".agents/skills/beta"), link).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+    );
+    assert_eq!(code, 1);
+    assert!(stdout.contains("wrong symlink target"));
+
+    let fixture = configured_fixture();
+    let link = fixture.repository().join(".codex/skills");
+    fs::remove_file(&link).unwrap();
+    symlink("missing", link).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "project"],
+    );
+    assert_eq!(code, 1);
+    assert!(stdout.contains("wrong symlink target"));
+}
+
+#[test]
+fn skill_file_must_exist_and_be_a_file() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.repository().join(".agents/skills/alpha/SKILL.md")).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+    assert_eq!(code, 1);
+    assert!(stdout.contains("SKILL.md is missing"));
+
+    let fixture = configured_fixture();
+    let file = fixture.repository().join(".agents/skills/alpha/SKILL.md");
+    fs::remove_file(&file).unwrap();
+    fs::create_dir(&file).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+    assert_eq!(code, 2);
+    assert!(stdout.contains("SKILL.md is not a file"));
+}
+
+#[test]
+fn missing_relative_resources_are_broken() {
+    let fixture = configured_fixture();
+    fs::remove_file(
+        fixture
+            .repository()
+            .join(".agents/skills/alpha/references/guide.md"),
+    )
+    .unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 1);
+    assert!(stdout.contains("local resource references/guide.md is missing"));
+
+    let fixture = configured_fixture();
+    fixture.write_repository(
+        ".agents/skills/alpha/SKILL.md",
+        "[missing root resource](guide.md)\n",
+    );
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+    assert_eq!(code, 1);
+    assert!(stdout.contains("local resource guide.md is missing"));
+}
+
+#[test]
+fn unmanaged_installations_are_preserved_and_not_validated_as_owned() {
+    let fixture = configured_fixture();
+    fixture.write_home(
+        ".claude/skills/third-party/SKILL.md",
+        "[missing](references/missing.md)\n",
+    );
+    let before = fixture.snapshot();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("unmanaged claude user skill third-party"));
+    assert!(!stdout.contains("local resource"));
+    assert_eq!(fixture.snapshot(), before);
+
+    let fixture = configured_fixture();
+    let link = fixture.home().join(".claude/skills/dangling-third-party");
+    symlink("missing-third-party", link).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("broken claude user skill dangling-third-party"));
+    assert!(stdout.contains("is unmanaged and not Arnes-owned"));
+}
+
+#[test]
+fn manifest_failures_fail_closed_as_skill_errors() {
+    let fixture = support::Fixture::new();
+    fixture.write_home(".arnes.yaml", "version: 2\n");
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "skills"]);
+
+    assert_eq!(code, 2);
+    assert_eq!(
+        stdout,
+        "error skills: version: unsupported version 2; expected 1\n"
+    );
+    assert!(stderr.is_empty());
+}

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -1,0 +1,94 @@
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use skill_support::{MANIFEST, configured_fixture, run};
+use support::Fixture;
+
+#[test]
+fn supported_user_and_project_projections_are_managed() {
+    let fixture = configured_fixture();
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "skills"]);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(stdout.lines().count(), 9);
+    assert_eq!(stdout.matches("healthy skills: managed").count(), 9);
+    for expected in [
+        "managed claude user skill alpha",
+        "managed claude project skill beta",
+        "managed cursor user skill alpha",
+        "managed cursor project skill beta",
+        "managed codex user skill alpha",
+        "managed codex project skill beta",
+    ] {
+        assert!(stdout.contains(expected), "missing {expected}: {stdout}");
+    }
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn agent_and_scope_filters_isolate_skill_projections() {
+    let fixture = configured_fixture();
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor", "skills", "--agent", "cursor", "--scope", "project",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(stdout.lines().count(), 2);
+    assert!(stdout.lines().all(|line| line.contains("cursor project")));
+
+    let (code, stdout, _) = run(&fixture, &["doctor", "skills", "--scope", "user"]);
+    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(stdout.lines().count(), 3);
+    assert!(stdout.lines().all(|line| line.contains(" user ")));
+}
+
+#[test]
+fn undeclared_and_unsupported_projections_are_reported() {
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user]\nresources: []\n",
+    );
+    let (code, stdout, _) = run(&fixture, &["doctor", "skills"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("unsupported skills: claude user skill projection"));
+
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        &MANIFEST.replace(".claude/skills/alpha", ".claude/other/alpha"),
+    );
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+    assert_eq!(code, 0);
+    assert!(stdout.contains("projection claude-user-alpha"));
+    assert!(stdout.contains("is unsupported"));
+}
+
+#[test]
+fn skills_doctor_is_isolated_and_read_only() {
+    let fixture = configured_fixture();
+    fixture.write_home("private", "temporary HOME sentinel");
+    fixture.write_repository("private", "temporary repository sentinel");
+    let before = fixture.snapshot();
+
+    let (code, _, _) = run(&fixture, &["doctor", "skills"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn doctor_without_resource_does_not_aggregate_skills_yet() {
+    let fixture = configured_fixture();
+    let (code, stdout, _) = run(&fixture, &["doctor"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "healthy manifest: manifest is valid\n");
+}

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -60,14 +60,18 @@ fn undeclared_and_unsupported_projections_are_reported() {
     let fixture = Fixture::new();
     fixture.write_home(
         ".arnes.yaml",
-        &MANIFEST.replace(".claude/skills/alpha", ".claude/other/alpha"),
+        &MANIFEST.replacen(
+            "source: { root: repository, path: .agents/skills }",
+            "source: { root: repository, path: .agents/other }",
+            1,
+        ),
     );
     let (code, stdout, _) = run(
         &fixture,
         &["doctor", "skills", "--agent", "claude", "--scope", "user"],
     );
     assert_eq!(code, 0);
-    assert!(stdout.contains("projection claude-user-alpha"));
+    assert!(stdout.contains("projection claude-user-skills"));
     assert!(stdout.contains("is unsupported"));
 }
 

--- a/tooling/arnes/tests/support/skills.rs
+++ b/tooling/arnes/tests/support/skills.rs
@@ -1,0 +1,102 @@
+use crate::support::Fixture;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+pub const MANIFEST: &str = "version: 1
+agents:
+  - id: claude
+    scopes: [user, project]
+  - id: cursor
+    scopes: [user, project]
+  - id: codex
+    scopes: [user, project]
+resources:
+  - id: claude-user-alpha
+    kind: skills
+    agent: claude
+    scope: user
+    source: { root: repository, path: .agents/skills/alpha }
+    destination: { root: home, path: .claude/skills/alpha }
+  - id: claude-project-skills
+    kind: skills
+    agent: claude
+    scope: project
+    source: { root: repository, path: .agents/skills }
+    destination: { root: repository, path: .claude/skills }
+  - id: cursor-user-alpha
+    kind: skills
+    agent: cursor
+    scope: user
+    source: { root: repository, path: .agents/skills/alpha }
+    destination: { root: home, path: .cursor/skills/alpha }
+  - id: cursor-project-skills
+    kind: skills
+    agent: cursor
+    scope: project
+    source: { root: repository, path: .agents/skills }
+    destination: { root: repository, path: .cursor/skills }
+  - id: codex-user-alpha
+    kind: skills
+    agent: codex
+    scope: user
+    source: { root: repository, path: .agents/skills/alpha }
+    destination: { root: home, path: .agents/skills/alpha }
+  - id: codex-project-skills
+    kind: skills
+    agent: codex
+    scope: project
+    source: { root: repository, path: .agents/skills }
+    destination: { root: repository, path: .codex/skills }
+";
+
+pub fn configured_fixture() -> Fixture {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", MANIFEST);
+    fixture.write_repository(
+        ".agents/skills/alpha/SKILL.md",
+        "# Alpha\n[guide](references/guide.md)\n",
+    );
+    fixture.write_repository(".agents/skills/alpha/references/guide.md", "guide\n");
+    fixture.write_repository(".agents/skills/beta/SKILL.md", "# Beta\n");
+    for destination in [
+        ".claude/skills/alpha",
+        ".cursor/skills/alpha",
+        ".agents/skills/alpha",
+    ] {
+        link_home(&fixture, ".agents/skills/alpha", destination);
+    }
+    for destination in [".claude/skills", ".cursor/skills", ".codex/skills"] {
+        link_project(&fixture, destination);
+    }
+    fixture
+}
+
+pub fn link_home(fixture: &Fixture, source: &str, destination: &str) {
+    let destination = fixture.home().join(destination);
+    fs::create_dir_all(destination.parent().unwrap()).unwrap();
+    symlink(fixture.repository().join(source), destination).unwrap();
+}
+
+pub fn link_home_relative(fixture: &Fixture, source: &str, destination: &str) {
+    let destination = fixture.home().join(destination);
+    fs::create_dir_all(destination.parent().unwrap()).unwrap();
+    symlink(Path::new("../../../repository").join(source), destination).unwrap();
+}
+
+pub fn link_project(fixture: &Fixture, destination: &str) {
+    let destination = fixture.repository().join(destination);
+    fs::create_dir_all(destination.parent().unwrap()).unwrap();
+    symlink("../.agents/skills", destination).unwrap();
+}
+
+pub fn run(fixture: &Fixture, args: &[&str]) -> (i32, String, String) {
+    let before = fixture.snapshot();
+    let output = fixture.command(args);
+    assert_eq!(fixture.snapshot(), before);
+    (
+        output.status.code().unwrap(),
+        String::from_utf8(output.stdout).unwrap(),
+        String::from_utf8(output.stderr).unwrap(),
+    )
+}

--- a/tooling/arnes/tests/support/skills.rs
+++ b/tooling/arnes/tests/support/skills.rs
@@ -11,41 +11,53 @@ agents:
     scopes: [user, project]
   - id: codex
     scopes: [user, project]
+skills:
+  - slug: alpha
+    installations:
+      - { agent: claude, scope: user }
+      - { agent: cursor, scope: user }
+      - { agent: codex, scope: user }
 resources:
-  - id: claude-user-alpha
+  - id: claude-user-skills
     kind: skills
     agent: claude
     scope: user
-    source: { root: repository, path: .agents/skills/alpha }
-    destination: { root: home, path: .claude/skills/alpha }
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .claude/skills }
   - id: claude-project-skills
     kind: skills
     agent: claude
     scope: project
+    layout: root
     source: { root: repository, path: .agents/skills }
     destination: { root: repository, path: .claude/skills }
-  - id: cursor-user-alpha
+  - id: cursor-user-skills
     kind: skills
     agent: cursor
     scope: user
-    source: { root: repository, path: .agents/skills/alpha }
-    destination: { root: home, path: .cursor/skills/alpha }
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .cursor/skills }
   - id: cursor-project-skills
     kind: skills
     agent: cursor
     scope: project
+    layout: root
     source: { root: repository, path: .agents/skills }
     destination: { root: repository, path: .cursor/skills }
-  - id: codex-user-alpha
+  - id: codex-user-skills
     kind: skills
     agent: codex
     scope: user
-    source: { root: repository, path: .agents/skills/alpha }
-    destination: { root: home, path: .agents/skills/alpha }
+    layout: leaves
+    source: { root: repository, path: .agents/skills }
+    destination: { root: home, path: .agents/skills }
   - id: codex-project-skills
     kind: skills
     agent: codex
     scope: project
+    layout: root
     source: { root: repository, path: .agents/skills }
     destination: { root: repository, path: .codex/skills }
 ";


### PR DESCRIPTION
## Summary

- diagnose declared Claude, Cursor, and Codex skill projections in user and project scopes
- declare each skill and each projection root once, deriving leaf paths from the normalized manifest relationship
- validate roots, symlink targets, `SKILL.md`, and relative local resources without mutation
- classify owned drift as managed/broken while preserving unmanaged and third-party installations

## Verification

- `cargo fmt --manifest-path tooling/arnes/Cargo.toml --check`
- `cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features`
- `git diff --check`
- macOS arm64: 36/36 real project projections healthy; Ubuntu delegated to CI
- independent adversarial passes: root escapes, intermediate/relative symlinks, resource false positives, managed/unmanaged spoofing, and normalized-slug aliases

Closes #118.
Refs #111.
Refs #61.