### PR TITLE
refactor(make): remove completed symlink migration

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -6,6 +6,7 @@ on:
       - home/**
       - harness/**
       - tooling/deploy-link
+      - tooling/deploy-link-adversarial-test
       - tooling/deploy-link-test
       - tooling/fish-deployment-test
       - Makefile
@@ -15,6 +16,7 @@ on:
       - home/**
       - harness/**
       - tooling/deploy-link
+      - tooling/deploy-link-adversarial-test
       - tooling/deploy-link-test
       - tooling/fish-deployment-test
       - Makefile
@@ -30,4 +32,5 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: tooling/deploy-link-test
+      - run: tooling/deploy-link-adversarial-test
       - run: tooling/fish-deployment-test

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ ${BREW_BIN}/fish:
 	@echo '$> sudo chpass -s ${BREW_BIN}/fish ${USER}'
 
 ~/.config/fish: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.config/fish | ~/.config
-	${DEPLOY_LINK} ${DOTFILES_PATH}/fish ${DOTFILES_PATH}/home/.config/fish $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.config/fish $@
 ~/.config/fish/functions/fzf_configure_bindings.fish: FORCE ${BREW_BIN}/fish | ~/.config/fish
 	@if [ ! -e "$@" ]; then \
 		if ! ${BREW_BIN}/fish -c 'fisher install PatrickF1/fzf.fish' || [ ! -e "$@" ]; then \
@@ -164,7 +164,7 @@ wezterm: brew font-jetbrains-mono font-iosevka-nerd-font /Applications/WezTerm.a
 	@if [ "$(HAS_BREW_TRUST)" = "yes" ]; then brew trust --cask wez/wezterm/wezterm-nightly; fi
 	brew install --cask wez/wezterm/wezterm-nightly
 ~/.wezterm.lua: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.wezterm.lua
-	${DEPLOY_LINK} ${DOTFILES_PATH}/.wezterm.lua ${DOTFILES_PATH}/home/.wezterm.lua $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.wezterm.lua $@
 
 ################################################################################
 # End of the terminal section
@@ -219,12 +219,12 @@ ai: \
 	skills
 
 ~/.arnes.yaml: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.arnes.yaml
-	${DEPLOY_LINK} ${DOTFILES_PATH}/.arnes.yaml ${DOTFILES_PATH}/home/.arnes.yaml $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.arnes.yaml $@
 
 .PHONY: arnes
 arnes: rust ${DEPLOY_LINK} ~/.arnes.yaml | ${LOCAL_BIN}
 	cd ${DOTFILES_PATH}/tooling/arnes && ${BREW_BIN}/cargo build --release
-	${DEPLOY_LINK} ${DOTFILES_PATH}/arnes/target/release/arnes ${DOTFILES_PATH}/tooling/arnes/target/release/arnes ${LOCAL_BIN}/arnes
+	${DEPLOY_LINK} ${DOTFILES_PATH}/tooling/arnes/target/release/arnes ${LOCAL_BIN}/arnes
 
 .PHONY: brain
 brain:
@@ -267,7 +267,7 @@ ${BREW_BIN}/bkt:
 .PHONY: daily-routine
 daily-routine: rust ${DEPLOY_LINK} | ${LOCAL_BIN} ~/.config/daily-routine/config.toml
 	cd ${DOTFILES_PATH}/tooling/daily-routine && ${BREW_BIN}/cargo build --release
-	${DEPLOY_LINK} ${DOTFILES_PATH}/daily-routine/target/release/daily-routine ${DOTFILES_PATH}/tooling/daily-routine/target/release/daily-routine ${LOCAL_BIN}/daily-routine
+	${DEPLOY_LINK} ${DOTFILES_PATH}/tooling/daily-routine/target/release/daily-routine ${LOCAL_BIN}/daily-routine
 ~/.config/daily-routine: | ~/.config
 	mkdir -p "$@"
 ~/.config/daily-routine/config.toml: | ~/.config/daily-routine ${DOTFILES_PATH}/tooling/daily-routine/config.example.toml
@@ -335,7 +335,7 @@ postgresql: brew ${BREW_GNU_BIN}/postgresql@16/bin/psql ~/.psqlrc
 ${BREW_GNU_BIN}/postgresql@16/bin/psql:
 	brew install postgresql@16
 ~/.psqlrc: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.psqlrc
-	${DEPLOY_LINK} ${DOTFILES_PATH}/.psqlrc ${DOTFILES_PATH}/home/.psqlrc $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.psqlrc $@
 
 .PHONY: renovate
 renovate: brew ${VOLTA_BIN}/renovate
@@ -387,17 +387,17 @@ ${LOCAL_BIN}/claude:
 ~/.claude:
 	mkdir -p $@
 ~/.claude/CLAUDE.md: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/harness/AGENTS.md | ~/.claude
-	${DEPLOY_LINK} ${DOTFILES_PATH}/ai/AGENTS.md ${DOTFILES_PATH}/harness/AGENTS.md $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/harness/AGENTS.md $@
 # Imported by AGENTS.md; linked as siblings so the @import resolves whether the
 # tool follows the symlink or reads it from the destination directory.
 ~/.claude/SOUL.md: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/harness/SOUL.md | ~/.claude
-	${DEPLOY_LINK} ${DOTFILES_PATH}/ai/SOUL.md ${DOTFILES_PATH}/harness/SOUL.md $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/harness/SOUL.md $@
 ~/.claude/USER.md: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/harness/USER.md | ~/.claude
-	${DEPLOY_LINK} ${DOTFILES_PATH}/ai/USER.md ${DOTFILES_PATH}/harness/USER.md $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/harness/USER.md $@
 ~/.claude/hooks ~/.claude/skills: | ~/.claude
 	mkdir -p $@
 ~/.claude/hooks/agent_handoff: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/tooling/agent-handoff | ~/.claude/hooks
-	${DEPLOY_LINK} ${DOTFILES_PATH}/scripts/agent_handoff ${DOTFILES_PATH}/tooling/agent-handoff $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/tooling/agent-handoff $@
 ~/.claude/skills/handoff: ${DOTFILES_PATH}/.agents/skills/handoff | ~/.claude/skills
 	ln -s ${DOTFILES_PATH}/.agents/skills/handoff $@
 ~/.claude/skills/enforcement-code: ${DOTFILES_PATH}/.agents/skills/enforcement-code | ~/.claude/skills
@@ -495,7 +495,7 @@ scrapling: docker ${LOCAL_BIN}/scrapling_mcp
 
 # MCP command for agents: starts the shared container on demand instead of one per session.
 ${LOCAL_BIN}/scrapling_mcp: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/tooling/scrapling-mcp | ${LOCAL_BIN}
-	${DEPLOY_LINK} ${DOTFILES_PATH}/scripts/scrapling_mcp ${DOTFILES_PATH}/tooling/scrapling-mcp $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/tooling/scrapling-mcp $@
 ${LOCAL_BIN}:
 	mkdir -p $@
 
@@ -690,13 +690,13 @@ ${BREW_BIN}/nvim: | ${VOLTA_BIN}/node
 	brew install neovim
 	${VOLTA_BIN}/npm install -g neovim
 ~/.config/nvim: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.config/nvim | ~/.config
-	${DEPLOY_LINK} ${DOTFILES_PATH}/nvim ${DOTFILES_PATH}/home/.config/nvim $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.config/nvim $@
 ~/cspell.json: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/cspell.json
-	${DEPLOY_LINK} ${DOTFILES_PATH}/cspell.json ${DOTFILES_PATH}/home/cspell.json $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/cspell.json $@
 ~/.config/cspell:
 	mkdir -p $@
 ~/.config/cspell/user.txt: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.config/cspell/user.txt | ~/.config/cspell
-	${DEPLOY_LINK} ${DOTFILES_PATH}/dict/user.txt ${DOTFILES_PATH}/home/.config/cspell/user.txt $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.config/cspell/user.txt $@
 
 .PHONY: font-jetbrains-mono
 font-jetbrains-mono: ~/Library/Fonts/JetBrainsMonoNLNerdFont-Regular.ttf
@@ -727,14 +727,14 @@ ${BREW_BIN}/zoxide:
 .PHONY: zsh
 zsh: ~/.zshrc
 ~/.zshrc: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.zshrc
-	${DEPLOY_LINK} ${DOTFILES_PATH}/.zshrc ${DOTFILES_PATH}/home/.zshrc $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.zshrc $@
 
 .PHONY: git-delta
 git-delta: brew ${BREW_BIN}/delta ~/.gitconfig.delta
 ${BREW_BIN}/delta:
 	brew install git-delta
 ~/.gitconfig.delta: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.gitconfig.delta
-	${DEPLOY_LINK} ${DOTFILES_PATH}/.gitconfig.delta ${DOTFILES_PATH}/home/.gitconfig.delta $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.gitconfig.delta $@
 	@if ! git config --global --get include.path | grep -q "\.gitconfig\.delta"; then \
 		git config --global include.path "~/.gitconfig.delta"; \
 		echo "Added include.path to ~/.gitconfig"; \
@@ -745,14 +745,14 @@ starship: brew ${BREW_BIN}/starship ~/.config/starship.toml
 ${BREW_BIN}/starship:
 	brew install starship
 ~/.config/starship.toml: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.config/starship.toml | ~/.config
-	${DEPLOY_LINK} ${DOTFILES_PATH}/.config/starship.toml ${DOTFILES_PATH}/home/.config/starship.toml $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.config/starship.toml $@
 
 .PHONY: tmux
 tmux: brew ${BREW_BIN}/tmux ~/.tmux.conf ~/.tmux/plugins/tpm/tpm
 ${BREW_BIN}/tmux:
 	brew install tmux
 ~/.tmux.conf: FORCE ${DEPLOY_LINK} ${DOTFILES_PATH}/home/.tmux.conf
-	${DEPLOY_LINK} ${DOTFILES_PATH}/tmux/.tmux.conf ${DOTFILES_PATH}/home/.tmux.conf $@
+	${DEPLOY_LINK} ${DOTFILES_PATH}/home/.tmux.conf $@
 ~/.tmux/plugins:
 	mkdir -p $@
 ~/.tmux/plugins/tpm/tpm: | ~/.tmux/plugins

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,9 +42,9 @@ Les points d'entrée restent à la racine :
 | `home/cspell.json`           | `~/cspell.json`           |
 
 Le `Makefile` déploie ces sources par liens symboliques. `tooling/deploy-link`
-crée une destination absente, conserve un lien déjà correct et migre seulement
-un lien vers l'ancienne source exacte. Il refuse tout fichier, répertoire ou
-lien inattendu afin de ne pas écraser de données locales.
+crée une destination absente et conserve un lien déjà correct. Il refuse tout
+fichier, répertoire ou lien inattendu afin de ne pas écraser de données
+locales.
 
 ## Intégrations d'agents
 
@@ -68,7 +68,7 @@ adaptateurs nécessaires à leur découverte.
 
 Les exécutables destinés au `PATH` sont liés depuis le `Makefile`, généralement
 sous `~/.local/bin`. `tooling/upgrade` met à jour le dépôt puis relance
-`make all`, ce qui applique aussi les migrations de chemins.
+`make all`, ce qui déploie les nouveaux chemins.
 
 ## Flux de changement
 

--- a/docs/adr/003-deploiement-par-symlinks.md
+++ b/docs/adr/003-deploiement-par-symlinks.md
@@ -18,11 +18,11 @@ instructions partagées et les exécutables suivent le même mécanisme depuis
 `harness/` et `tooling/` ([ADR-038](038-frontieres-home-harness-tooling.md)).
 L'édition se fait dans le dépôt, l'effet est immédiat.
 
-Une migration de source remplace une destination seulement si elle est absente
-ou si elle pointe textuellement vers l'ancienne source exacte. Un fichier, un
-répertoire ou tout autre lien fait échouer la cible sans modifier cette
-destination. La vérification est forcée par le `Makefile`, même lorsqu'un lien
-inattendu pointe vers une cible existante.
+Le déploiement crée une destination absente ou conserve un lien qui pointe
+textuellement vers la source exacte. Un fichier, un répertoire ou tout autre
+lien fait échouer la cible sans modifier cette destination. La vérification est
+forcée par le `Makefile`, même lorsqu'un lien inattendu pointe vers une cible
+existante.
 
 Une exception documentée : `~/.codex/AGENTS.md` est **assemblé** par
 concaténation à l'installation. Le commit `1772db9` en donne la raison —

--- a/docs/adr/023-ci-lint-et-installation.md
+++ b/docs/adr/023-ci-lint-et-installation.md
@@ -18,7 +18,7 @@ Fish sur macOS et Linux, le Lua Neovim, les scripts shell et le chargement de
 la configuration CSpell avec son dictionnaire. `test-fish.yml` exécute les
 tests Fish sur les deux systèmes lorsque les fichiers couverts changent.
 `test-rust.yml` vérifie le formatage, exécute Clippy et les tests de
-`tooling/daily-routine` sur macOS. `test-deployment.yml` attaque la migration
+`tooling/daily-routine` sur macOS. `test-deployment.yml` attaque le déploiement
 des liens sur macOS et Linux. Sur `main`, `test.yml` exécute deux fois
 l'installation par défaut sur un runner macOS. Sur une pull request,
 `ci-smoke-targets` repère les blocs `.PHONY` modifiés et les exécute sur des

--- a/docs/adr/038-frontieres-home-harness-tooling.md
+++ b/docs/adr/038-frontieres-home-harness-tooling.md
@@ -30,11 +30,10 @@ Les chemins imposés par un outil (`.agents/`, `.claude/`, `.codex/`,
 `.cursor/`, `.github/`) et les points d'entrée du dépôt (`AGENTS.md`,
 `CLAUDE.md`, `Makefile`, `README.md`, `install.sh`) restent à la racine.
 
-Les anciens liens sont migrés par le déploiement normal. Chaque destination
-absente est créée ; un lien textuellement égal à son ancienne source exacte
-est remplacé ; un fichier, un répertoire ou tout autre lien fait échouer la
-cible sans modifier cette destination. Aucun lien de compatibilité n'est
-conservé dans le dépôt.
+Le déploiement normal crée chaque destination absente et conserve un lien
+textuellement égal à sa source exacte. Un fichier, un répertoire ou tout autre
+lien fait échouer la cible sans modifier cette destination. Aucun lien de
+compatibilité n'est conservé dans le dépôt.
 
 ## Conséquences
 

--- a/tooling/deploy-link
+++ b/tooling/deploy-link
@@ -9,29 +9,55 @@ fi
 source=$1
 destination=$2
 
-for required_command in readlink ln; do
+link_points_to() {
+  local current_source
+  current_source=$(readlink -n "$1" && printf .) || return
+  current_source=${current_source%.}
+  [[ $current_source == "$2" ]]
+}
+
+for required_command in readlink perl; do
   if ! command -v "$required_command" >/dev/null; then
     echo "Error: $required_command is required to deploy $destination" >&2
     exit 1
   fi
 done
 
+if [[ $source != /* ]] || [[ $source == */ ]]; then
+  echo "Error: source must be an absolute path without a trailing slash: $source" >&2
+  exit 1
+fi
+
+if [[ $destination != /* ]] || [[ $destination == */ ]]; then
+  echo "Error: destination must be an absolute path without a trailing slash: $destination" >&2
+  exit 1
+fi
+
 if [[ ! -e $source ]]; then
   echo "Error: source does not exist: $source" >&2
   exit 1
 fi
 
