### PR TITLE
fix(arnes): report undeclared project skills

### DIFF
--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -88,6 +88,10 @@ impl Manifest {
             })
             .map(|skill| skill.slug.as_str())
     }
+
+    pub fn declared_skills(&self) -> impl Iterator<Item = &str> {
+        self.skills.iter().map(|skill| skill.slug.as_str())
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/tooling/arnes/src/skills.rs
+++ b/tooling/arnes/src/skills.rs
@@ -46,7 +46,7 @@ fn diagnose_one(roots: &Roots, manifest: &Manifest, agent: Agent, scope: Scope) 
     for resource in supported {
         match resource.layout {
             SkillLayout::Leaves => diagnostics.extend(diagnose_leaves(roots, manifest, &resource)),
-            SkillLayout::Root => diagnostics.extend(projection::root(roots, &resource)),
+            SkillLayout::Root => diagnostics.extend(diagnose_root(roots, manifest, &resource)),
         }
     }
     diagnostics
@@ -68,6 +68,30 @@ fn diagnose_leaves(
         .iter()
         .map(|skill| projection::leaf(roots, resource, skill))
         .collect::<Vec<_>>();
+    diagnostics.extend(discovery::unmanaged(
+        roots,
+        resource.agent,
+        resource.scope,
+        resource.destination,
+        &declared,
+    ));
+    diagnostics
+}
+
+fn diagnose_root(
+    roots: &Roots,
+    manifest: &Manifest,
+    resource: &SkillProjection<'_>,
+) -> Vec<Diagnostic> {
+    let skills = manifest.declared_skills().collect::<Vec<_>>();
+    let declared = skills
+        .iter()
+        .map(|skill| resource.destination.join(*skill))
+        .collect::<HashSet<PathBuf>>();
+    let mut diagnostics = match projection::root(roots, resource, &skills) {
+        Ok(diagnostics) => diagnostics,
+        Err(diagnostic) => return vec![diagnostic],
+    };
     diagnostics.extend(discovery::unmanaged(
         roots,
         resource.agent,

--- a/tooling/arnes/src/skills/projection.rs
+++ b/tooling/arnes/src/skills/projection.rs
@@ -25,7 +25,11 @@ pub fn leaf(roots: &Roots, resource: &SkillProjection<'_>, name: &str) -> Diagno
     }
 }
 
-pub fn root(roots: &Roots, resource: &SkillProjection<'_>) -> Vec<Diagnostic> {
+pub fn root(
+    roots: &Roots,
+    resource: &SkillProjection<'_>,
+    skills: &[&str],
+) -> Result<Vec<Diagnostic>, Diagnostic> {
     let source = roots.repository().join(resource.source);
     let destination = destination(roots, resource.scope, resource.destination);
     let subject = format!(
@@ -34,17 +38,11 @@ pub fn root(roots: &Roots, resource: &SkillProjection<'_>) -> Vec<Diagnostic> {
         resource.scope,
         label(resource.scope, resource.destination)
     );
-    if let Err(diagnostic) = expected_link(roots, resource.scope, &source, &destination, &subject) {
-        return vec![diagnostic];
-    }
-    let entries = match super::discovery::installations(&source) {
-        Ok(entries) => entries,
-        Err(reason) => return vec![broken(&subject, State::Error, reason)],
-    };
-    entries
-        .into_iter()
-        .map(|name| root_skill(roots, resource, &source, &destination, &name))
-        .collect()
+    expected_link(roots, resource.scope, &source, &destination, &subject)?;
+    Ok(skills
+        .iter()
+        .map(|name| root_skill(roots, resource, &source, &destination, Path::new(name)))
+        .collect())
 }
 
 fn root_skill(

--- a/tooling/arnes/tests/skill_failures.rs
+++ b/tooling/arnes/tests/skill_failures.rs
@@ -110,6 +110,23 @@ fn missing_relative_resources_are_broken() {
 }
 
 #[test]
+fn project_discovery_survives_managed_skill_drift() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.repository().join(".agents/skills/alpha/SKILL.md")).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor", "skills", "--agent", "claude", "--scope", "project",
+        ],
+    );
+
+    assert_eq!(code, 1, "{stdout}");
+    assert!(stdout.contains("broken managed claude project skill alpha"));
+    assert!(stdout.contains("unmanaged claude project skill beta"));
+    assert!(!stdout.contains("local resource references/missing.md"));
+}
+
+#[test]
 fn unmanaged_installations_are_preserved_and_not_validated_as_owned() {
     let fixture = configured_fixture();
     fixture.write_home(

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -6,20 +6,24 @@ use skill_support::{MANIFEST, configured_fixture, run};
 use support::Fixture;
 
 #[test]
-fn supported_user_and_project_projections_are_managed() {
+fn declared_skills_are_managed_and_undeclared_project_skills_are_unmanaged() {
     let fixture = configured_fixture();
     let (code, stdout, stderr) = run(&fixture, &["doctor", "skills"]);
 
     assert_eq!(code, 0, "{stdout}");
     assert_eq!(stdout.lines().count(), 9);
-    assert_eq!(stdout.matches("healthy skills: managed").count(), 9);
+    assert_eq!(stdout.matches("healthy skills: managed").count(), 6);
+    assert_eq!(stdout.matches("unsupported skills: unmanaged").count(), 3);
     for expected in [
         "managed claude user skill alpha",
-        "managed claude project skill beta",
+        "managed claude project skill alpha",
+        "unmanaged claude project skill beta",
         "managed cursor user skill alpha",
-        "managed cursor project skill beta",
+        "managed cursor project skill alpha",
+        "unmanaged cursor project skill beta",
         "managed codex user skill alpha",
-        "managed codex project skill beta",
+        "managed codex project skill alpha",
+        "unmanaged codex project skill beta",
     ] {
         assert!(stdout.contains(expected), "missing {expected}: {stdout}");
     }

--- a/tooling/arnes/tests/support/skills.rs
+++ b/tooling/arnes/tests/support/skills.rs
@@ -70,7 +70,10 @@ pub fn configured_fixture() -> Fixture {
         "# Alpha\n[guide](references/guide.md)\n",
     );
     fixture.write_repository(".agents/skills/alpha/references/guide.md", "guide\n");
-    fixture.write_repository(".agents/skills/beta/SKILL.md", "# Beta\n");
+    fixture.write_repository(
+        ".agents/skills/beta/SKILL.md",
+        "# Beta\n[missing](references/missing.md)\n",
+    );
     for destination in [
         ".claude/skills/alpha",
         ".cursor/skills/alpha",


### PR DESCRIPTION
## Summary

- classify project-root skills as managed only when their slug is declared in the Arnes manifest
- report other physically exposed project skills as unmanaged and not Arnes-owned
- keep unmanaged references unchecked and continue discovery beside managed drift

## Verification

- `cargo fmt --manifest-path tooling/arnes/Cargo.toml --check`
- `cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features`
- `git diff --check`
- macOS arm64 real project projection: 9 managed, 27 unmanaged, 36 total, temporary HOME, worktree unchanged
- independent adversarial pass: missing/broken declared skills, external/dangling symlinks, missing unmanaged references, invalid roots, filters, leaves regression, and read-only

Fixes a classification defect introduced by #142.
Refs #118.
Refs #111.
Refs #61.