### PR TITLE
fix(fish): restore Fisher plugin after layout migration

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -7,6 +7,7 @@ on:
       - harness/**
       - tooling/deploy-link
       - tooling/deploy-link-test
+      - tooling/fish-deployment-test
       - Makefile
       - .github/workflows/test-deployment.yml
   pull_request:
@@ -15,6 +16,7 @@ on:
       - harness/**
       - tooling/deploy-link
       - tooling/deploy-link-test
+      - tooling/fish-deployment-test
       - Makefile
       - .github/workflows/test-deployment.yml
 
@@ -28,3 +30,4 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: tooling/deploy-link-test
+      - run: tooling/fish-deployment-test

--- a/Makefile
+++ b/Makefile
@@ -120,15 +120,21 @@ ${BREW_BIN}/fd:
 	brew install fd
 
 .PHONY: fish
-fish: brew starship ~/.config/fish ${BREW_BIN}/fish
+fish: brew starship ~/.config/fish ${BREW_BIN}/fish ~/.config/fish/functions/fzf_configure_bindings.fish
 ${BREW_BIN}/fish:
 	brew install fish fisher
-	fish -c 'fisher install PatrickF1/fzf.fish'
 	@echo 'If you want to switch your shell to fish, please run the following command'
 	@echo '$> sudo chpass -s ${BREW_BIN}/fish ${USER}'
 
 ~/.config/fish: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.config/fish | ~/.config
 	${DEPLOY_LINK} ${DOTFILES_PATH}/fish ${DOTFILES_PATH}/home/.config/fish $@
+~/.config/fish/functions/fzf_configure_bindings.fish: FORCE ${BREW_BIN}/fish | ~/.config/fish
+	@if [ ! -e "$@" ]; then \
+		if ! ${BREW_BIN}/fish -c 'fisher install PatrickF1/fzf.fish' || [ ! -e "$@" ]; then \
+			echo "Error: Fisher did not install $@" >&2; \
+			exit 1; \
+		fi; \
+	fi
 
 .PHONY: gnu-sed
 gnu-sed: brew ${BREW_GNU_BIN}/gnu-sed

--- a/tooling/fish-deployment-test
+++ b/tooling/fish-deployment-test
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tooling_dir=$(cd "$(dirname "$0")" && pwd)
+repository=$(cd "$tooling_dir/.." && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/fish-deployment-test.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT
+
+test_home=$test_root/home
+test_repository=$test_root/repository
+fake_bin=$test_root/bin
+old_config=$test_repository/fish
+new_config=$test_repository/home/.config/fish
+bindings=$test_home/.config/fish/functions/fzf_configure_bindings.fish
+marker=$test_root/fish-called
+
+assert_failure() {
+  if "$@" >"$test_root/stdout" 2>"$test_root/stderr"; then
+    echo "FAIL: command unexpectedly succeeded: $*" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$test_home/.config" "$old_config/functions" "$new_config" "$test_repository/tooling" "$fake_bin"
+cp "$repository/tooling/deploy-link" "$test_repository/tooling/deploy-link"
+touch "$old_config/functions/fzf_configure_bindings.fish"
+ln -s "$old_config" "$test_home/.config/fish"
+printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' "printf \"%s\\n\" \"\$*\" >\"\$FISH_MARKER\"" "mkdir -p \"\$HOME/.config/fish/functions\"" ": >\"\$HOME/.config/fish/functions/fzf_configure_bindings.fish\"" >"$fake_bin/fish"
+chmod +x "$fake_bin/fish"
+
+env HOME="$test_home" FISH_MARKER="$marker" make -f "$repository/Makefile" DOTFILES_PATH="$test_repository" DEPLOY_LINK="$test_repository/tooling/deploy-link" BREW_BIN="$fake_bin" "$bindings"
+
+[[ $(readlink "$test_home/.config/fish") == "$new_config" ]]
+[[ -f $bindings ]]
+[[ -f $old_config/functions/fzf_configure_bindings.fish ]]
+[[ $(cat "$marker") == "-c fisher install PatrickF1/fzf.fish" ]]
+
+rm "$marker"
+env HOME="$test_home" FISH_MARKER="$marker" make -f "$repository/Makefile" DOTFILES_PATH="$test_repository" DEPLOY_LINK="$test_repository/tooling/deploy-link" BREW_BIN="$fake_bin" "$bindings"
+[[ ! -e $marker ]]
+
+rm "$bindings"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$fake_bin/fish"
+chmod +x "$fake_bin/fish"
+assert_failure env HOME="$test_home" FISH_MARKER="$marker" make -f "$repository/Makefile" DOTFILES_PATH="$test_repository" DEPLOY_LINK="$test_repository/tooling/deploy-link" BREW_BIN="$fake_bin" "$bindings"
+grep -q "Error: Fisher did not install $bindings" "$test_root/stderr"
+
+echo "fish deployment tests passed"


### PR DESCRIPTION
## Description

- Install PatrickF1/fzf.fish after the Fish configuration symlink has been migrated.
- Fail deployment when Fisher exits without creating fzf_configure_bindings.fish.
- Add a portable regression test for migration, preservation, idempotency, and false-success handling.

## Useful Links

- Issue: N/A

## How to Test

- tooling/fish-deployment-test
- tooling/deploy-link-test
- shellcheck tooling/fish-deployment-test
- bash -n tooling/fish-deployment-test
- fish -i -c 'type -q fzf_configure_bindings'
- prettier --check .github/workflows/test-deployment.yml

## Checklist

- [x] Changes have been tested locally on macOS
- [x] Documentation is unchanged because behavior remains within the existing deployment architecture
- [x] No breaking changes