+if [[ ! -f $source ]] && [[ ! -d $source ]]; then
+  echo "Error: source is not a regular file or directory: $source" >&2
+  exit 1
+fi
+
 if [[ -L $destination ]]; then
-  current_source=$(readlink "$destination")
-  if [[ $current_source == "$source" ]]; then
+  if link_points_to "$destination" "$source"; then
     exit 0
   fi
-  echo "Error: $destination links to unexpected source: $current_source" >&2
+  echo "Error: $destination links to an unexpected source" >&2
   exit 1
 elif [[ -e $destination ]]; then
   echo "Error: $destination exists and is not a symbolic link" >&2
   exit 1
-else
-  ln -s "$source" "$destination"
-  [[ -e $source ]] || { echo "Error: source disappeared while deploying $destination" >&2; exit 1; }
+fi
+
+if ! perl \
+  -e '(-f $ARGV[0] || -d $ARGV[0]) or die "source unavailable: $ARGV[0]\n";' \
+  -e 'symlink $ARGV[0], $ARGV[1] or die "could not create $ARGV[1]: $!\n"' \
+  -- "$source" "$destination"; then
+  echo "Error: could not create $destination" >&2
+  exit 1
 fi

--- a/tooling/deploy-link
+++ b/tooling/deploy-link
@@ -1,78 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 3 ]]; then
-  echo "Usage: deploy-link OLD_SOURCE NEW_SOURCE DESTINATION" >&2
+if [[ $# -ne 2 ]]; then
+  echo "Usage: deploy-link SOURCE DESTINATION" >&2
   exit 2
 fi
 
-old_source=$1
-new_source=$2
-destination=$3
+source=$1
+destination=$2
 
-for required_command in readlink ln mktemp mv rm rmdir; do
+for required_command in readlink ln; do
   if ! command -v "$required_command" >/dev/null; then
     echo "Error: $required_command is required to deploy $destination" >&2
     exit 1
   fi
 done
 
-if [[ ! -e $new_source ]]; then
-  echo "Error: source does not exist: $new_source" >&2
+if [[ ! -e $source ]]; then
+  echo "Error: source does not exist: $source" >&2
   exit 1
 fi
 
 if [[ -L $destination ]]; then
   current_source=$(readlink "$destination")
-  if [[ $current_source == "$new_source" ]]; then
+  if [[ $current_source == "$source" ]]; then
     exit 0
   fi
-  if [[ $current_source != "$old_source" ]]; then
-    echo "Error: $destination links to unexpected source: $current_source" >&2
-    exit 1
-  fi
+  echo "Error: $destination links to unexpected source: $current_source" >&2
+  exit 1
 elif [[ -e $destination ]]; then
   echo "Error: $destination exists and is not a symbolic link" >&2
   exit 1
 else
-  ln -s "$new_source" "$destination"
-  [[ -e $new_source ]] || { echo "Error: source disappeared while deploying $destination" >&2; exit 1; }
-  exit 0
+  ln -s "$source" "$destination"
+  [[ -e $source ]] || { echo "Error: source disappeared while deploying $destination" >&2; exit 1; }
 fi
-
-if [[ $destination == */* ]]; then
-  destination_parent=${destination%/*}
-else
-  destination_parent=.
-fi
-
-quarantine=$(mktemp -d "$destination_parent/.deploy-link.XXXXXX")
-previous=$quarantine/previous
-if ! mv "$destination" "$previous"; then
-  rmdir "$quarantine"
-  echo "Error: could not quarantine $destination" >&2
-  exit 1
-fi
-
-if [[ ! -L $previous ]] || [[ $(readlink "$previous") != "$old_source" ]]; then
-  echo "Error: $destination changed during deployment; recover it from $previous" >&2
-  exit 1
-fi
-
-if [[ ! -e $new_source ]]; then
-  echo "Error: source disappeared; recover the previous link from $previous" >&2
-  exit 1
-fi
-
-if ! ln -s "$new_source" "$destination"; then
-  echo "Error: could not create $destination; recover the previous link from $previous" >&2
-  exit 1
-fi
-
-if [[ ! -e $new_source ]]; then
-  echo "Error: source disappeared; recover the previous link from $previous" >&2
-  exit 1
-fi
-
-rm "$previous"
-rmdir "$quarantine"

--- a/tooling/deploy-link-adversarial-test
+++ b/tooling/deploy-link-adversarial-test
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tooling_dir=$(cd "$(dirname "$0")" && pwd)
+helper=$tooling_dir/deploy-link
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/deploy-link-adversarial-test.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_link() {
+  actual_source=$(readlink -n "$1" && printf .) || fail "$1 cannot be read"
+  actual_source=${actual_source%.}
+  [[ -L $1 ]] || fail "$1 is not a symbolic link"
+  [[ $actual_source == "$2" ]] || fail "$1 has an unexpected source"
+}
+
+assert_failure() {
+  if "$@" >"$test_root/stdout" 2>"$test_root/stderr"; then
+    fail "command unexpectedly succeeded: $*"
+  fi
+}
+
+new_case() {
+  case_root=$test_root/$1
+  source=$case_root/source
+  destination=$case_root/destination
+  mkdir -p "$source"
+}
+
+new_case relative_source
+(
+  cd "$case_root"
+  assert_failure "$helper" source "$destination"
+)
+[[ ! -e $destination && ! -L $destination ]] || fail "relative source created a destination"
+
+new_case relative_destination
+(
+  cd "$case_root"
+  assert_failure "$helper" "$source" destination
+)
+[[ ! -e $destination && ! -L $destination ]] || fail "relative destination was created"
+
+new_case newline_suffixed_link
+unexpected_source=${source}$'\n'
+ln -s "$unexpected_source" "$destination"
+assert_failure "$helper" "$source" "$destination"
+assert_link "$destination" "$unexpected_source"
+
+new_case unsupported_source
+rmdir "$source"
+mkfifo "$source"
+assert_failure "$helper" "$source" "$destination"
+[[ ! -e $destination && ! -L $destination ]] || fail "unsupported source created a destination"
+
+new_case concurrent_directory
+wrapper_dir=$case_root/bin
+mkdir "$wrapper_dir"
+printf '%s\n' '#!/usr/bin/env bash' '"$REAL_MKDIR" "$7"' '"$REAL_PERL" "$@"' >"$wrapper_dir/perl"
+chmod +x "$wrapper_dir/perl"
+assert_failure env REAL_MKDIR="$(command -v mkdir)" REAL_PERL="$(command -v perl)" PATH="$wrapper_dir:$PATH" "$helper" "$source" "$destination"
+[[ -d $destination && ! -L $destination ]] || fail "raced destination was not preserved"
+[[ -z $(find "$destination" -mindepth 1 -print -quit) ]] || fail "raced destination retained a nested link"
+
+new_case concurrent_directory_link
+actual_directory=$case_root/actual-directory
+mkdir "$actual_directory"
+wrapper_dir=$case_root/bin
+mkdir "$wrapper_dir"
+printf '%s\n' '#!/usr/bin/env bash' '"$REAL_LN" -s "$ACTUAL_DIRECTORY" "$7"' '"$REAL_PERL" "$@"' >"$wrapper_dir/perl"
+chmod +x "$wrapper_dir/perl"
+assert_failure env ACTUAL_DIRECTORY="$actual_directory" REAL_LN="$(command -v ln)" REAL_PERL="$(command -v perl)" PATH="$wrapper_dir:$PATH" "$helper" "$source" "$destination"
+assert_link "$destination" "$actual_directory"
+[[ -z $(find "$actual_directory" -mindepth 1 -print -quit) ]] || fail "raced directory link retained a nested link"
+
+new_case concurrent_file
+wrapper_dir=$case_root/bin
+mkdir "$wrapper_dir"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "valuable\n" >"$7"' '"$REAL_PERL" "$@"' >"$wrapper_dir/perl"
+chmod +x "$wrapper_dir/perl"
+assert_failure env REAL_PERL="$(command -v perl)" PATH="$wrapper_dir:$PATH" "$helper" "$source" "$destination"
+[[ -f $destination && ! -L $destination ]] || fail "raced file was not preserved"
+[[ $(cat "$destination") == valuable ]] || fail "raced file changed"
+
+new_case disappearing_source
+wrapper_dir=$case_root/bin
+mkdir "$wrapper_dir"
+printf '%s\n' '#!/usr/bin/env bash' '"$REAL_RMDIR" "$6"' '"$REAL_PERL" "$@"' >"$wrapper_dir/perl"
+chmod +x "$wrapper_dir/perl"
+assert_failure env REAL_PERL="$(command -v perl)" REAL_RMDIR="$(command -v rmdir)" PATH="$wrapper_dir:$PATH" "$helper" "$source" "$destination"
+[[ ! -e $source ]] || fail "source did not disappear"
+[[ ! -e $destination && ! -L $destination ]] || fail "disappearing source created a destination"
+
+echo "deploy-link adversarial tests passed"

--- a/tooling/deploy-link-test
+++ b/tooling/deploy-link-test
@@ -13,8 +13,10 @@ fail() {
 }
 
 assert_link() {
+  actual_source=$(readlink -n "$1" && printf .) || fail "$1 cannot be read"
+  actual_source=${actual_source%.}
   [[ -L $1 ]] || fail "$1 is not a symbolic link"
-  [[ $(readlink "$1") == "$2" ]] || fail "$1 has an unexpected source"
+  [[ $actual_source == "$2" ]] || fail "$1 has an unexpected source"
 }
 
 assert_failure() {
@@ -96,12 +98,12 @@ new_case missing_readlink
 assert_failure env PATH="$case_root/empty-path" /bin/bash "$helper" "$source" "$destination"
 grep -q 'readlink is required' "$test_root/stderr" || fail "missing readlink was not reported"
 
-new_case missing_ln
+new_case missing_perl
 wrapper_dir=$case_root/bin
 mkdir "$wrapper_dir"
 command ln -s "$(command -v readlink)" "$wrapper_dir/readlink"
 assert_failure env PATH="$wrapper_dir" /bin/bash "$helper" "$source" "$destination"
-grep -q 'ln is required' "$test_root/stderr" || fail "missing ln was not reported"
+grep -q 'perl is required' "$test_root/stderr" || fail "missing Perl was not reported"
 
 case_root=$test_root/make_starship_integration
 test_home=$case_root/home

--- a/tooling/deploy-link-test
+++ b/tooling/deploy-link-test
@@ -32,102 +32,76 @@ assert_hooks_failure_preserves() {
 
 new_case() {
   case_root=$test_root/$1
-  old_source=$case_root/old
-  new_source=$case_root/new
+  source=$case_root/source
   destination=$case_root/destination
-  mkdir -p "$old_source" "$new_source"
+  mkdir -p "$source"
 }
 
 new_case missing_destination
-"$helper" "$old_source" "$new_source" "$destination"
-assert_link "$destination" "$new_source"
+"$helper" "$source" "$destination"
+assert_link "$destination" "$source"
 
-new_case old_link
-ln -s "$old_source" "$destination"
-"$helper" "$old_source" "$new_source" "$destination"
-assert_link "$destination" "$new_source"
-
-new_case dangling_old_link
-rmdir "$old_source"
-ln -s "$old_source" "$destination"
-"$helper" "$old_source" "$new_source" "$destination"
-assert_link "$destination" "$new_source"
+new_case legacy_interface
+assert_failure "$helper" "$source" "$source" "$destination"
+grep -q 'Usage: deploy-link SOURCE DESTINATION' "$test_root/stderr" || fail "legacy interface was accepted"
 
 new_case current_link
-ln -s "$new_source" "$destination"
+ln -s "$source" "$destination"
 before=$(ls -di "$destination" | awk '{print $1}')
-"$helper" "$old_source" "$new_source" "$destination"
+"$helper" "$source" "$destination"
 after=$(ls -di "$destination" | awk '{print $1}')
 [[ $before == "$after" ]] || fail "current link was replaced"
 
 new_case regular_file
 printf 'keep\n' >"$destination"
-assert_failure "$helper" "$old_source" "$new_source" "$destination"
+assert_failure "$helper" "$source" "$destination"
 [[ $(cat "$destination") == keep ]] || fail "regular file changed"
 
 new_case directory
 mkdir "$destination"
-assert_failure "$helper" "$old_source" "$new_source" "$destination"
+assert_failure "$helper" "$source" "$destination"
 [[ -d $destination && ! -L $destination ]] || fail "directory changed"
 
 new_case unexpected_link
 unexpected_source=$case_root/unexpected
 mkdir "$unexpected_source"
 ln -s "$unexpected_source" "$destination"
-assert_failure "$helper" "$old_source" "$new_source" "$destination"
+assert_failure "$helper" "$source" "$destination"
 assert_link "$destination" "$unexpected_source"
 
 new_case dangling_unexpected_link
 unexpected_source=$case_root/unexpected
 ln -s "$unexpected_source" "$destination"
-assert_failure "$helper" "$old_source" "$new_source" "$destination"
+assert_failure "$helper" "$source" "$destination"
 assert_link "$destination" "$unexpected_source"
 
 new_case relative_equivalent_link
-ln -s old "$destination"
-assert_failure "$helper" "$old_source" "$new_source" "$destination"
-assert_link "$destination" old
+ln -s source "$destination"
+assert_failure "$helper" "$source" "$destination"
+assert_link "$destination" source
 
-new_case missing_new_source
-rmdir "$new_source"
-ln -s "$old_source" "$destination"
-assert_failure "$helper" "$old_source" "$new_source" "$destination"
-assert_link "$destination" "$old_source"
-
-new_case concurrent_destination_change
-ln -s "$old_source" "$destination"
-wrapper_dir=$case_root/bin
-mkdir "$wrapper_dir"
-printf '%s\n' '#!/usr/bin/env bash' 'target=$(/usr/bin/readlink "$1")' 'PATH=/usr/bin:/bin unlink "$1"' 'printf "valuable\n" >"$1"' 'printf "%s\n" "$target"' >"$wrapper_dir/readlink"
-chmod +x "$wrapper_dir/readlink"
-assert_failure env PATH="$wrapper_dir:$PATH" "$helper" "$old_source" "$new_source" "$destination"
-recovered_entries=("$case_root"/.deploy-link.*/previous)
-[[ -f ${recovered_entries[0]} ]] || fail "raced destination was not preserved"
-[[ $(cat "${recovered_entries[0]}") == valuable ]] || fail "raced destination content changed"
-
-new_case disappearing_source
-ln -s "$old_source" "$destination"
-wrapper_dir=$case_root/bin
-mkdir "$wrapper_dir"
-real_ln=$(command -v ln)
-printf '%s\n' '#!/usr/bin/env bash' 'rmdir "$2"' '"$REAL_LN" "$@"' >"$wrapper_dir/ln"
-chmod +x "$wrapper_dir/ln"
-assert_failure env REAL_LN="$real_ln" PATH="$wrapper_dir:$PATH" "$helper" "$old_source" "$new_source" "$destination"
-assert_link "$destination" "$new_source"
-recovered_entries=("$case_root"/.deploy-link.*/previous)
-assert_link "${recovered_entries[0]}" "$old_source"
+new_case missing_source
+rmdir "$source"
+assert_failure "$helper" "$source" "$destination"
+[[ ! -e $destination && ! -L $destination ]] || fail "missing source created a destination"
 
 case_root="$test_root/paths with spaces"
-old_source="$case_root/old source"
-new_source="$case_root/new source"
+source="$case_root/source directory"
 destination="$case_root/destination link"
-mkdir -p "$old_source" "$new_source"
-"$helper" "$old_source" "$new_source" "$destination"
-assert_link "$destination" "$new_source"
+mkdir -p "$source"
+"$helper" "$source" "$destination"
+assert_link "$destination" "$source"
 
 new_case missing_readlink
-assert_failure env PATH="$case_root/empty-path" /bin/bash "$helper" "$old_source" "$new_source" "$destination"
+assert_failure env PATH="$case_root/empty-path" /bin/bash "$helper" "$source" "$destination"
 grep -q 'readlink is required' "$test_root/stderr" || fail "missing readlink was not reported"
+
+new_case missing_ln
+wrapper_dir=$case_root/bin
+mkdir "$wrapper_dir"
+command ln -s "$(command -v readlink)" "$wrapper_dir/readlink"
+assert_failure env PATH="$wrapper_dir" /bin/bash "$helper" "$source" "$destination"
+grep -q 'ln is required' "$test_root/stderr" || fail "missing ln was not reported"
 
 case_root=$test_root/make_starship_integration
 test_home=$case_root/home
@@ -146,10 +120,6 @@ printf '%s\n' '#!/usr/bin/env bash' ': >"$LN_MARKER"' '"$REAL_LN" "$@"' >"$case_
 chmod +x "$case_root/bin/ln"
 env HOME="$test_home" REAL_LN="$(command -v ln)" LN_MARKER="$case_root/ln-called" PATH="$case_root/bin:$PATH" make -f "$repository/Makefile" DOTFILES_PATH="$repository" "$starship_destination"
 [[ ! -e $case_root/ln-called ]] || fail "Make relinked the current Starship destination"
-assert_link "$starship_destination" "$repository/home/.config/starship.toml"
-rm "$starship_destination"
-ln -s "$repository/.config/starship.toml" "$starship_destination"
-env HOME="$test_home" make -f "$repository/Makefile" DOTFILES_PATH="$repository" "$starship_destination"
 assert_link "$starship_destination" "$repository/home/.config/starship.toml"
 rm "$starship_destination"
 unexpected_source=$case_root/unexpected

--- a/tooling/fish-deployment-test
+++ b/tooling/fish-deployment-test
@@ -9,7 +9,6 @@ trap 'rm -rf "$test_root"' EXIT
 test_home=$test_root/home
 test_repository=$test_root/repository
 fake_bin=$test_root/bin
-old_config=$test_repository/fish
 new_config=$test_repository/home/.config/fish
 bindings=$test_home/.config/fish/functions/fzf_configure_bindings.fish
 marker=$test_root/fish-called
@@ -21,10 +20,8 @@ assert_failure() {
   fi
 }
 
-mkdir -p "$test_home/.config" "$old_config/functions" "$new_config" "$test_repository/tooling" "$fake_bin"
+mkdir -p "$test_home/.config" "$new_config" "$test_repository/tooling" "$fake_bin"
 cp "$repository/tooling/deploy-link" "$test_repository/tooling/deploy-link"
-touch "$old_config/functions/fzf_configure_bindings.fish"
-ln -s "$old_config" "$test_home/.config/fish"
 printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' "printf \"%s\\n\" \"\$*\" >\"\$FISH_MARKER\"" "mkdir -p \"\$HOME/.config/fish/functions\"" ": >\"\$HOME/.config/fish/functions/fzf_configure_bindings.fish\"" >"$fake_bin/fish"
 chmod +x "$fake_bin/fish"
 
@@ -32,7 +29,6 @@ env HOME="$test_home" FISH_MARKER="$marker" make -f "$repository/Makefile" DOTFI
 
 [[ $(readlink "$test_home/.config/fish") == "$new_config" ]]
 [[ -f $bindings ]]
-[[ -f $old_config/functions/fzf_configure_bindings.fish ]]
 [[ $(cat "$marker") == "-c fisher install PatrickF1/fzf.fish" ]]
 
 rm "$marker"


### PR DESCRIPTION
## Description

- Removes the completed repository-layout symlink migration and the legacy `OLD_SOURCE` argument from all 18 Make recipes.
- Keeps deployment idempotent and fail-closed for unexpected destinations; link creation now uses the atomic `symlink(2)` syscall to avoid following a concurrently-created directory.
- Aligns active architecture documentation and adds a dedicated adversarial deployment suite on macOS and Ubuntu.

## Interaction

- #132 still uses the three-argument helper API and will need its deployment calls adapted when rebased, depending on merge order.
- A source can intrinsically disappear after validation or after the helper returns unless every source mutation shares a lock; destination creation remains atomic and never overwrites an existing path.

## Verification

- macOS 15 / Bash 3.2: `bash -n`, `tooling/deploy-link-test`, and `tooling/deploy-link-adversarial-test` pass.
- macOS 15 / Docker: ShellCheck `stable` passes at severity `error` for all three scripts.
- Linux / `rust:latest` container: `tooling/deploy-link-adversarial-test` passes; GitHub Actions covers the full Ubuntu deployment suite.
- macOS 15: all 18 changed Make targets pass `make -n` with an isolated `HOME`.
- The 250-line review trigger is satisfied by splitting adversarial cases into a cohesive test executable. The canonical `Makefile` remains intact because ADR-038 explicitly keeps installation in one file.

## Comments added

- None.