### PR TITLE
feat(arnes): audit external skills and plugins

### DIFF
--- a/docs/arnes-capacites-externes.md
+++ b/docs/arnes-capacites-externes.md
@@ -19,6 +19,8 @@ Une autorisation permet une capacité, elle ne la rend pas obligatoire. Son abse
 aucun drift. La propriété reste `external`, même pour une capacité autorisée. Les diagnostics
 conservent le schéma partagé `resource/state/message` et exposent dans le message l'origine, le
 conteneur, la version, l'exposition, la topologie, la politique et la limite d'observation runtime.
+La sortie humaine regroupe et abrège ces dimensions ; `--format json` conserve le diagnostic
+exhaustif, notamment les chemins sains omis de la vue humaine.
 
 ## Codex
 

--- a/docs/arnes-capacites-externes.md
+++ b/docs/arnes-capacites-externes.md
@@ -1,0 +1,85 @@
+# Audit Arnes des skills et plugins externes
+
+`arnes doctor skills` inventorie des capacités durablement disponibles ou exposées. Il ne déduit
+ni leur activation pendant une session, ni les tokens réellement consommés. La divulgation
+progressive de Codex charge d'abord le nom, la description et le chemin, puis le `SKILL.md` complet
+seulement lorsque le skill est sélectionné. Cette liste initiale est bornée à 2 % de la fenêtre de
+contexte ou 8 000 caractères lorsque la fenêtre est inconnue.
+
+Le manifest `.arnes.yaml` sépare trois déclarations :
+
+- `external.roots` borne chaque racine de skills système effectivement auditée ;
+- `external.plugins` autorise l'identifiant stable d'un plugin sans autoriser ses futurs skills ;
+- `external.skills` autorise un slug système ou un slug fourni par un plugin déjà autorisé.
+
+Une autorisation permet une capacité, elle ne la rend pas obligatoire. Son absence ne crée donc
+aucun drift. La propriété reste `external`, même pour une capacité autorisée. Les diagnostics
+conservent le schéma partagé `resource/state/message` et exposent dans le message l'origine, le
+conteneur, la version, l'exposition, la topologie, la politique et la limite d'observation runtime.
+
+## Codex
+
+La documentation officielle définit les racines repository `.agents/skills` du répertoire courant
+jusqu'à la racine Git, `$HOME/.agents/skills`, `/etc/codex/skills` et des skills `SYSTEM` embarqués,
+sans chemin physique public pour ces derniers. Elle définit aussi `[[skills.config]]` dans
+`~/.codex/config.toml` pour désactiver un skill par chemin.
+
+Le chemin `~/.codex/skills/.system` utilisé dans le manifest de ce dépôt est un contrat
+d'implémentation local explicite, pas une convention Codex universelle. Arnes peut donc auditer
+`openai-docs` sous cette racine sans transformer une observation de HOME en table Rust. Une autre
+installation doit déclarer sa propre racine stable ou accepter un diagnostic `unsupported`.
+
+Les plugins ont une identité `.codex-plugin/plugin.json`, un état on/off dans
+`~/.codex/config.toml` et un cache versionné sous
+`~/.codex/plugins/cache/$MARKETPLACE/$PLUGIN/$VERSION`. La configuration publique ne désigne pas la
+version active du cache. Arnes rapporte donc l'état observable du plugin, mais garde sa topologie et
+ses skills `unsupported` au lieu de choisir arbitrairement une version ou d'énumérer les caches.
+
+Sources : [Build skills](https://learn.chatgpt.com/docs/build-skills),
+[Plugins](https://learn.chatgpt.com/docs/plugins),
+[Package your plugin](https://developers.openai.com/plugins/build/plugins).
+
+## Claude Code
+
+L'état durable combine les installations et `enabledPlugins`. Les réglages user, project et local
+sont lus depuis leurs fichiers documentés ; le réglage le plus proche du projet prévaut dans le
+périmètre observable par un doctor lancé dans ce projet. Les réglages managed, serveur ou MDM ne
+sont pas déduits depuis HOME.
+
+L'interface officiellement supportée pour l'inventaire est `claude plugin list --json`. Le schéma
+statique de `~/.claude/plugins/installed_plugins.json` n'est pas publié. Arnes reconnaît seulement la
+version 2 observée par l'installation couverte par cette slice ; toute autre version devient
+`unsupported`. Le registre sélectionne l'unique `installPath` effectif. Les anciennes versions du
+cache et les market places connues ne sont jamais prises pour des plugins actifs.
+
+Un plugin de skills-directory est reconnu par `.claude-plugin/plugin.json` directement sous une
+racine `.claude/skills`; il porte l'identité `<name>@skills-dir`. Il n'est pas aussi rapporté comme
+skill standalone unmanaged. Les skills externes ne passent jamais par les contrôles qualitatifs ou
+de ressources locales réservés aux skills possédés par Arnes.
+
+Sources : [Settings](https://code.claude.com/docs/en/settings),
+[Plugins reference](https://code.claude.com/docs/en/plugins-reference),
+[Discover plugins](https://code.claude.com/docs/en/discover-plugins).
+
+## Cursor
+
+Cursor documente les skills builtin et plusieurs racines de skills locales, mais aucun chemin
+filesystem stable pour les builtins. Il documente le chargement de plugins de développement sous
+`~/.cursor/plugins/local/<plugin>` ; Arnes audite uniquement cette racine explicite.
+
+Customize reste l'interface officielle des plugins marketplace installés. Aucun registre
+filesystem stable ne publie leur activation, et `workspaceOpen` peut produire des chemins
+dynamiquement. Les plugins marketplace, extensions, builtins et capacités dynamiques sont donc
+`unsupported` plutôt que déduits depuis un cache ou exécutés par le doctor.
+
+Sources : [Skills](https://cursor.com/docs/skills),
+[Plugins](https://cursor.com/docs/plugins),
+[Plugin reference](https://cursor.com/docs/reference/plugins).
+
+## Frontières de lecture
+
+Chaque scan part d'une racine déclarée, d'un registre installé ou d'une configuration effectivement
+lue par l'agent. Les symlinks absolus et relatifs sont acceptés seulement si leur cible canonique
+reste dans cette racine. Un lien pendant ou une sortie par un composant intermédiaire est rapporté
+sans être traversé. `doctor` n'appelle aucun gestionnaire de plugin, n'analyse aucun cache orphelin,
+ne charge aucune capacité et ne modifie ni le repository ni HOME.

--- a/docs/arnes-capacites-externes.md
+++ b/docs/arnes-capacites-externes.md
@@ -10,7 +10,10 @@ Le manifest `.arnes.yaml` sépare trois déclarations :
 
 - `external.roots` borne chaque racine de skills système effectivement auditée ;
 - `external.plugins` autorise l'identifiant stable d'un plugin sans autoriser ses futurs skills ;
-- `external.skills` autorise un slug système ou un slug fourni par un plugin déjà autorisé.
+- `external.skills` autorise un slug standalone, système ou fourni par un plugin déjà autorisé.
+
+L'origine `managed` désigne un skill standalone géré hors d'Arnes mais déjà exposé dans une racine
+de projection. Cette autorisation ne l'adopte pas et ne déclenche aucun contrôle qualitatif.
 
 Une autorisation permet une capacité, elle ne la rend pas obligatoire. Son absence ne crée donc
 aucun drift. La propriété reste `external`, même pour une capacité autorisée. Les diagnostics

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -27,7 +27,10 @@ external:
       scope: user
       origin: system
       location: { root: home, path: .codex/skills/.system }
-  plugins: []
+  plugins:
+    - agent: claude
+      scope: user
+      id: superpowers@claude-plugins-official
   skills:
     - agent: claude
       scope: user
@@ -65,6 +68,76 @@ external:
       scope: user
       origin: system
       slug: openai-docs
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: brainstorming
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: dispatching-parallel-agents
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: executing-plans
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: finishing-a-development-branch
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: receiving-code-review
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: requesting-code-review
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: subagent-driven-development
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: systematic-debugging
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: test-driven-development
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: using-git-worktrees
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: using-superpowers
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: verification-before-completion
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: writing-plans
+    - agent: claude
+      scope: user
+      origin: plugin
+      plugin: superpowers@claude-plugins-official
+      slug: writing-skills
 resources:
   - id: claude-user-instructions
     kind: instructions

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -29,6 +29,10 @@ external:
       location: { root: home, path: .codex/skills/.system }
   plugins: []
   skills:
+    - agent: claude
+      scope: user
+      origin: managed
+      slug: ponytail
     - agent: codex
       scope: user
       origin: managed

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -33,10 +33,34 @@ external:
       scope: user
       origin: managed
       slug: ponytail
+    - agent: claude
+      scope: user
+      origin: managed
+      slug: ponytail-audit
+    - agent: claude
+      scope: user
+      origin: managed
+      slug: ponytail-debt
+    - agent: claude
+      scope: user
+      origin: managed
+      slug: ponytail-gain
+    - agent: claude
+      scope: user
+      origin: managed
+      slug: ponytail-help
+    - agent: claude
+      scope: user
+      origin: managed
+      slug: ponytail-review
     - agent: codex
       scope: user
       origin: managed
       slug: ponytail
+    - agent: codex
+      scope: user
+      origin: managed
+      slug: ponytail-help
     - agent: codex
       scope: user
       origin: system

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -31,6 +31,10 @@ external:
   skills:
     - agent: codex
       scope: user
+      origin: managed
+      slug: ponytail
+    - agent: codex
+      scope: user
       origin: system
       slug: openai-docs
 resources:

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -21,6 +21,18 @@ skills:
       - { agent: claude, scope: user }
       - { agent: cursor, scope: user }
       - { agent: codex, scope: user }
+external:
+  roots:
+    - agent: codex
+      scope: user
+      origin: system
+      location: { root: home, path: .codex/skills/.system }
+  plugins: []
+  skills:
+    - agent: codex
+      scope: user
+      origin: system
+      slug: openai-docs
 resources:
   - id: claude-user-instructions
     kind: instructions

--- a/tooling/arnes/src/diagnostic.rs
+++ b/tooling/arnes/src/diagnostic.rs
@@ -26,6 +26,14 @@ pub struct Diagnostic {
     pub resource: String,
     pub state: State,
     pub message: String,
+    #[serde(skip)]
+    human: Option<HumanDiagnostic>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct HumanDiagnostic {
+    group: String,
+    summary: String,
 }
 
 impl Diagnostic {
@@ -34,7 +42,16 @@ impl Diagnostic {
             resource: resource.into(),
             state,
             message: message.into(),
+            human: None,
         }
+    }
+
+    pub fn with_human(mut self, group: impl Into<String>, summary: impl Into<String>) -> Self {
+        self.human = Some(HumanDiagnostic {
+            group: group.into(),
+            summary: summary.into(),
+        });
+        self
     }
 }
 
@@ -81,11 +98,28 @@ impl Report {
     }
 
     pub fn human(&self) -> String {
-        self.diagnostics
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join("\n")
+        let mut lines = Vec::new();
+        let mut group = None;
+        for diagnostic in &self.diagnostics {
+            if let Some(human) = &diagnostic.human {
+                if group != Some(human.group.as_str()) {
+                    if !lines.is_empty() {
+                        lines.push(String::new());
+                    }
+                    lines.push(human.group.clone());
+                    group = Some(&human.group);
+                }
+                lines.push(format!(
+                    "  {:11} {}",
+                    diagnostic.state.to_string(),
+                    human.summary
+                ));
+            } else {
+                group = None;
+                lines.push(diagnostic.to_string());
+            }
+        }
+        lines.join("\n")
     }
 
     pub fn json(&self) -> Result<String, serde_json::Error> {

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -1,11 +1,14 @@
 use clap::ValueEnum;
 use serde::Deserialize;
-use serde_yaml_ng::Value;
 use std::fmt::{self, Display};
-use std::fs;
 use std::path::{Path, PathBuf};
 
+mod external;
+mod parsing;
 mod validation;
+
+pub use external::{ExternalOrigin, ExternalRoot, ExternalSkill};
+pub use parsing::{load, parse};
 
 const MANIFEST_FILE: &str = ".arnes.yaml";
 const SCHEMA_VERSION: u64 = 1;
@@ -41,6 +44,8 @@ pub struct Manifest {
     agents: Vec<AgentDeclaration>,
     #[serde(default)]
     skills: Vec<SkillDeclaration>,
+    #[serde(default)]
+    external: external::ExternalPolicy,
     resources: Vec<ResourceDeclaration>,
 }
 
@@ -91,6 +96,22 @@ impl Manifest {
 
     pub fn declared_skills(&self) -> impl Iterator<Item = &str> {
         self.skills.iter().map(|skill| skill.slug.as_str())
+    }
+
+    pub fn external_roots(&self) -> impl Iterator<Item = ExternalRoot<'_>> {
+        self.external.roots()
+    }
+
+    pub fn external_plugins(&self, agent: Agent, scope: Scope) -> impl Iterator<Item = &str> {
+        self.external.plugins(agent, scope)
+    }
+
+    pub fn external_skills(
+        &self,
+        agent: Agent,
+        scope: Scope,
+    ) -> impl Iterator<Item = ExternalSkill<'_>> {
+        self.external.skills(agent, scope)
     }
 }
 
@@ -194,41 +215,4 @@ enum ResourceKind {
     Hooks,
     Mcp,
     Statusline,
-}
-
-pub fn load(home: &Path) -> Result<Manifest, ManifestError> {
-    let manifest = fs::read_to_string(home.join(MANIFEST_FILE)).map_err(|error| {
-        let reason = match error.kind() {
-            std::io::ErrorKind::NotFound => format!("{MANIFEST_FILE} was not found"),
-            _ => format!("could not read {MANIFEST_FILE}"),
-        };
-        ManifestError::new("manifest", reason)
-    })?;
-
-    parse(&manifest)
-}
-
-pub fn parse(input: &str) -> Result<Manifest, ManifestError> {
-    let value: Value = serde_yaml_ng::from_str(input)
-        .map_err(|error| ManifestError::new("manifest", error.to_string()))?;
-    validation::validate_value(&value)?;
-
-    if let Some(field) = validation::secret_field(&value, "") {
-        return Err(ManifestError::new(field, "secret values are not allowed"));
-    }
-
-    let deserializer = serde_yaml_ng::Deserializer::from_str(input);
-    let manifest: Manifest = serde_path_to_error::deserialize(deserializer).map_err(|error| {
-        let field = error.path().to_string();
-        ManifestError::new(
-            if field.is_empty() || field == "." {
-                "manifest"
-            } else {
-                &field
-            },
-            error.into_inner().to_string(),
-        )
-    })?;
-    validation::validate(&manifest)?;
-    Ok(manifest)
 }

--- a/tooling/arnes/src/manifest/external.rs
+++ b/tooling/arnes/src/manifest/external.rs
@@ -77,6 +77,7 @@ pub(super) struct ExternalSkillDeclaration {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ExternalOrigin {
+    Managed,
     System,
     Plugin,
 }
@@ -84,6 +85,7 @@ pub enum ExternalOrigin {
 impl Display for ExternalOrigin {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
+            Self::Managed => "managed",
             Self::System => "system",
             Self::Plugin => "plugin",
         })

--- a/tooling/arnes/src/manifest/external.rs
+++ b/tooling/arnes/src/manifest/external.rs
@@ -1,0 +1,106 @@
+use super::{Agent, RootedPath, Scope};
+use serde::Deserialize;
+use std::fmt::{self, Display};
+use std::path::Path;
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ExternalPolicy {
+    #[serde(default)]
+    pub(super) roots: Vec<ExternalRootDeclaration>,
+    #[serde(default)]
+    pub(super) plugins: Vec<ExternalPluginDeclaration>,
+    #[serde(default)]
+    pub(super) skills: Vec<ExternalSkillDeclaration>,
+}
+
+impl ExternalPolicy {
+    pub(super) fn roots(&self) -> impl Iterator<Item = ExternalRoot<'_>> {
+        self.roots.iter().map(|root| ExternalRoot {
+            agent: root.agent,
+            scope: root.scope,
+            origin: root.origin,
+            path: &root.location.path,
+        })
+    }
+
+    pub(super) fn plugins(&self, agent: Agent, scope: Scope) -> impl Iterator<Item = &str> {
+        self.plugins
+            .iter()
+            .filter(move |plugin| plugin.agent == agent && plugin.scope == scope)
+            .map(|plugin| plugin.id.as_str())
+    }
+
+    pub(super) fn skills(
+        &self,
+        agent: Agent,
+        scope: Scope,
+    ) -> impl Iterator<Item = ExternalSkill<'_>> {
+        self.skills
+            .iter()
+            .filter(move |skill| skill.agent == agent && skill.scope == scope)
+            .map(|skill| ExternalSkill {
+                origin: skill.origin,
+                plugin: skill.plugin.as_deref(),
+                slug: &skill.slug,
+            })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ExternalRootDeclaration {
+    pub(super) agent: Agent,
+    pub(super) scope: Scope,
+    pub(super) origin: ExternalOrigin,
+    pub(super) location: RootedPath,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ExternalPluginDeclaration {
+    pub(super) agent: Agent,
+    pub(super) scope: Scope,
+    pub(super) id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ExternalSkillDeclaration {
+    pub(super) agent: Agent,
+    pub(super) scope: Scope,
+    pub(super) origin: ExternalOrigin,
+    pub(super) plugin: Option<String>,
+    pub(super) slug: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExternalOrigin {
+    System,
+    Plugin,
+}
+
+impl Display for ExternalOrigin {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::System => "system",
+            Self::Plugin => "plugin",
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ExternalRoot<'a> {
+    pub agent: Agent,
+    pub scope: Scope,
+    pub origin: ExternalOrigin,
+    pub path: &'a Path,
+}
+
+#[derive(Clone, Copy)]
+pub struct ExternalSkill<'a> {
+    pub origin: ExternalOrigin,
+    pub plugin: Option<&'a str>,
+    pub slug: &'a str,
+}

--- a/tooling/arnes/src/manifest/parsing.rs
+++ b/tooling/arnes/src/manifest/parsing.rs
@@ -1,0 +1,38 @@
+use super::{MANIFEST_FILE, Manifest, ManifestError, validation};
+use serde_yaml_ng::Value;
+use std::fs;
+use std::path::Path;
+
+pub fn load(home: &Path) -> Result<Manifest, ManifestError> {
+    let manifest = fs::read_to_string(home.join(MANIFEST_FILE)).map_err(|error| {
+        let reason = match error.kind() {
+            std::io::ErrorKind::NotFound => format!("{MANIFEST_FILE} was not found"),
+            _ => format!("could not read {MANIFEST_FILE}"),
+        };
+        ManifestError::new("manifest", reason)
+    })?;
+    parse(&manifest)
+}
+
+pub fn parse(input: &str) -> Result<Manifest, ManifestError> {
+    let value: Value = serde_yaml_ng::from_str(input)
+        .map_err(|error| ManifestError::new("manifest", error.to_string()))?;
+    validation::validate_value(&value)?;
+    if let Some(field) = validation::secret_field(&value, "") {
+        return Err(ManifestError::new(field, "secret values are not allowed"));
+    }
+    let deserializer = serde_yaml_ng::Deserializer::from_str(input);
+    let manifest: Manifest = serde_path_to_error::deserialize(deserializer).map_err(|error| {
+        let field = error.path().to_string();
+        ManifestError::new(
+            if field.is_empty() || field == "." {
+                "manifest"
+            } else {
+                &field
+            },
+            error.into_inner().to_string(),
+        )
+    })?;
+    validation::validate(&manifest)?;
+    Ok(manifest)
+}

--- a/tooling/arnes/src/manifest/validation.rs
+++ b/tooling/arnes/src/manifest/validation.rs
@@ -3,6 +3,7 @@ use serde_yaml_ng::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path};
 
+mod external;
 mod skills;
 
 pub(super) fn validate_value(value: &Value) -> Result<(), ManifestError> {
@@ -75,7 +76,8 @@ pub(super) fn validate(manifest: &Manifest) -> Result<(), ManifestError> {
     }
 
     validate_resources(&manifest.resources, &agents)?;
-    skills::validate(&manifest.skills, &manifest.resources, &agents)
+    skills::validate(&manifest.skills, &manifest.resources, &agents)?;
+    external::validate(&manifest.external, &agents)
 }
 
 fn validate_resources(
@@ -181,7 +183,7 @@ fn validate_resource_paths(
     Ok(())
 }
 
-fn validate_path(field: &str, path: &Path) -> Result<(), ManifestError> {
+pub(super) fn validate_path(field: &str, path: &Path) -> Result<(), ManifestError> {
     if path.as_os_str().is_empty() {
         return Err(ManifestError::new(field, "path cannot be empty"));
     }

--- a/tooling/arnes/src/manifest/validation/external.rs
+++ b/tooling/arnes/src/manifest/validation/external.rs
@@ -76,6 +76,13 @@ fn validate_skills(
         validate_target(&field, skill.agent, skill.scope, agents)?;
         super::skills::validate_slug(&field("slug"), &skill.slug)?;
         match (skill.origin, skill.plugin.as_deref()) {
+            (ExternalOrigin::Managed, None) => {}
+            (ExternalOrigin::Managed, Some(_)) => {
+                return Err(ManifestError::new(
+                    field("plugin"),
+                    "managed external skills cannot name a plugin",
+                ));
+            }
             (ExternalOrigin::System, None) => {}
             (ExternalOrigin::System, Some(_)) => {
                 return Err(ManifestError::new(

--- a/tooling/arnes/src/manifest/validation/external.rs
+++ b/tooling/arnes/src/manifest/validation/external.rs
@@ -1,0 +1,135 @@
+use super::super::external::{
+    ExternalOrigin, ExternalPluginDeclaration, ExternalPolicy, ExternalRootDeclaration,
+    ExternalSkillDeclaration,
+};
+use super::super::{Agent, ManifestError, PathRoot, Scope};
+use std::collections::{HashMap, HashSet};
+
+pub(super) fn validate(
+    external: &ExternalPolicy,
+    agents: &HashMap<Agent, HashSet<Scope>>,
+) -> Result<(), ManifestError> {
+    validate_roots(&external.roots, agents)?;
+    let plugins = validate_plugins(&external.plugins, agents)?;
+    validate_skills(&external.skills, agents, &plugins)
+}
+
+fn validate_roots(
+    roots: &[ExternalRootDeclaration],
+    agents: &HashMap<Agent, HashSet<Scope>>,
+) -> Result<(), ManifestError> {
+    let mut declarations = HashSet::new();
+    for (index, root) in roots.iter().enumerate() {
+        let field = |name: &str| format!("external.roots[{index}].{name}");
+        validate_target(&field, root.agent, root.scope, agents)?;
+        if root.origin != ExternalOrigin::System {
+            return Err(ManifestError::new(
+                field("origin"),
+                "external roots only support system skills",
+            ));
+        }
+        super::validate_path(&field("location.path"), &root.location.path)?;
+        let expected = match root.scope {
+            Scope::User => PathRoot::Home,
+            Scope::Project => PathRoot::Repository,
+        };
+        if root.location.root != expected {
+            return Err(ManifestError::new(
+                field("location.root"),
+                "location root is incompatible with external scope",
+            ));
+        }
+        if !declarations.insert((root.agent, root.scope, root.origin, root.location.clone())) {
+            return Err(ManifestError::new(
+                field("location"),
+                "duplicate external root",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_plugins(
+    plugins: &[ExternalPluginDeclaration],
+    agents: &HashMap<Agent, HashSet<Scope>>,
+) -> Result<HashSet<(Agent, Scope, String)>, ManifestError> {
+    let mut declarations = HashSet::new();
+    for (index, plugin) in plugins.iter().enumerate() {
+        let field = |name: &str| format!("external.plugins[{index}].{name}");
+        validate_target(&field, plugin.agent, plugin.scope, agents)?;
+        super::skills::validate_slug(&field("id"), &plugin.id)?;
+        if !declarations.insert((plugin.agent, plugin.scope, plugin.id.clone())) {
+            return Err(ManifestError::new(field("id"), "duplicate external plugin"));
+        }
+    }
+    Ok(declarations)
+}
+
+fn validate_skills(
+    skills: &[ExternalSkillDeclaration],
+    agents: &HashMap<Agent, HashSet<Scope>>,
+    plugins: &HashSet<(Agent, Scope, String)>,
+) -> Result<(), ManifestError> {
+    let mut declarations = HashSet::new();
+    for (index, skill) in skills.iter().enumerate() {
+        let field = |name: &str| format!("external.skills[{index}].{name}");
+        validate_target(&field, skill.agent, skill.scope, agents)?;
+        super::skills::validate_slug(&field("slug"), &skill.slug)?;
+        match (skill.origin, skill.plugin.as_deref()) {
+            (ExternalOrigin::System, None) => {}
+            (ExternalOrigin::System, Some(_)) => {
+                return Err(ManifestError::new(
+                    field("plugin"),
+                    "system skills cannot name a plugin",
+                ));
+            }
+            (ExternalOrigin::Plugin, None) => {
+                return Err(ManifestError::new(
+                    field("plugin"),
+                    "plugin skills require a plugin identifier",
+                ));
+            }
+            (ExternalOrigin::Plugin, Some(plugin))
+                if !plugins.contains(&(skill.agent, skill.scope, plugin.to_owned())) =>
+            {
+                return Err(ManifestError::new(
+                    field("plugin"),
+                    "plugin skill requires a matching allowed plugin",
+                ));
+            }
+            (ExternalOrigin::Plugin, Some(_)) => {}
+        }
+        if !declarations.insert((
+            skill.agent,
+            skill.scope,
+            skill.origin,
+            skill.plugin.clone(),
+            skill.slug.clone(),
+        )) {
+            return Err(ManifestError::new(
+                field("slug"),
+                "duplicate external skill",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_target(
+    field: &impl Fn(&str) -> String,
+    agent: Agent,
+    scope: Scope,
+    agents: &HashMap<Agent, HashSet<Scope>>,
+) -> Result<(), ManifestError> {
+    let Some(scopes) = agents.get(&agent) else {
+        return Err(ManifestError::new(field("agent"), "agent is not declared"));
+    };
+    if scopes.contains(&scope) {
+        Ok(())
+    } else {
+        Err(ManifestError::new(
+            field("scope"),
+            "scope is not declared for this agent",
+        ))
+    }
+}

--- a/tooling/arnes/src/manifest/validation/skills.rs
+++ b/tooling/arnes/src/manifest/validation/skills.rs
@@ -69,7 +69,7 @@ fn validate_installation(
     }
 }
 
-fn validate_slug(field: &str, slug: &str) -> Result<(), ManifestError> {
+pub(super) fn validate_slug(field: &str, slug: &str) -> Result<(), ManifestError> {
     let path = Path::new(slug);
     let mut components = path.components();
     let valid = match (components.next(), components.next()) {

--- a/tooling/arnes/src/skills.rs
+++ b/tooling/arnes/src/skills.rs
@@ -78,6 +78,7 @@ fn diagnose_leaves(
         resource.scope,
         resource.destination,
         &declared,
+        manifest,
     ));
     diagnostics
 }
@@ -102,6 +103,7 @@ fn diagnose_root(
         resource.scope,
         resource.destination,
         &declared,
+        manifest,
     ));
     diagnostics
 }

--- a/tooling/arnes/src/skills.rs
+++ b/tooling/arnes/src/skills.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 mod discovery;
+mod external;
 mod paths;
 mod projection;
 mod references;
@@ -35,7 +36,9 @@ fn diagnose_one(roots: &Roots, manifest: &Manifest, agent: Agent, scope: Scope) 
         .filter(|resource| resource.agent == agent && resource.scope == scope)
         .collect::<Vec<_>>();
     if resources.is_empty() {
-        return vec![unsupported(Some(agent), Some(scope))];
+        return std::iter::once(unsupported(Some(agent), Some(scope)))
+            .chain(external::diagnose(roots, manifest, agent, scope))
+            .collect();
     }
     let (supported, unsupported_resources): (Vec<_>, Vec<_>) =
         resources.into_iter().partition(declaration_supported);
@@ -49,6 +52,7 @@ fn diagnose_one(roots: &Roots, manifest: &Manifest, agent: Agent, scope: Scope) 
             SkillLayout::Root => diagnostics.extend(diagnose_root(roots, manifest, &resource)),
         }
     }
+    diagnostics.extend(external::diagnose(roots, manifest, agent, scope));
     diagnostics
 }
 

--- a/tooling/arnes/src/skills/discovery.rs
+++ b/tooling/arnes/src/skills/discovery.rs
@@ -1,7 +1,7 @@
 use super::paths::{canonical_within, label};
 use crate::Roots;
 use crate::diagnostic::{Diagnostic, State};
-use crate::manifest::{Agent, Scope};
+use crate::manifest::{Agent, ExternalOrigin, Manifest, Scope};
 use std::collections::HashSet;
 use std::fs;
 use std::io::ErrorKind;
@@ -13,6 +13,7 @@ pub fn unmanaged(
     scope: Scope,
     root: &Path,
     declared: &HashSet<PathBuf>,
+    manifest: &Manifest,
 ) -> Vec<Diagnostic> {
     let base = match scope {
         Scope::User => roots.home(),
@@ -31,7 +32,7 @@ pub fn unmanaged(
         .into_iter()
         .filter(|name| !declared.contains(&root.join(name)))
         .filter(|name| !super::external::is_claude_skills_plugin(agent, &directory.join(name)))
-        .map(|name| classify(&directory, agent, scope, root, &name))
+        .map(|name| classify(&directory, agent, scope, root, &name, manifest))
         .collect()
 }
 
@@ -49,18 +50,44 @@ pub fn installations(directory: &Path) -> Result<Vec<PathBuf>, String> {
     Ok(names)
 }
 
-fn classify(directory: &Path, agent: Agent, scope: Scope, root: &Path, name: &Path) -> Diagnostic {
+fn classify(
+    directory: &Path,
+    agent: Agent,
+    scope: Scope,
+    root: &Path,
+    name: &Path,
+    manifest: &Manifest,
+) -> Diagnostic {
     let path = directory.join(name);
     let broken = fs::symlink_metadata(&path)
         .is_ok_and(|metadata| metadata.file_type().is_symlink())
         && !fs::metadata(&path).is_ok_and(|metadata| metadata.is_dir());
     let classification = if broken { "broken" } else { "unmanaged" };
+    let allowed = name.to_str().is_some_and(|slug| {
+        manifest.external_skills(agent, scope).any(|skill| {
+            skill.origin == ExternalOrigin::Managed && skill.plugin.is_none() && skill.slug == slug
+        })
+    });
     Diagnostic::new(
         "skills",
-        State::Unsupported,
+        if broken {
+            State::Error
+        } else if allowed {
+            State::Healthy
+        } else {
+            State::Drift
+        },
         format!(
-            "{classification} {agent} {scope} skill {} at {}/{} is unmanaged and not Arnes-owned",
+            "{classification} {agent} {scope} skill {} origin=managed ownership=external container=none version=unknown exposure={} topology={} policy={} activation={} path={}/{} detail=unmanaged and not Arnes-owned",
             name.display(),
+            if broken { "unknown" } else { "enabled" },
+            if broken { "broken" } else { "healthy" },
+            if allowed { "allowed" } else { "unexpected" },
+            if broken {
+                "unknown"
+            } else {
+                "available-not-runtime-observed"
+            },
             label(scope, root),
             name.display()
         ),

--- a/tooling/arnes/src/skills/discovery.rs
+++ b/tooling/arnes/src/skills/discovery.rs
@@ -92,6 +92,21 @@ fn classify(
             name.display()
         ),
     )
+    .with_human(
+        format!("{agent} {scope} external skills"),
+        format!(
+            "{} · managed · {} · {} · {}{}",
+            name.display(),
+            if broken { "unknown" } else { "enabled" },
+            if broken { "broken" } else { "healthy" },
+            if allowed { "allowed" } else { "unexpected" },
+            if broken {
+                format!(" · {}/{}", label(scope, root), name.display())
+            } else {
+                String::new()
+            },
+        ),
+    )
 }
 
 fn missing(path: &Path) -> bool {

--- a/tooling/arnes/src/skills/discovery.rs
+++ b/tooling/arnes/src/skills/discovery.rs
@@ -30,6 +30,7 @@ pub fn unmanaged(
     names
         .into_iter()
         .filter(|name| !declared.contains(&root.join(name)))
+        .filter(|name| !super::external::is_claude_skills_plugin(agent, &directory.join(name)))
         .map(|name| classify(&directory, agent, scope, root, &name))
         .collect()
 }

--- a/tooling/arnes/src/skills/external/claude.rs
+++ b/tooling/arnes/src/skills/external/claude.rs
@@ -1,0 +1,112 @@
+use super::manifest;
+use super::model::{Plugin, plugin_diagnostics};
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Manifest, Scope};
+use crate::skills::paths::canonical_within;
+use std::collections::BTreeMap;
+use std::fs;
+use std::fs::DirEntry;
+use std::path::Path;
+
+mod registry;
+mod settings;
+
+pub(super) fn diagnose(roots: &Roots, policy: &Manifest, scope: Scope) -> Vec<Diagnostic> {
+    let (settings, mut diagnostics) = settings::load(roots, scope);
+    let mut plugins = skills_directory_plugins(roots, policy, scope, &settings);
+    let (installed, registry_diagnostics) = registry::diagnose(roots, scope, &settings);
+    plugins.extend(installed);
+    diagnostics.extend(registry_diagnostics);
+    plugins.sort_by(|left, right| {
+        left.id
+            .cmp(&right.id)
+            .then_with(|| left.version.cmp(&right.version))
+    });
+    diagnostics.extend(plugin_diagnostics(policy, Agent::Claude, scope, plugins));
+    diagnostics
+}
+
+fn skills_directory_plugins(
+    roots: &Roots,
+    policy: &Manifest,
+    scope: Scope,
+    settings: &Result<BTreeMap<String, bool>, ()>,
+) -> Vec<Plugin> {
+    let mut plugins = Vec::new();
+    for projection in policy
+        .skill_projections()
+        .filter(|projection| projection.agent == Agent::Claude && projection.scope == scope)
+    {
+        let base = match scope {
+            Scope::User => roots.home(),
+            Scope::Project => roots.repository(),
+        };
+        let directory = base.join(projection.destination);
+        if canonical_within(&directory, base).is_none() {
+            continue;
+        }
+        let Ok(entries) = fs::read_dir(&directory) else {
+            continue;
+        };
+        for entry in entries.filter_map(Result::ok) {
+            if let Some(plugin) = inspect_skills_directory_entry(&directory, entry, settings) {
+                plugins.push(plugin);
+            }
+        }
+    }
+    plugins
+}
+
+fn inspect_skills_directory_entry(
+    root: &Path,
+    entry: DirEntry,
+    settings: &Result<BTreeMap<String, bool>, ()>,
+) -> Option<Plugin> {
+    let path = entry.path();
+    canonical_within(&path, root)?;
+    if !path.join(".claude-plugin/plugin.json").is_file() {
+        return None;
+    }
+    let inspected = manifest::inspect(&path, &[".claude-plugin/plugin.json"]);
+    let name = inspected
+        .name
+        .clone()
+        .unwrap_or_else(|| entry.file_name().to_string_lossy().into_owned());
+    let id = format!("{name}@skills-dir");
+    Some(Plugin {
+        exposure: settings::exposure(settings, &id),
+        id,
+        version: inspected.version,
+        path: Some(path),
+        topology: inspected.topology,
+        detail: inspected.detail,
+        skills: inspected.skills,
+    })
+}
+
+fn installation_scope(scope: &str) -> Option<Scope> {
+    match scope {
+        "user" => Some(Scope::User),
+        "project" | "local" => Some(Scope::Project),
+        _ => None,
+    }
+}
+
+fn registry_diagnostic(
+    scope: Scope,
+    subject: &str,
+    path: &Path,
+    state: State,
+    topology: &str,
+    detail: &str,
+) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        state,
+        format!(
+            "external claude {scope} {subject} origin=plugin ownership=external exposure=unknown topology={topology} policy=unknown activation=unknown path={} detail={detail}",
+            path.display(),
+        ),
+    )
+}

--- a/tooling/arnes/src/skills/external/claude/registry.rs
+++ b/tooling/arnes/src/skills/external/claude/registry.rs
@@ -1,0 +1,243 @@
+use super::{installation_scope, registry_diagnostic, settings};
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::Scope;
+use crate::skills::external::manifest;
+use crate::skills::external::model::{Exposure, Plugin, Topology};
+use crate::skills::paths::{ancestor_within, canonical_within};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+#[derive(Deserialize)]
+struct Registry {
+    version: u64,
+    plugins: BTreeMap<String, Vec<Installation>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Installation {
+    scope: String,
+    install_path: PathBuf,
+    version: String,
+}
+
+pub(super) fn diagnose(
+    roots: &Roots,
+    scope: Scope,
+    settings: &Result<BTreeMap<String, bool>, ()>,
+) -> (Vec<Plugin>, Vec<Diagnostic>) {
+    let plugin_root = roots.home().join(".claude/plugins");
+    let registry_path = plugin_root.join("installed_plugins.json");
+    if !plugin_root_supported(&plugin_root, roots.home()) {
+        return (
+            Vec::new(),
+            vec![registry_diagnostic(
+                scope,
+                "plugin root",
+                &plugin_root,
+                State::Error,
+                "broken",
+                "plugin root is unreadable or resolves outside HOME",
+            )],
+        );
+    }
+    match load(&registry_path, &plugin_root) {
+        Ok(Some(registry)) if registry.version == 2 => (
+            installed_plugins(&plugin_root, scope, settings, registry),
+            Vec::new(),
+        ),
+        Ok(Some(registry)) => (
+            Vec::new(),
+            vec![registry_diagnostic(
+                scope,
+                "plugin registry",
+                &registry_path,
+                State::Unsupported,
+                "unknown",
+                &format!("unsupported registry version {}", registry.version),
+            )],
+        ),
+        Ok(None) => (Vec::new(), Vec::new()),
+        Err(detail) => (
+            Vec::new(),
+            vec![registry_diagnostic(
+                scope,
+                "plugin registry",
+                &registry_path,
+                State::Error,
+                "unreadable",
+                detail,
+            )],
+        ),
+    }
+}
+
+fn load(path: &Path, root: &Path) -> Result<Option<Registry>, &'static str> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err("registry metadata could not be read"),
+    }
+    if canonical_within(path, root).is_none() {
+        return Err("registry resolves outside the plugin root");
+    }
+    let contents = fs::read_to_string(path).map_err(|_| "registry could not be read")?;
+    serde_json::from_str(&contents)
+        .map(Some)
+        .map_err(|_| "registry is invalid JSON")
+}
+
+fn plugin_root_supported(root: &Path, home: &Path) -> bool {
+    match fs::symlink_metadata(root) {
+        Ok(_) => {
+            canonical_within(root, home).is_some()
+                && fs::metadata(root).is_ok_and(|metadata| metadata.is_dir())
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            crate::skills::paths::ancestor_within(root, home)
+        }
+        Err(_) => false,
+    }
+}
+
+fn installed_plugins(
+    plugin_root: &Path,
+    scope: Scope,
+    settings: &Result<BTreeMap<String, bool>, ()>,
+    registry: Registry,
+) -> Vec<Plugin> {
+    registry
+        .plugins
+        .into_iter()
+        .flat_map(|(id, installations)| {
+            plugins_for_id(plugin_root, scope, settings, id, installations)
+        })
+        .collect()
+}
+
+fn plugins_for_id(
+    plugin_root: &Path,
+    scope: Scope,
+    settings: &Result<BTreeMap<String, bool>, ()>,
+    id: String,
+    installations: Vec<Installation>,
+) -> Vec<Plugin> {
+    let (known, unknown): (Vec<_>, Vec<_>) = installations
+        .into_iter()
+        .partition(|installation| installation_scope(&installation.scope).is_some());
+    let exposure = settings::exposure(settings, &id);
+    let mut plugins = Vec::new();
+    if !unknown.is_empty() {
+        let scopes = unknown
+            .iter()
+            .map(|installation| installation.scope.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+        plugins.push(Plugin {
+            id: id.clone(),
+            version: None,
+            path: None,
+            exposure: Exposure::Unknown,
+            topology: Topology::Unknown,
+            detail: Some(format!("unsupported installation scopes {scopes}")),
+            skills: Vec::new(),
+        });
+    }
+    let matching = known
+        .into_iter()
+        .filter(|installation| installation_scope(&installation.scope) == Some(scope))
+        .collect::<Vec<_>>();
+    if let Some(plugin) = matching_plugin(plugin_root, id, matching, exposure) {
+        plugins.push(plugin);
+    }
+    plugins
+}
+
+fn matching_plugin(
+    plugin_root: &Path,
+    id: String,
+    matching: Vec<Installation>,
+    exposure: Exposure,
+) -> Option<Plugin> {
+    if matching.is_empty() {
+        return None;
+    }
+    if matching.len() == 1 {
+        return Some(inspect_installation(
+            plugin_root,
+            id,
+            matching.into_iter().next().unwrap(),
+            exposure,
+        ));
+    }
+    let versions = matching
+        .iter()
+        .map(|installation| installation.version.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    Some(Plugin {
+        id,
+        version: None,
+        path: None,
+        exposure,
+        topology: Topology::Broken,
+        detail: Some(format!("ambiguous installed versions {versions}")),
+        skills: Vec::new(),
+    })
+}
+
+fn inspect_installation(
+    plugin_root: &Path,
+    id: String,
+    installation: Installation,
+    exposure: Exposure,
+) -> Plugin {
+    let path = installation.install_path;
+    let invalid = if !ancestor_within(&path, plugin_root) {
+        Some("installed plugin path escapes the plugin root")
+    } else if fs::metadata(&path).is_err() {
+        Some("installed plugin path is missing")
+    } else if canonical_within(&path, plugin_root).is_none() {
+        Some("installed plugin path escapes the plugin root")
+    } else {
+        None
+    };
+    if let Some(detail) = invalid {
+        return Plugin {
+            id,
+            version: Some(installation.version),
+            path: Some(path),
+            exposure,
+            topology: Topology::Broken,
+            detail: Some(detail.to_owned()),
+            skills: Vec::new(),
+        };
+    }
+    let inspected = manifest::inspect(&path, &[".claude-plugin/plugin.json"]);
+    let version = installation.version;
+    let mismatch = inspected
+        .version
+        .as_deref()
+        .is_some_and(|manifest_version| manifest_version != version.as_str());
+    Plugin {
+        id,
+        version: Some(version),
+        path: Some(path),
+        exposure,
+        topology: if mismatch {
+            Topology::Broken
+        } else {
+            inspected.topology
+        },
+        detail: if mismatch {
+            Some("registry and plugin manifest versions differ".to_owned())
+        } else {
+            inspected.detail
+        },
+        skills: inspected.skills,
+    }
+}

--- a/tooling/arnes/src/skills/external/claude/settings.rs
+++ b/tooling/arnes/src/skills/external/claude/settings.rs
@@ -1,0 +1,83 @@
+use super::super::model::Exposure;
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::Scope;
+use crate::skills::paths::{ancestor_within, canonical_within};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+pub(super) fn load(
+    roots: &Roots,
+    scope: Scope,
+) -> (Result<BTreeMap<String, bool>, ()>, Vec<Diagnostic>) {
+    let mut merged = BTreeMap::new();
+    let paths = match scope {
+        Scope::User => vec![(roots.home().join(".claude/settings.json"), roots.home())],
+        Scope::Project => vec![
+            (roots.home().join(".claude/settings.json"), roots.home()),
+            (
+                roots.repository().join(".claude/settings.json"),
+                roots.repository(),
+            ),
+            (
+                roots.repository().join(".claude/settings.local.json"),
+                roots.repository(),
+            ),
+        ],
+    };
+    for (path, base) in paths {
+        match load_one(&path, base) {
+            Ok(values) => merged.extend(values),
+            Err(detail) => {
+                return (
+                    Err(()),
+                    vec![Diagnostic::new(
+                        "skills",
+                        State::Error,
+                        format!(
+                            "external claude {scope} plugin settings origin=plugin ownership=external exposure=unknown topology=unreadable policy=unknown activation=unknown path={} detail={detail}",
+                            path.display(),
+                        ),
+                    )],
+                );
+            }
+        }
+    }
+    (Ok(merged), Vec::new())
+}
+
+pub(super) fn exposure(settings: &Result<BTreeMap<String, bool>, ()>, id: &str) -> Exposure {
+    match settings {
+        Ok(settings) => match settings.get(id) {
+            Some(true) => Exposure::Enabled,
+            Some(false) => Exposure::Disabled,
+            None => Exposure::Unknown,
+        },
+        Err(()) => Exposure::Unknown,
+    }
+}
+
+fn load_one(path: &Path, base: &Path) -> Result<BTreeMap<String, bool>, &'static str> {
+    match fs::symlink_metadata(path) {
+        Ok(_) if canonical_within(path, base).is_none() => {
+            return Err("settings resolve outside their scope");
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return if ancestor_within(path, base) {
+                Ok(BTreeMap::new())
+            } else {
+                Err("settings parent resolves outside its scope")
+            };
+        }
+        Err(_) => return Err("settings metadata could not be read"),
+    }
+    let contents = fs::read_to_string(path).map_err(|_| "settings could not be read")?;
+    let value: Value = serde_json::from_str(&contents).map_err(|_| "settings are invalid JSON")?;
+    let Some(enabled) = value.get("enabledPlugins") else {
+        return Ok(BTreeMap::new());
+    };
+    serde_json::from_value(enabled.clone()).map_err(|_| "enabledPlugins must map ids to booleans")
+}

--- a/tooling/arnes/src/skills/external/codex.rs
+++ b/tooling/arnes/src/skills/external/codex.rs
@@ -1,0 +1,129 @@
+use super::model::{Exposure, Plugin, Topology, plugin_diagnostics};
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Manifest, Scope};
+use crate::skills::paths::{ancestor_within, canonical_within};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Default, Deserialize)]
+struct Config {
+    #[serde(default)]
+    plugins: BTreeMap<String, PluginConfig>,
+    #[serde(default)]
+    skills: SkillsConfig,
+}
+
+#[derive(Deserialize)]
+struct PluginConfig {
+    enabled: Option<bool>,
+}
+
+#[derive(Default, Deserialize)]
+struct SkillsConfig {
+    #[serde(default)]
+    config: Vec<SkillConfig>,
+}
+
+#[derive(Deserialize)]
+struct SkillConfig {
+    path: PathBuf,
+    enabled: bool,
+}
+
+pub(super) fn diagnose(roots: &Roots, policy: &Manifest, scope: Scope) -> Vec<Diagnostic> {
+    if scope == Scope::Project {
+        return vec![Diagnostic::new(
+            "skills",
+            State::Unsupported,
+            "external codex project plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=project plugin activation has no documented filesystem registry",
+        )];
+    }
+    let path = roots.home().join(".codex/config.toml");
+    let config = match load(&path, roots.home()) {
+        Ok(config) => config,
+        Err(detail) => {
+            return vec![Diagnostic::new(
+                "skills",
+                State::Error,
+                format!(
+                    "external codex user plugin configuration origin=plugin ownership=external exposure=unknown topology=unreadable policy=unknown activation=unknown path={} detail={detail}",
+                    path.display(),
+                ),
+            )];
+        }
+    };
+    let plugins = config
+        .plugins
+        .into_iter()
+        .map(|(id, plugin)| Plugin {
+            id,
+            version: None,
+            path: None,
+            exposure: match plugin.enabled {
+                Some(true) => Exposure::Enabled,
+                Some(false) => Exposure::Disabled,
+                None => Exposure::Unknown,
+            },
+            topology: Topology::Unknown,
+            detail: Some("active plugin version and cache path are not recorded in config".into()),
+            skills: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+    let mut diagnostics = plugin_diagnostics(policy, Agent::Codex, scope, plugins);
+    if !diagnostics.is_empty() {
+        diagnostics.push(Diagnostic::new(
+            "skills",
+            State::Unsupported,
+            "external codex user plugin skills inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=the active cache version cannot be selected reliably from config.toml",
+        ));
+    }
+    diagnostics
+}
+
+pub(super) fn skill_exposure(roots: &Roots, skill_file: &Path) -> Exposure {
+    let Ok(config) = load(&roots.home().join(".codex/config.toml"), roots.home()) else {
+        return Exposure::Unknown;
+    };
+    let matching = config
+        .skills
+        .config
+        .iter()
+        .filter(|entry| same_path(&entry.path, skill_file))
+        .map(|entry| entry.enabled)
+        .collect::<Vec<_>>();
+    match matching.as_slice() {
+        [] | [true] => Exposure::Enabled,
+        [false] => Exposure::Disabled,
+        _ => Exposure::Unknown,
+    }
+}
+
+fn load(path: &Path, root: &Path) -> Result<Config, &'static str> {
+    match fs::symlink_metadata(path) {
+        Ok(_) if canonical_within(path, root).is_none() => {
+            return Err("config resolves outside HOME");
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return if ancestor_within(path, root) {
+                Ok(Config::default())
+            } else {
+                Err("config parent resolves outside HOME")
+            };
+        }
+        Err(_) => return Err("config metadata could not be read"),
+    }
+    let contents = fs::read_to_string(path).map_err(|_| "config could not be read")?;
+    toml::from_str(&contents).map_err(|_| "config is invalid TOML")
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    left == right
+        || fs::canonicalize(left)
+            .ok()
+            .zip(fs::canonicalize(right).ok())
+            .is_some_and(|(left, right)| left == right)
+}

--- a/tooling/arnes/src/skills/external/cursor.rs
+++ b/tooling/arnes/src/skills/external/cursor.rs
@@ -1,0 +1,132 @@
+use super::manifest;
+use super::model::{Exposure, Plugin, Topology, plugin_diagnostics};
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Manifest, Scope};
+use crate::skills::paths::{ancestor_within, canonical_within};
+use std::fs;
+use std::fs::DirEntry;
+use std::io::ErrorKind;
+use std::path::Path;
+
+pub(super) fn diagnose(roots: &Roots, policy: &Manifest, scope: Scope) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    if scope == Scope::User {
+        let root = roots.home().join(".cursor/plugins/local");
+        match local_plugins(&root, roots.home()) {
+            Ok(plugins) => diagnostics.extend(plugin_diagnostics(
+                policy,
+                Agent::Cursor,
+                scope,
+                plugins,
+            )),
+            Err(detail) => diagnostics.push(Diagnostic::new(
+                "skills",
+                State::Error,
+                format!(
+                    "external cursor user local plugin root origin=plugin ownership=external exposure=unknown topology=unreadable policy=unknown activation=unknown path={} detail={detail}",
+                    root.display(),
+                ),
+            )),
+        }
+    }
+    diagnostics.push(unsupported(
+        scope,
+        "marketplace plugin activation has no documented filesystem registry",
+    ));
+    diagnostics.push(unsupported(
+        scope,
+        "extension activation and skill exposure have no documented filesystem registry",
+    ));
+    diagnostics
+}
+
+fn local_plugins(root: &Path, home: &Path) -> Result<Vec<Plugin>, &'static str> {
+    match fs::symlink_metadata(root) {
+        Ok(_) if canonical_within(root, home).is_none() => {
+            return Err("local plugin root resolves outside HOME");
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return if ancestor_within(root, home) {
+                Ok(Vec::new())
+            } else {
+                Err("local plugin root has an ancestor outside HOME")
+            };
+        }
+        Err(_) => return Err("local plugin root metadata could not be read"),
+    };
+    let entries = fs::read_dir(root).map_err(|_| "local plugin root could not be read")?;
+    let mut plugins = entries
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| "local plugin root entry could not be read")?
+        .into_iter()
+        .filter_map(|entry| inspect_plugin(root, entry))
+        .collect::<Vec<_>>();
+    plugins.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(plugins)
+}
+
+fn inspect_plugin(root: &Path, entry: DirEntry) -> Option<Plugin> {
+    match entry.file_type() {
+        Ok(kind) if !kind.is_dir() && !kind.is_symlink() => return None,
+        Err(_) => {
+            return Some(Plugin {
+                id: entry.file_name().to_string_lossy().into_owned(),
+                version: None,
+                path: Some(entry.path()),
+                exposure: Exposure::Unknown,
+                topology: Topology::Unreadable,
+                detail: Some("local plugin metadata could not be read".into()),
+                skills: Vec::new(),
+            });
+        }
+        Ok(_) => {}
+    }
+    let path = entry.path();
+    if fs::metadata(&path).is_err() || canonical_within(&path, root).is_none() {
+        return Some(Plugin {
+            id: entry.file_name().to_string_lossy().into_owned(),
+            version: None,
+            path: Some(path),
+            exposure: Exposure::Enabled,
+            topology: Topology::Broken,
+            detail: Some("local plugin link is dangling or escapes its root".into()),
+            skills: Vec::new(),
+        });
+    }
+    let inspected = manifest::inspect(&path, &["plugin.json", ".cursor-plugin/plugin.json"]);
+    let id = inspected
+        .name
+        .clone()
+        .unwrap_or_else(|| entry.file_name().to_string_lossy().into_owned());
+    let missing_name = inspected.name.is_none() && inspected.topology == Topology::Healthy;
+    let detail = if missing_name && inspected.detail.is_none() {
+        Some("plugin manifest name is missing".to_owned())
+    } else {
+        inspected.detail
+    };
+    Some(Plugin {
+        id,
+        version: inspected.version,
+        path: Some(path),
+        exposure: Exposure::Enabled,
+        topology: if missing_name {
+            Topology::Broken
+        } else {
+            inspected.topology
+        },
+        detail,
+        skills: inspected.skills,
+    })
+}
+
+fn unsupported(scope: Scope, detail: &str) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        State::Unsupported,
+        format!(
+            "external cursor {scope} plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail={detail}"
+        ),
+    )
+}

--- a/tooling/arnes/src/skills/external/manifest.rs
+++ b/tooling/arnes/src/skills/external/manifest.rs
@@ -1,0 +1,213 @@
+use super::model::{Skill, Topology};
+use crate::skills::paths::canonical_within;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+pub(super) struct Inspection {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub topology: Topology,
+    pub detail: Option<String>,
+    pub skills: Vec<Skill>,
+}
+
+pub(super) fn inspect(root: &Path, candidates: &[&str]) -> Inspection {
+    let manifest = match manifest_path(root, candidates) {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) => return failure(Topology::Broken, "plugin manifest is missing"),
+        Err((topology, detail)) => return failure(topology, detail),
+    };
+    let contents = match fs::read_to_string(&manifest) {
+        Ok(contents) => contents,
+        Err(_) => return failure(Topology::Unreadable, "plugin manifest could not be read"),
+    };
+    let value: Value = match serde_json::from_str(&contents) {
+        Ok(value) => value,
+        Err(_) => return failure(Topology::Broken, "plugin manifest is invalid JSON"),
+    };
+    let name = value.get("name").and_then(Value::as_str).map(str::to_owned);
+    let version = value
+        .get("version")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let paths = match skill_paths(root, &value) {
+        Ok(paths) => paths,
+        Err(detail) => return failure(Topology::Broken, detail),
+    };
+    let skills = match discover_skills(root, paths) {
+        Ok(skills) => skills,
+        Err(detail) => return failure(Topology::Unreadable, detail),
+    };
+    Inspection {
+        name,
+        version,
+        topology: Topology::Healthy,
+        detail: None,
+        skills,
+    }
+}
+
+fn manifest_path(
+    root: &Path,
+    candidates: &[&str],
+) -> Result<Option<PathBuf>, (Topology, &'static str)> {
+    for candidate in candidates.iter().map(|candidate| root.join(candidate)) {
+        match fs::symlink_metadata(&candidate) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => return Err((Topology::Unreadable, "plugin manifest metadata failed")),
+            Ok(_) => {}
+        }
+        match fs::metadata(&candidate) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err((Topology::Broken, "plugin manifest link is dangling"));
+            }
+            Err(_) => return Err((Topology::Unreadable, "plugin manifest metadata failed")),
+            Ok(metadata) if !metadata.is_file() => {
+                return Err((Topology::Broken, "plugin manifest is not a file"));
+            }
+            Ok(_) => {}
+        }
+        if canonical_within(&candidate, root).is_none() {
+            return Err((
+                Topology::Broken,
+                "plugin manifest resolves outside its root",
+            ));
+        }
+        return Ok(Some(candidate));
+    }
+    Ok(None)
+}
+
+fn skill_paths(root: &Path, value: &Value) -> Result<Vec<PathBuf>, &'static str> {
+    let Some(skills) = value.get("skills") else {
+        let default = root.join("skills");
+        return if fs::symlink_metadata(&default).is_ok() {
+            Ok(vec![default])
+        } else if fs::symlink_metadata(root.join("SKILL.md")).is_ok() {
+            Ok(vec![root.to_owned()])
+        } else {
+            Ok(Vec::new())
+        };
+    };
+    let values = match skills {
+        Value::String(path) => vec![path.as_str()],
+        Value::Array(paths) => paths
+            .iter()
+            .map(Value::as_str)
+            .collect::<Option<Vec<_>>>()
+            .ok_or("plugin skills paths must be strings")?,
+        _ => return Err("plugin skills must be a path or path list"),
+    };
+    values
+        .into_iter()
+        .map(|path| {
+            let relative = Path::new(path);
+            if relative
+                .components()
+                .all(|component| matches!(component, Component::CurDir | Component::Normal(_)))
+            {
+                Ok(root.join(relative))
+            } else {
+                Err("plugin skills path escapes its root")
+            }
+        })
+        .collect()
+}
+
+fn discover_skills(root: &Path, paths: Vec<PathBuf>) -> Result<Vec<Skill>, &'static str> {
+    let mut discovered = Vec::new();
+    let mut seen = HashSet::new();
+    for path in paths {
+        if !seen.insert(path.clone()) {
+            continue;
+        }
+        if fs::symlink_metadata(&path).is_err() {
+            discovered.push(Skill {
+                slug: slug(&path),
+                path,
+                topology: Topology::Broken,
+                detail: Some("declared skill path is missing".to_owned()),
+            });
+            continue;
+        }
+        if canonical_within(&path, root).is_none() {
+            discovered.push(Skill {
+                slug: slug(&path),
+                path,
+                topology: Topology::Broken,
+                detail: Some("skills directory resolves outside its plugin".to_owned()),
+            });
+            continue;
+        }
+        if fs::symlink_metadata(path.join("SKILL.md")).is_ok() {
+            discovered.push(classify_skill(root, path));
+            continue;
+        }
+        let entries = fs::read_dir(&path).map_err(|_| "skills directory could not be read")?;
+        for entry in entries {
+            let entry = entry.map_err(|_| "skills directory could not be read")?;
+            let kind = entry
+                .file_type()
+                .map_err(|_| "skill metadata could not be read")?;
+            if kind.is_dir() || kind.is_symlink() {
+                discovered.push(classify_skill(root, entry.path()));
+            }
+        }
+    }
+    discovered.sort_by(|left, right| {
+        left.slug
+            .cmp(&right.slug)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    Ok(discovered)
+}
+
+fn classify_skill(root: &Path, path: PathBuf) -> Skill {
+    let slug = slug(&path);
+    let result = if fs::metadata(&path).is_err() {
+        (Topology::Broken, Some("skill link is dangling"))
+    } else if canonical_within(&path, root).is_none() {
+        (Topology::Broken, Some("skill resolves outside its plugin"))
+    } else if !fs::metadata(&path).is_ok_and(|metadata| metadata.is_dir()) {
+        (Topology::Broken, Some("skill is not a directory"))
+    } else {
+        let skill_file = path.join("SKILL.md");
+        if fs::metadata(&skill_file).is_err() {
+            (Topology::Broken, Some("SKILL.md is missing"))
+        } else if canonical_within(&skill_file, root).is_none() {
+            (
+                Topology::Broken,
+                Some("SKILL.md resolves outside its plugin"),
+            )
+        } else if fs::metadata(skill_file).is_ok_and(|metadata| metadata.is_file()) {
+            (Topology::Healthy, None)
+        } else {
+            (Topology::Broken, Some("SKILL.md is not a file"))
+        }
+    };
+    Skill {
+        slug,
+        path,
+        topology: result.0,
+        detail: result.1.map(str::to_owned),
+    }
+}
+
+fn slug(path: &Path) -> String {
+    path.file_name().map_or_else(
+        || "unknown".to_owned(),
+        |name| name.to_string_lossy().into(),
+    )
+}
+
+fn failure(topology: Topology, detail: impl Into<String>) -> Inspection {
+    Inspection {
+        name: None,
+        version: None,
+        topology,
+        detail: Some(detail.into()),
+        skills: Vec::new(),
+    }
+}

--- a/tooling/arnes/src/skills/external/mod.rs
+++ b/tooling/arnes/src/skills/external/mod.rs
@@ -1,0 +1,43 @@
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Manifest, Scope};
+
+mod claude;
+mod codex;
+mod cursor;
+mod manifest;
+mod model;
+mod system;
+
+pub(super) fn diagnose(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Agent,
+    scope: Scope,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = system::diagnose(roots, manifest, agent, scope);
+    diagnostics.extend(match agent {
+        Agent::Claude => claude::diagnose(roots, manifest, scope),
+        Agent::Cursor => cursor::diagnose(roots, manifest, scope),
+        Agent::Codex => codex::diagnose(roots, manifest, scope),
+    });
+    diagnostics
+}
+
+pub(super) fn unsupported(agent: Agent, scope: Scope, subject: &str) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        State::Unsupported,
+        format!(
+            "external {agent} {scope} {subject} origin=system ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown"
+        ),
+    )
+}
+
+pub(super) fn is_claude_skills_plugin(agent: Agent, path: &std::path::Path) -> bool {
+    agent == Agent::Claude
+        && path
+            .parent()
+            .is_some_and(|root| super::paths::canonical_within(path, root).is_some())
+        && path.join(".claude-plugin/plugin.json").is_file()
+}

--- a/tooling/arnes/src/skills/external/mod.rs
+++ b/tooling/arnes/src/skills/external/mod.rs
@@ -32,6 +32,10 @@ pub(super) fn unsupported(agent: Agent, scope: Scope, subject: &str) -> Diagnost
             "external {agent} {scope} {subject} origin=system ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown"
         ),
     )
+    .with_human(
+        format!("{agent} {scope} unsupported capabilities"),
+        subject,
+    )
 }
 
 pub(super) fn is_claude_skills_plugin(agent: Agent, path: &std::path::Path) -> bool {

--- a/tooling/arnes/src/skills/external/model.rs
+++ b/tooling/arnes/src/skills/external/model.rs
@@ -1,0 +1,240 @@
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, ExternalOrigin, Manifest, Scope};
+use std::collections::BTreeMap;
+use std::fmt::{self, Display};
+use std::path::PathBuf;
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(super) enum Exposure {
+    Enabled,
+    Disabled,
+    Unknown,
+}
+
+impl Display for Exposure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Enabled => "enabled",
+            Self::Disabled => "disabled",
+            Self::Unknown => "unknown",
+        })
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(super) enum Topology {
+    Healthy,
+    Broken,
+    Unreadable,
+    Unknown,
+}
+
+impl Display for Topology {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Healthy => "healthy",
+            Self::Broken => "broken",
+            Self::Unreadable => "unreadable",
+            Self::Unknown => "unknown",
+        })
+    }
+}
+
+pub(super) struct Plugin {
+    pub id: String,
+    pub version: Option<String>,
+    pub path: Option<PathBuf>,
+    pub exposure: Exposure,
+    pub topology: Topology,
+    pub detail: Option<String>,
+    pub skills: Vec<Skill>,
+}
+
+pub(super) struct Skill {
+    pub slug: String,
+    pub path: PathBuf,
+    pub topology: Topology,
+    pub detail: Option<String>,
+}
+
+pub(super) struct SystemSkill {
+    pub slug: String,
+    pub path: PathBuf,
+    pub exposure: Exposure,
+    pub topology: Topology,
+    pub detail: Option<String>,
+}
+
+pub(super) fn plugin_diagnostics(
+    manifest: &Manifest,
+    agent: Agent,
+    scope: Scope,
+    mut plugins: Vec<Plugin>,
+) -> Vec<Diagnostic> {
+    mark_collisions(&mut plugins);
+    plugins.sort_by(|left, right| {
+        left.id
+            .cmp(&right.id)
+            .then_with(|| left.version.cmp(&right.version))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let allowed = manifest.external_plugins(agent, scope).collect::<Vec<_>>();
+    let allowed_skills = manifest
+        .external_skills(agent, scope)
+        .filter(|skill| skill.origin == ExternalOrigin::Plugin)
+        .collect::<Vec<_>>();
+    plugins
+        .into_iter()
+        .flat_map(|plugin| {
+            let plugin_allowed = allowed.contains(&plugin.id.as_str());
+            let mut diagnostics = vec![plugin_diagnostic(agent, scope, &plugin, plugin_allowed)];
+            diagnostics.extend(plugin.skills.iter().map(|skill| {
+                let skill_allowed = plugin_allowed
+                    && allowed_skills.iter().any(|allowed| {
+                        allowed.plugin == Some(plugin.id.as_str()) && allowed.slug == skill.slug
+                    });
+                skill_diagnostic(agent, scope, &plugin, skill, skill_allowed)
+            }));
+            diagnostics
+        })
+        .collect()
+}
+
+fn mark_collisions(plugins: &mut [Plugin]) {
+    let mut plugin_counts = BTreeMap::new();
+    let mut skill_counts = BTreeMap::new();
+    for plugin in plugins.iter() {
+        *plugin_counts.entry(plugin.id.clone()).or_insert(0) += 1;
+        for skill in &plugin.skills {
+            *skill_counts
+                .entry((plugin.id.clone(), skill.slug.clone()))
+                .or_insert(0) += 1;
+        }
+    }
+    for plugin in plugins {
+        if plugin_counts.get(&plugin.id).copied().unwrap_or(0) > 1 {
+            mark_collision(
+                &mut plugin.topology,
+                &mut plugin.detail,
+                "duplicate plugin identifier",
+            );
+        }
+        for skill in &mut plugin.skills {
+            if skill_counts
+                .get(&(plugin.id.clone(), skill.slug.clone()))
+                .copied()
+                .unwrap_or(0)
+                > 1
+            {
+                mark_collision(
+                    &mut skill.topology,
+                    &mut skill.detail,
+                    "duplicate plugin skill slug",
+                );
+            }
+        }
+    }
+}
+
+fn mark_collision(topology: &mut Topology, detail: &mut Option<String>, reason: &str) {
+    if *topology != Topology::Unreadable {
+        *topology = Topology::Broken;
+    }
+    *detail = Some(match detail.take() {
+        Some(detail) => format!("{detail}; {reason}"),
+        None => reason.to_owned(),
+    });
+}
+
+fn plugin_diagnostic(agent: Agent, scope: Scope, plugin: &Plugin, allowed: bool) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        state(plugin.topology, plugin.exposure, allowed),
+        format!(
+            "external {agent} {scope} plugin {} origin=plugin ownership=external version={} exposure={} topology={} policy={} activation={} path={}{}",
+            plugin.id,
+            plugin.version.as_deref().unwrap_or("unknown"),
+            plugin.exposure,
+            plugin.topology,
+            policy(allowed),
+            activation(plugin.exposure),
+            plugin
+                .path
+                .as_deref()
+                .map_or_else(|| "unknown".to_owned(), |path| path.display().to_string()),
+            detail(plugin.detail.as_deref()),
+        ),
+    )
+}
+
+fn skill_diagnostic(
+    agent: Agent,
+    scope: Scope,
+    plugin: &Plugin,
+    skill: &Skill,
+    allowed: bool,
+) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        state(skill.topology, plugin.exposure, allowed),
+        format!(
+            "external {agent} {scope} skill {} origin=plugin ownership=external container={} version={} exposure={} topology={} policy={} activation={} path={}{}",
+            skill.slug,
+            plugin.id,
+            plugin.version.as_deref().unwrap_or("unknown"),
+            plugin.exposure,
+            skill.topology,
+            policy(allowed),
+            activation(plugin.exposure),
+            skill.path.display(),
+            detail(skill.detail.as_deref()),
+        ),
+    )
+}
+
+pub(super) fn external_skill_diagnostic(
+    agent: Agent,
+    scope: Scope,
+    skill: SystemSkill,
+    allowed: bool,
+) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        state(skill.topology, skill.exposure, allowed),
+        format!(
+            "external {agent} {scope} skill {} origin=system ownership=external container=none version=unknown exposure={} topology={} policy={} activation={} path={}{}",
+            skill.slug,
+            skill.exposure,
+            skill.topology,
+            policy(allowed),
+            activation(skill.exposure),
+            skill.path.display(),
+            detail(skill.detail.as_deref()),
+        ),
+    )
+}
+
+fn state(topology: Topology, exposure: Exposure, allowed: bool) -> State {
+    match (topology, exposure, allowed) {
+        (Topology::Broken | Topology::Unreadable, _, _) => State::Error,
+        (_, Exposure::Enabled, false) => State::Drift,
+        (Topology::Unknown, _, _) | (_, Exposure::Unknown, _) => State::Unsupported,
+        _ => State::Healthy,
+    }
+}
+
+fn policy(allowed: bool) -> &'static str {
+    if allowed { "allowed" } else { "unexpected" }
+}
+
+fn activation(exposure: Exposure) -> &'static str {
+    match exposure {
+        Exposure::Enabled => "available-not-runtime-observed",
+        Exposure::Disabled => "disabled",
+        Exposure::Unknown => "unknown",
+    }
+}
+
+fn detail(value: Option<&str>) -> String {
+    value.map_or_else(String::new, |value| format!(" detail={value}"))
+}

--- a/tooling/arnes/src/skills/external/model.rs
+++ b/tooling/arnes/src/skills/external/model.rs
@@ -1,8 +1,10 @@
 use crate::diagnostic::{Diagnostic, State};
 use crate::manifest::{Agent, ExternalOrigin, Manifest, Scope};
-use std::collections::BTreeMap;
 use std::fmt::{self, Display};
 use std::path::PathBuf;
+
+mod collisions;
+mod human;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub(super) enum Exposure {
@@ -71,7 +73,7 @@ pub(super) fn plugin_diagnostics(
     scope: Scope,
     mut plugins: Vec<Plugin>,
 ) -> Vec<Diagnostic> {
-    mark_collisions(&mut plugins);
+    collisions::mark(&mut plugins);
     plugins.sort_by(|left, right| {
         left.id
             .cmp(&right.id)
@@ -100,52 +102,6 @@ pub(super) fn plugin_diagnostics(
         .collect()
 }
 
-fn mark_collisions(plugins: &mut [Plugin]) {
-    let mut plugin_counts = BTreeMap::new();
-    let mut skill_counts = BTreeMap::new();
-    for plugin in plugins.iter() {
-        *plugin_counts.entry(plugin.id.clone()).or_insert(0) += 1;
-        for skill in &plugin.skills {
-            *skill_counts
-                .entry((plugin.id.clone(), skill.slug.clone()))
-                .or_insert(0) += 1;
-        }
-    }
-    for plugin in plugins {
-        if plugin_counts.get(&plugin.id).copied().unwrap_or(0) > 1 {
-            mark_collision(
-                &mut plugin.topology,
-                &mut plugin.detail,
-                "duplicate plugin identifier",
-            );
-        }
-        for skill in &mut plugin.skills {
-            if skill_counts
-                .get(&(plugin.id.clone(), skill.slug.clone()))
-                .copied()
-                .unwrap_or(0)
-                > 1
-            {
-                mark_collision(
-                    &mut skill.topology,
-                    &mut skill.detail,
-                    "duplicate plugin skill slug",
-                );
-            }
-        }
-    }
-}
-
-fn mark_collision(topology: &mut Topology, detail: &mut Option<String>, reason: &str) {
-    if *topology != Topology::Unreadable {
-        *topology = Topology::Broken;
-    }
-    *detail = Some(match detail.take() {
-        Some(detail) => format!("{detail}; {reason}"),
-        None => reason.to_owned(),
-    });
-}
-
 fn plugin_diagnostic(agent: Agent, scope: Scope, plugin: &Plugin, allowed: bool) -> Diagnostic {
     Diagnostic::new(
         "skills",
@@ -164,6 +120,10 @@ fn plugin_diagnostic(agent: Agent, scope: Scope, plugin: &Plugin, allowed: bool)
                 .map_or_else(|| "unknown".to_owned(), |path| path.display().to_string()),
             detail(plugin.detail.as_deref()),
         ),
+    )
+    .with_human(
+        human::plugin_group(agent, scope, plugin),
+        human::plugin_summary(plugin, policy(allowed)),
     )
 }
 
@@ -190,6 +150,10 @@ fn skill_diagnostic(
             detail(skill.detail.as_deref()),
         ),
     )
+    .with_human(
+        human::plugin_group(agent, scope, plugin),
+        human::plugin_skill_summary(plugin, skill, policy(allowed)),
+    )
 }
 
 pub(super) fn external_skill_diagnostic(
@@ -211,6 +175,10 @@ pub(super) fn external_skill_diagnostic(
             skill.path.display(),
             detail(skill.detail.as_deref()),
         ),
+    )
+    .with_human(
+        format!("{agent} {scope} system skills"),
+        human::system_skill_summary(&skill, policy(allowed)),
     )
 }
 

--- a/tooling/arnes/src/skills/external/model/collisions.rs
+++ b/tooling/arnes/src/skills/external/model/collisions.rs
@@ -1,0 +1,48 @@
+use super::{Plugin, Topology};
+use std::collections::BTreeMap;
+
+pub(super) fn mark(plugins: &mut [Plugin]) {
+    let mut plugin_counts = BTreeMap::new();
+    let mut skill_counts = BTreeMap::new();
+    for plugin in plugins.iter() {
+        *plugin_counts.entry(plugin.id.clone()).or_insert(0) += 1;
+        for skill in &plugin.skills {
+            *skill_counts
+                .entry((plugin.id.clone(), skill.slug.clone()))
+                .or_insert(0) += 1;
+        }
+    }
+    for plugin in plugins {
+        if plugin_counts.get(&plugin.id).copied().unwrap_or(0) > 1 {
+            mark_one(
+                &mut plugin.topology,
+                &mut plugin.detail,
+                "duplicate plugin identifier",
+            );
+        }
+        for skill in &mut plugin.skills {
+            if skill_counts
+                .get(&(plugin.id.clone(), skill.slug.clone()))
+                .copied()
+                .unwrap_or(0)
+                > 1
+            {
+                mark_one(
+                    &mut skill.topology,
+                    &mut skill.detail,
+                    "duplicate plugin skill slug",
+                );
+            }
+        }
+    }
+}
+
+fn mark_one(topology: &mut Topology, detail: &mut Option<String>, reason: &str) {
+    if *topology != Topology::Unreadable {
+        *topology = Topology::Broken;
+    }
+    *detail = Some(match detail.take() {
+        Some(detail) => format!("{detail}; {reason}"),
+        None => reason.to_owned(),
+    });
+}

--- a/tooling/arnes/src/skills/external/model/human.rs
+++ b/tooling/arnes/src/skills/external/model/human.rs
@@ -1,0 +1,55 @@
+use super::{Plugin, Skill, SystemSkill, Topology};
+use crate::manifest::{Agent, Scope};
+use std::path::Path;
+
+pub(super) fn plugin_group(agent: Agent, scope: Scope, plugin: &Plugin) -> String {
+    format!(
+        "{agent} {scope} plugin {}@{}",
+        plugin.id,
+        plugin.version.as_deref().unwrap_or("?")
+    )
+}
+
+pub(super) fn plugin_summary(plugin: &Plugin, policy: &str) -> String {
+    format!(
+        "plugin · {} · {} · {policy}{}{}",
+        plugin.exposure,
+        plugin.topology,
+        path(plugin.topology, plugin.path.as_deref()),
+        detail(plugin.detail.as_deref()),
+    )
+}
+
+pub(super) fn plugin_skill_summary(plugin: &Plugin, skill: &Skill, policy: &str) -> String {
+    format!(
+        "skill {} · {} · {} · {policy}{}{}",
+        skill.slug,
+        plugin.exposure,
+        skill.topology,
+        path(skill.topology, Some(&skill.path)),
+        detail(skill.detail.as_deref()),
+    )
+}
+
+pub(super) fn system_skill_summary(skill: &SystemSkill, policy: &str) -> String {
+    format!(
+        "{} · {} · {} · {policy}{}{}",
+        skill.slug,
+        skill.exposure,
+        skill.topology,
+        path(skill.topology, Some(&skill.path)),
+        detail(skill.detail.as_deref()),
+    )
+}
+
+fn detail(value: Option<&str>) -> String {
+    value.map_or_else(String::new, |value| format!(" — {value}"))
+}
+
+fn path(topology: Topology, path: Option<&Path>) -> String {
+    if topology == Topology::Healthy {
+        String::new()
+    } else {
+        path.map_or_else(String::new, |path| format!(" · {}", path.display()))
+    }
+}

--- a/tooling/arnes/src/skills/external/system.rs
+++ b/tooling/arnes/src/skills/external/system.rs
@@ -1,0 +1,226 @@
+use super::codex;
+use super::model::{Exposure, SystemSkill, Topology, external_skill_diagnostic};
+use super::unsupported;
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, ExternalOrigin, Manifest, Scope};
+use crate::skills::paths::{ancestor_within, canonical_within, label};
+use std::collections::BTreeMap;
+use std::fs::{self, DirEntry};
+use std::io::ErrorKind;
+use std::path::Path;
+
+pub(super) fn diagnose(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Agent,
+    scope: Scope,
+) -> Vec<Diagnostic> {
+    let declared = manifest
+        .external_roots()
+        .filter(|root| root.agent == agent && root.scope == scope)
+        .collect::<Vec<_>>();
+    if declared.is_empty() {
+        return vec![unsupported(
+            agent,
+            scope,
+            "system skills inventory is unsupported",
+        )];
+    }
+    let base = match scope {
+        Scope::User => roots.home(),
+        Scope::Project => roots.repository(),
+    };
+    let mut diagnostics = Vec::new();
+    let mut skills = Vec::new();
+    for root in declared {
+        let (root_diagnostics, root_skills) = scan_root(roots, agent, scope, root.path, base);
+        diagnostics.extend(root_diagnostics);
+        skills.extend(root_skills);
+    }
+    let mut counts = BTreeMap::new();
+    for skill in &skills {
+        *counts.entry(skill.slug.clone()).or_insert(0) += 1;
+    }
+    for mut skill in skills {
+        if counts[&skill.slug] > 1 {
+            skill.topology = Topology::Broken;
+            skill.detail = Some("duplicate system skill slug across roots".to_owned());
+        }
+        let allowed = manifest.external_skills(agent, scope).any(|allowed| {
+            allowed.origin == ExternalOrigin::System
+                && allowed.plugin.is_none()
+                && allowed.slug == skill.slug
+        });
+        diagnostics.push(external_skill_diagnostic(agent, scope, skill, allowed));
+    }
+    diagnostics
+}
+
+fn scan_root(
+    roots: &Roots,
+    agent: Agent,
+    scope: Scope,
+    relative: &Path,
+    base: &Path,
+) -> (Vec<Diagnostic>, Vec<SystemSkill>) {
+    let directory = base.join(relative);
+    let entries = match root_entries(&directory, base) {
+        Ok(Some(entries)) => entries,
+        Ok(None) => {
+            return (
+                vec![root_diagnostic(
+                    agent,
+                    scope,
+                    relative,
+                    State::Healthy,
+                    "absent",
+                    "healthy",
+                    "root is absent",
+                )],
+                Vec::new(),
+            );
+        }
+        Err((topology, detail)) => {
+            return (
+                vec![root_diagnostic(
+                    agent,
+                    scope,
+                    relative,
+                    State::Error,
+                    "unknown",
+                    topology,
+                    detail,
+                )],
+                Vec::new(),
+            );
+        }
+    };
+    let skills = entries
+        .into_iter()
+        .filter_map(|entry| entry_skill(roots, agent, &directory, entry))
+        .collect();
+    (Vec::new(), skills)
+}
+
+fn root_entries(
+    directory: &Path,
+    base: &Path,
+) -> Result<Option<Vec<DirEntry>>, (&'static str, &'static str)> {
+    let metadata = match fs::symlink_metadata(directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return if ancestor_within(directory, base) {
+                Ok(None)
+            } else {
+                Err(("broken", "root has an ancestor outside its scope"))
+            };
+        }
+        Err(_) => return Err(("unreadable", "root metadata could not be read")),
+    };
+    if canonical_within(directory, base).is_none() {
+        let detail = if metadata.file_type().is_symlink() && fs::metadata(directory).is_err() {
+            "root symlink is dangling"
+        } else {
+            "root resolves outside its scope"
+        };
+        return Err(("broken", detail));
+    }
+    if !fs::metadata(directory).is_ok_and(|metadata| metadata.is_dir()) {
+        return Err(("broken", "root is not a directory"));
+    }
+    let mut entries = fs::read_dir(directory)
+        .map_err(|_| ("unreadable", "root directory could not be read"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| ("unreadable", "root directory entry could not be read"))?;
+    entries.sort_by_key(|entry| entry.file_name());
+    Ok(Some(entries))
+}
+
+fn entry_skill(roots: &Roots, agent: Agent, root: &Path, entry: DirEntry) -> Option<SystemSkill> {
+    let slug = entry.file_name().to_string_lossy().into_owned();
+    let path = entry.path();
+    let (topology, detail, exposure) = match entry.file_type() {
+        Ok(kind) if kind.is_dir() || kind.is_symlink() => {
+            let (topology, detail) = classify_skill(&path, root);
+            let exposure = match agent {
+                Agent::Codex => codex::skill_exposure(roots, &path.join("SKILL.md")),
+                Agent::Claude | Agent::Cursor => Exposure::Enabled,
+            };
+            (topology, detail, exposure)
+        }
+        Ok(_) => return None,
+        Err(_) => (
+            Topology::Unreadable,
+            Some("skill metadata could not be read"),
+            Exposure::Unknown,
+        ),
+    };
+    Some(SystemSkill {
+        slug,
+        path,
+        exposure,
+        topology,
+        detail: detail.map(str::to_owned),
+    })
+}
+
+fn classify_skill(path: &Path, root: &Path) -> (Topology, Option<&'static str>) {
+    match fs::metadata(path) {
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return (Topology::Broken, Some("skill link is dangling"));
+        }
+        Err(_) => {
+            return (
+                Topology::Unreadable,
+                Some("skill metadata could not be read"),
+            );
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            return (Topology::Broken, Some("skill is not a directory"));
+        }
+        Ok(_) => {}
+    }
+    if canonical_within(path, root).is_none() {
+        return (Topology::Broken, Some("skill resolves outside its root"));
+    }
+    let skill_file = path.join("SKILL.md");
+    match fs::metadata(&skill_file) {
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return (Topology::Broken, Some("SKILL.md is missing"));
+        }
+        Err(_) => {
+            return (
+                Topology::Unreadable,
+                Some("SKILL.md metadata could not be read"),
+            );
+        }
+        Ok(metadata) if !metadata.is_file() => {
+            return (Topology::Broken, Some("SKILL.md is not a file"));
+        }
+        Ok(_) => {}
+    }
+    if canonical_within(&skill_file, root).is_none() {
+        return (Topology::Broken, Some("SKILL.md resolves outside its root"));
+    }
+    (Topology::Healthy, None)
+}
+
+fn root_diagnostic(
+    agent: Agent,
+    scope: Scope,
+    root: &Path,
+    state: State,
+    exposure: &str,
+    topology: &str,
+    detail: &str,
+) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        state,
+        format!(
+            "external {agent} {scope} system skills root {} origin=system ownership=external exposure={exposure} topology={topology} policy=not-applicable activation=not-runtime-observed detail={detail}",
+            label(scope, root),
+        ),
+    )
+}

--- a/tooling/arnes/tests/cli.rs
+++ b/tooling/arnes/tests/cli.rs
@@ -76,7 +76,7 @@ fn doctor_accepts_shared_options_without_reading_the_environment() {
     assert_eq!(output.status.code(), Some(0));
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
-        "unsupported skills: codex project skill projection is not declared or supported\nunsupported skills: external codex project system skills inventory is unsupported origin=system ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown\nunsupported skills: external codex project plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=project plugin activation has no documented filesystem registry\n"
+        "unsupported skills: codex project skill projection is not declared or supported\n\ncodex project unsupported capabilities\n  unsupported system skills inventory is unsupported\nunsupported skills: external codex project plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=project plugin activation has no documented filesystem registry\n"
     );
     assert!(output.stderr.is_empty());
 }

--- a/tooling/arnes/tests/cli.rs
+++ b/tooling/arnes/tests/cli.rs
@@ -76,7 +76,7 @@ fn doctor_accepts_shared_options_without_reading_the_environment() {
     assert_eq!(output.status.code(), Some(0));
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
-        "unsupported skills: codex project skill projection is not declared or supported\n"
+        "unsupported skills: codex project skill projection is not declared or supported\nunsupported skills: external codex project system skills inventory is unsupported origin=system ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown\nunsupported skills: external codex project plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=project plugin activation has no documented filesystem registry\n"
     );
     assert!(output.stderr.is_empty());
 }

--- a/tooling/arnes/tests/diagnostic.rs
+++ b/tooling/arnes/tests/diagnostic.rs
@@ -71,3 +71,21 @@ fn exit_codes_prioritize_errors_over_drift() {
         assert_eq!(report.exit_code(), expected);
     }
 }
+
+#[test]
+fn human_groups_compact_diagnostics_without_changing_json() {
+    let report = Report::new(vec![
+        Diagnostic::new("skills", State::Healthy, "verbose first")
+            .with_human("claude user external skills", "ponytail · allowed"),
+        Diagnostic::new("skills", State::Drift, "verbose second")
+            .with_human("claude user external skills", "ponytail-audit · unexpected"),
+    ]);
+
+    assert_eq!(
+        report.human(),
+        "claude user external skills\n  healthy     ponytail · allowed\n  drift       ponytail-audit · unexpected"
+    );
+    let json = report.json().unwrap();
+    assert!(json.contains("verbose first"));
+    assert!(!json.contains("ponytail · allowed"));
+}

--- a/tooling/arnes/tests/external_boundary_failures.rs
+++ b/tooling/arnes/tests/external_boundary_failures.rs
@@ -1,0 +1,162 @@
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use serde_json::json;
+use skill_support::{MANIFEST, configured_fixture, run};
+use std::fs;
+use std::os::unix::fs::symlink;
+
+fn policy(roots: &str, skills: &str) -> String {
+    MANIFEST.replacen(
+        "resources:",
+        &format!("external:\n  roots:\n{roots}  plugins: []\n  skills:\n{skills}resources:"),
+        1,
+    )
+}
+
+#[test]
+fn claude_registry_symlink_outside_temporary_home_is_not_read() {
+    let fixture = support::Fixture::new();
+    fixture.write_home(".arnes.yaml", &policy("", ""));
+    fixture.write_home(".claude/plugins/.keep", "");
+    let outside = tempfile::tempdir().unwrap();
+    let outside_registry = outside.path().join("installed_plugins.json");
+    fs::write(
+        &outside_registry,
+        r#"{"version":2,"plugins":{"real-home-sentinel@marketplace":[]}}"#,
+    )
+    .unwrap();
+    symlink(
+        &outside_registry,
+        fixture
+            .home()
+            .join(".claude/plugins/installed_plugins.json"),
+    )
+    .unwrap();
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("registry resolves outside the plugin root"));
+    assert!(!stdout.contains("real-home-sentinel"));
+    assert!(outside_registry.exists());
+}
+
+#[test]
+fn claude_unknown_registry_scope_is_explicitly_unsupported() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &policy("", ""));
+    fixture.write_home(
+        ".claude/plugins/installed_plugins.json",
+        &serde_json::to_string(&json!({
+            "version": 2,
+            "plugins": {"demo@marketplace": [{
+                "scope": "future",
+                "installPath": "/must/not/be/read",
+                "version": "1.0.0"
+            }]}
+        }))
+        .unwrap(),
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("exposure=unknown topology=unknown"));
+    assert!(stdout.contains("unsupported installation scopes future"));
+    assert!(!stdout.contains("must/not/be/read"));
+}
+
+#[test]
+fn claude_install_path_outside_plugin_root_is_not_inspected() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &policy("", ""));
+    fixture.write_home(
+        ".claude/plugins/installed_plugins.json",
+        r#"{"version":2,"plugins":{"demo@marketplace":[{"scope":"user","installPath":"/must/not/be/read","version":"1.0.0"}]}}"#,
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("installed plugin path escapes the plugin root"));
+    assert!(!stdout.contains("plugin manifest is missing"));
+}
+
+#[test]
+fn missing_roots_below_escaping_intermediate_links_are_errors() {
+    for (agent, intermediate, root_path) in [
+        ("codex", ".codex", ".codex/skills/.system"),
+        ("cursor", ".cursor", ".cursor/system-skills"),
+    ] {
+        let fixture = support::Fixture::new();
+        let roots = format!(
+            "    - {{ agent: {agent}, scope: user, origin: system, location: {{ root: home, path: {root_path} }} }}\n"
+        );
+        fixture.write_home(".arnes.yaml", &policy(&roots, ""));
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), fixture.home().join(intermediate)).unwrap();
+
+        let (code, stdout, _) = run(
+            &fixture,
+            &["doctor", "skills", "--agent", agent, "--scope", "user"],
+        );
+
+        assert_eq!(code, 2, "{stdout}");
+        assert!(
+            stdout.contains("root has an ancestor outside its scope"),
+            "{stdout}"
+        );
+        if agent == "cursor" {
+            assert!(
+                stdout.contains("local plugin root has an ancestor outside HOME"),
+                "{stdout}"
+            );
+        }
+    }
+
+    let fixture = support::Fixture::new();
+    fixture.write_home(".arnes.yaml", &policy("", ""));
+    let outside = tempfile::tempdir().unwrap();
+    symlink(outside.path(), fixture.home().join(".claude")).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("plugin root is unreadable or resolves outside HOME"));
+}
+
+#[test]
+fn duplicate_system_skill_slugs_across_roots_are_topological_errors() {
+    let fixture = support::Fixture::new();
+    let roots = "    - { agent: codex, scope: user, origin: system, location: { root: home, path: .codex/first } }\n    - { agent: codex, scope: user, origin: system, location: { root: home, path: .codex/second } }\n";
+    let skills = "    - { agent: codex, scope: user, origin: system, slug: duplicate }\n";
+    fixture.write_home(".arnes.yaml", &policy(roots, skills));
+    fixture.write_home(".codex/first/duplicate/SKILL.md", "first\n");
+    fixture.write_home(".codex/second/duplicate/SKILL.md", "second\n");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2, "{stdout}");
+    assert_eq!(stdout.matches("skill duplicate origin=system").count(), 2);
+    assert_eq!(
+        stdout
+            .matches("duplicate system skill slug across roots")
+            .count(),
+        2
+    );
+}

--- a/tooling/arnes/tests/external_boundary_failures.rs
+++ b/tooling/arnes/tests/external_boundary_failures.rs
@@ -69,7 +69,7 @@ fn claude_unknown_registry_scope_is_explicitly_unsupported() {
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("exposure=unknown topology=unknown"));
+    assert!(stdout.contains("plugin · unknown · unknown · unexpected"));
     assert!(stdout.contains("unsupported installation scopes future"));
     assert!(!stdout.contains("must/not/be/read"));
 }
@@ -152,7 +152,12 @@ fn duplicate_system_skill_slugs_across_roots_are_topological_errors() {
     );
 
     assert_eq!(code, 2, "{stdout}");
-    assert_eq!(stdout.matches("skill duplicate origin=system").count(), 2);
+    assert_eq!(
+        stdout
+            .matches("duplicate · enabled · broken · allowed")
+            .count(),
+        2
+    );
     assert_eq!(
         stdout
             .matches("duplicate system skill slug across roots")

--- a/tooling/arnes/tests/external_claude_plugins.rs
+++ b/tooling/arnes/tests/external_claude_plugins.rs
@@ -74,10 +74,9 @@ fn active_allowlisted_plugin_and_skill_are_external_and_healthy() {
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("plugin demo@marketplace origin=plugin ownership=external"));
-    assert!(stdout.contains("version=1.0.0 exposure=enabled topology=healthy policy=allowed"));
-    assert!(stdout.contains("skill hello origin=plugin ownership=external"));
-    assert!(stdout.contains("container=demo@marketplace version=1.0.0"));
+    assert!(stdout.contains("claude user plugin demo@marketplace@1.0.0"));
+    assert!(stdout.contains("plugin · enabled · healthy · allowed"));
+    assert!(stdout.contains("skill hello · enabled · healthy · allowed"));
     assert!(!stdout.contains("local resource"));
 }
 
@@ -98,13 +97,10 @@ fn active_unexpected_plugin_reports_plugin_and_skill_policy_drift() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert_eq!(
-        stdout.matches("drift skills: external claude user").count(),
-        2
-    );
+    assert_eq!(stdout.matches("  drift       ").count(), 2);
     assert!(stdout.contains("plugin demo@marketplace"));
     assert!(stdout.contains("skill hello"));
-    assert!(stdout.contains("policy=unexpected"));
+    assert!(stdout.contains("· unexpected"));
 }
 
 #[test]
@@ -126,14 +122,14 @@ fn plugin_allowlist_does_not_allow_new_skills_implicitly() {
     assert_eq!(code, 1, "{stdout}");
     let plugin = stdout
         .lines()
-        .find(|line| line.contains("plugin demo@marketplace"))
+        .find(|line| line.contains("plugin ·"))
         .unwrap();
     let skill = stdout
         .lines()
         .find(|line| line.contains("skill future-capability"))
         .unwrap();
-    assert!(plugin.starts_with("healthy skills:"));
-    assert!(skill.starts_with("drift skills:"));
+    assert!(plugin.trim_start().starts_with("healthy"));
+    assert!(skill.trim_start().starts_with("drift"));
 }
 
 #[test]
@@ -153,8 +149,7 @@ fn disabled_plugin_is_visible_without_being_reported_as_active() {
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("exposure=disabled"));
-    assert!(stdout.contains("activation=disabled"));
+    assert!(stdout.contains("· disabled · healthy · unexpected"));
     assert!(!stdout.contains("available-not-runtime-observed"));
 }
 
@@ -185,7 +180,7 @@ fn orphan_cache_is_ignored_and_duplicate_active_versions_are_errors() {
         &["doctor", "skills", "--agent", "claude", "--scope", "user"],
     );
     assert_eq!(code, 2, "{stdout}");
-    assert!(stdout.contains("topology=broken"));
+    assert!(stdout.contains("· broken · allowed"));
     assert!(stdout.contains("ambiguous installed versions 1.0.0,2.0.0"));
 }
 
@@ -210,7 +205,7 @@ fn registry_and_manifest_version_mismatch_is_topological_error() {
     );
 
     assert_eq!(code, 2, "{stdout}");
-    assert!(stdout.contains("topology=broken policy=allowed"));
+    assert!(stdout.contains("· broken · allowed"));
     assert!(stdout.contains("registry and plugin manifest versions differ"));
 }
 

--- a/tooling/arnes/tests/external_claude_plugins.rs
+++ b/tooling/arnes/tests/external_claude_plugins.rs
@@ -1,0 +1,230 @@
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use serde_json::json;
+use skill_support::{MANIFEST, configured_fixture, run};
+use support::Fixture;
+
+fn manifest(plugin: bool, skill: bool) -> String {
+    let plugins = if plugin {
+        "    - { agent: claude, scope: user, id: demo@marketplace }\n"
+    } else {
+        ""
+    };
+    let skills = if skill {
+        "    - { agent: claude, scope: user, origin: plugin, plugin: demo@marketplace, slug: hello }\n"
+    } else {
+        ""
+    };
+    MANIFEST.replacen(
+        "resources:",
+        &format!("external:\n  roots: []\n  plugins:\n{plugins}  skills:\n{skills}resources:"),
+        1,
+    )
+}
+
+fn plugin(fixture: &Fixture, version: &str, slug: &str) -> String {
+    let root = format!(".claude/plugins/cache/marketplace/demo/{version}");
+    fixture.write_home(
+        format!("{root}/.claude-plugin/plugin.json"),
+        &format!("{{\"name\":\"demo\",\"version\":\"{version}\",\"skills\":\"./skills\"}}"),
+    );
+    fixture.write_home(
+        format!("{root}/skills/{slug}/SKILL.md"),
+        "[missing](references/missing.md)\n",
+    );
+    fixture.home().join(root).display().to_string()
+}
+
+fn registry(fixture: &Fixture, installations: serde_json::Value) {
+    fixture.write_home(
+        ".claude/plugins/installed_plugins.json",
+        &serde_json::to_string(&json!({
+            "version": 2,
+            "plugins": {"demo@marketplace": installations}
+        }))
+        .unwrap(),
+    );
+}
+
+fn installation(path: &str, version: &str) -> serde_json::Value {
+    json!({
+        "scope": "user",
+        "installPath": path,
+        "version": version,
+        "installedAt": "2026-08-17T00:00:00Z"
+    })
+}
+
+#[test]
+fn active_allowlisted_plugin_and_skill_are_external_and_healthy() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true, true));
+    let path = plugin(&fixture, "1.0.0", "hello");
+    registry(&fixture, json!([installation(&path, "1.0.0")]));
+    fixture.write_home(
+        ".claude/settings.json",
+        "{\"enabledPlugins\":{\"demo@marketplace\":true}}",
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("plugin demo@marketplace origin=plugin ownership=external"));
+    assert!(stdout.contains("version=1.0.0 exposure=enabled topology=healthy policy=allowed"));
+    assert!(stdout.contains("skill hello origin=plugin ownership=external"));
+    assert!(stdout.contains("container=demo@marketplace version=1.0.0"));
+    assert!(!stdout.contains("local resource"));
+}
+
+#[test]
+fn active_unexpected_plugin_reports_plugin_and_skill_policy_drift() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false, false));
+    let path = plugin(&fixture, "1.0.0", "hello");
+    registry(&fixture, json!([installation(&path, "1.0.0")]));
+    fixture.write_home(
+        ".claude/settings.json",
+        "{\"enabledPlugins\":{\"demo@marketplace\":true}}",
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 1, "{stdout}");
+    assert_eq!(
+        stdout.matches("drift skills: external claude user").count(),
+        2
+    );
+    assert!(stdout.contains("plugin demo@marketplace"));
+    assert!(stdout.contains("skill hello"));
+    assert!(stdout.contains("policy=unexpected"));
+}
+
+#[test]
+fn plugin_allowlist_does_not_allow_new_skills_implicitly() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true, false));
+    let path = plugin(&fixture, "1.0.0", "future-capability");
+    registry(&fixture, json!([installation(&path, "1.0.0")]));
+    fixture.write_home(
+        ".claude/settings.json",
+        "{\"enabledPlugins\":{\"demo@marketplace\":true}}",
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 1, "{stdout}");
+    let plugin = stdout
+        .lines()
+        .find(|line| line.contains("plugin demo@marketplace"))
+        .unwrap();
+    let skill = stdout
+        .lines()
+        .find(|line| line.contains("skill future-capability"))
+        .unwrap();
+    assert!(plugin.starts_with("healthy skills:"));
+    assert!(skill.starts_with("drift skills:"));
+}
+
+#[test]
+fn disabled_plugin_is_visible_without_being_reported_as_active() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false, false));
+    let path = plugin(&fixture, "1.0.0", "hello");
+    registry(&fixture, json!([installation(&path, "1.0.0")]));
+    fixture.write_home(
+        ".claude/settings.json",
+        "{\"enabledPlugins\":{\"demo@marketplace\":false}}",
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("exposure=disabled"));
+    assert!(stdout.contains("activation=disabled"));
+    assert!(!stdout.contains("available-not-runtime-observed"));
+}
+
+#[test]
+fn orphan_cache_is_ignored_and_duplicate_active_versions_are_errors() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true, true));
+    let current = plugin(&fixture, "1.0.0", "hello");
+    plugin(&fixture, "0.9.0", "orphaned");
+    registry(&fixture, json!([installation(&current, "1.0.0")]));
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+    assert_eq!(code, 0, "{stdout}");
+    assert!(!stdout.contains("orphaned"));
+    assert!(!stdout.contains("0.9.0"));
+
+    registry(
+        &fixture,
+        json!([
+            installation(&current, "1.0.0"),
+            installation(&plugin(&fixture, "2.0.0", "hello"), "2.0.0")
+        ]),
+    );
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("topology=broken"));
+    assert!(stdout.contains("ambiguous installed versions 1.0.0,2.0.0"));
+}
+
+#[test]
+fn registry_and_manifest_version_mismatch_is_topological_error() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true, true));
+    let path = plugin(&fixture, "1.0.0", "hello");
+    fixture.write_home(
+        ".claude/plugins/cache/marketplace/demo/1.0.0/.claude-plugin/plugin.json",
+        "{\"name\":\"demo\",\"version\":\"2.0.0\",\"skills\":\"./skills\"}",
+    );
+    registry(&fixture, json!([installation(&path, "1.0.0")]));
+    fixture.write_home(
+        ".claude/settings.json",
+        "{\"enabledPlugins\":{\"demo@marketplace\":true}}",
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("topology=broken policy=allowed"));
+    assert!(stdout.contains("registry and plugin manifest versions differ"));
+}
+
+#[test]
+fn absent_allowed_plugin_and_skill_create_no_policy_drift() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true, true));
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(!stdout.contains("demo@marketplace"));
+    assert!(!stdout.contains("skill hello"));
+}

--- a/tooling/arnes/tests/external_codex_plugins.rs
+++ b/tooling/arnes/tests/external_codex_plugins.rs
@@ -38,8 +38,9 @@ fn codex_plugin_policy_uses_config_but_never_guesses_active_cache_version() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert!(stdout.contains("drift skills: external codex user plugin demo@marketplace"));
-    assert!(stdout.contains("exposure=enabled topology=unknown policy=unexpected"));
+    assert!(stdout.contains("codex user plugin demo@marketplace@?"));
+    assert!(stdout.contains("drift       plugin · enabled · unknown · unexpected"));
+    assert!(stdout.contains("· enabled · unknown · unexpected"));
     assert!(stdout.contains("active cache version cannot be selected reliably"));
     assert!(!stdout.contains("orphan"));
     assert!(!stdout.contains("0.9.0"));
@@ -58,8 +59,9 @@ fn allowed_or_disabled_codex_plugin_does_not_create_false_policy_drift() {
         &["doctor", "skills", "--agent", "codex", "--scope", "user"],
     );
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("unsupported skills: external codex user plugin demo@marketplace"));
-    assert!(stdout.contains("policy=allowed"));
+    assert!(stdout.contains("codex user plugin demo@marketplace@?"));
+    assert!(stdout.contains("unsupported plugin · enabled · unknown · allowed"));
+    assert!(stdout.contains("· enabled · unknown · allowed"));
 
     fixture.write_home(".arnes.yaml", &manifest(false));
     fixture.write_home(
@@ -71,6 +73,6 @@ fn allowed_or_disabled_codex_plugin_does_not_create_false_policy_drift() {
         &["doctor", "skills", "--agent", "codex", "--scope", "user"],
     );
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("exposure=disabled topology=unknown policy=unexpected"));
-    assert!(!stdout.contains("drift skills: external codex user plugin"));
+    assert!(stdout.contains("· disabled · unknown · unexpected"));
+    assert!(!stdout.contains("drift       plugin"));
 }

--- a/tooling/arnes/tests/external_codex_plugins.rs
+++ b/tooling/arnes/tests/external_codex_plugins.rs
@@ -1,0 +1,76 @@
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use skill_support::{MANIFEST, configured_fixture, run};
+
+fn manifest(allowed: bool) -> String {
+    let plugins = if allowed {
+        "    - { agent: codex, scope: user, id: demo@marketplace }\n"
+    } else {
+        ""
+    };
+    MANIFEST.replacen(
+        "resources:",
+        &format!(
+            "external:\n  roots:\n    - {{ agent: codex, scope: user, origin: system, location: {{ root: home, path: .codex/skills/.system }} }}\n  plugins:\n{plugins}  skills: []\nresources:"
+        ),
+        1,
+    )
+}
+
+#[test]
+fn codex_plugin_policy_uses_config_but_never_guesses_active_cache_version() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false));
+    fixture.write_home(
+        ".codex/config.toml",
+        "[plugins.\"demo@marketplace\"]\nenabled = true\n",
+    );
+    fixture.write_home(
+        ".codex/plugins/cache/marketplace/demo/0.9.0/skills/orphan/SKILL.md",
+        "orphan\n",
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 1, "{stdout}");
+    assert!(stdout.contains("drift skills: external codex user plugin demo@marketplace"));
+    assert!(stdout.contains("exposure=enabled topology=unknown policy=unexpected"));
+    assert!(stdout.contains("active cache version cannot be selected reliably"));
+    assert!(!stdout.contains("orphan"));
+    assert!(!stdout.contains("0.9.0"));
+}
+
+#[test]
+fn allowed_or_disabled_codex_plugin_does_not_create_false_policy_drift() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true));
+    fixture.write_home(
+        ".codex/config.toml",
+        "[plugins.\"demo@marketplace\"]\nenabled = true\n",
+    );
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("unsupported skills: external codex user plugin demo@marketplace"));
+    assert!(stdout.contains("policy=allowed"));
+
+    fixture.write_home(".arnes.yaml", &manifest(false));
+    fixture.write_home(
+        ".codex/config.toml",
+        "[plugins.\"demo@marketplace\"]\nenabled = false\n",
+    );
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("exposure=disabled topology=unknown policy=unexpected"));
+    assert!(!stdout.contains("drift skills: external codex user plugin"));
+}

--- a/tooling/arnes/tests/external_cursor_plugins.rs
+++ b/tooling/arnes/tests/external_cursor_plugins.rs
@@ -1,0 +1,198 @@
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use serde_json::Value;
+use skill_support::{MANIFEST, configured_fixture, run};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use support::Fixture;
+
+fn manifest(allow_plugin: bool, allow_skill: bool, system: bool) -> String {
+    let roots = if system {
+        "    - agent: cursor\n      scope: user\n      origin: system\n      location: { root: home, path: .cursor/system-skills }\n"
+    } else {
+        ""
+    };
+    let plugins = if allow_plugin {
+        "    - { agent: cursor, scope: user, id: cursor-demo }\n"
+    } else {
+        ""
+    };
+    let mut skills = String::new();
+    if allow_skill {
+        skills.push_str(
+            "    - { agent: cursor, scope: user, origin: plugin, plugin: cursor-demo, slug: hello }\n",
+        );
+    }
+    if system {
+        skills.push_str("    - { agent: cursor, scope: user, origin: system, slug: alpha }\n");
+    }
+    MANIFEST.replacen(
+        "resources:",
+        &format!("external:\n  roots:\n{roots}  plugins:\n{plugins}  skills:\n{skills}resources:"),
+        1,
+    )
+}
+
+fn plugin(fixture: &Fixture, directory: &str, id: &str, slug: &str) {
+    let root = format!(".cursor/plugins/local/{directory}");
+    fixture.write_home(
+        format!("{root}/plugin.json"),
+        &format!("{{\"name\":\"{id}\",\"version\":\"1.2.3\",\"skills\":\"./skills\"}}"),
+    );
+    fixture.write_home(format!("{root}/skills/{slug}/SKILL.md"), "skill\n");
+}
+
+#[test]
+fn active_allowlisted_cursor_plugin_and_skill_are_healthy() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true, true, false));
+    plugin(&fixture, "demo-directory", "cursor-demo", "hello");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("plugin cursor-demo origin=plugin ownership=external"));
+    assert!(stdout.contains("version=1.2.3 exposure=enabled topology=healthy policy=allowed"));
+    assert!(stdout.contains("skill hello origin=plugin ownership=external"));
+    assert!(stdout.contains("container=cursor-demo version=1.2.3"));
+}
+
+#[test]
+fn active_unexpected_cursor_plugin_reports_plugin_and_skill() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false, false, false));
+    plugin(&fixture, "demo-directory", "cursor-demo", "hello");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+    );
+
+    assert_eq!(code, 1, "{stdout}");
+    assert_eq!(
+        stdout.matches("drift skills: external cursor user").count(),
+        2
+    );
+    assert!(stdout.contains("plugin cursor-demo"));
+    assert!(stdout.contains("skill hello"));
+}
+
+#[test]
+fn managed_system_and_plugin_slug_collisions_remain_distinct() {
+    let fixture = configured_fixture();
+    let policy = manifest(true, false, true).replace(
+        "  skills:\n    - { agent: cursor, scope: user, origin: system, slug: alpha }",
+        "  skills:\n    - { agent: cursor, scope: user, origin: plugin, plugin: cursor-demo, slug: alpha }\n    - { agent: cursor, scope: user, origin: system, slug: alpha }",
+    );
+    fixture.write_home(".arnes.yaml", &policy);
+    plugin(&fixture, "demo-directory", "cursor-demo", "alpha");
+    fixture.write_home(".cursor/system-skills/alpha/SKILL.md", "system\n");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("managed cursor user skill alpha"));
+    assert!(stdout.contains("skill alpha origin=system ownership=external"));
+    assert!(stdout.contains("skill alpha origin=plugin ownership=external container=cursor-demo"));
+}
+
+#[test]
+fn human_and_json_plugin_order_is_stable_and_filters_are_preserved() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false, false, false));
+    plugin(&fixture, "z-directory", "z-plugin", "z-skill");
+    plugin(&fixture, "a-directory", "a-plugin", "a-skill");
+
+    let (_, human, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+    );
+    let (_, json, _) = run(
+        &fixture,
+        &[
+            "doctor", "skills", "--agent", "cursor", "--scope", "user", "--format", "json",
+        ],
+    );
+    assert!(human.find("plugin a-plugin").unwrap() < human.find("plugin z-plugin").unwrap());
+    let diagnostics: Vec<Value> = serde_json::from_str(&json).unwrap();
+    let messages = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic["message"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    let a = messages
+        .iter()
+        .position(|message| message.contains("plugin a-plugin"))
+        .unwrap();
+    let z = messages
+        .iter()
+        .position(|message| message.contains("plugin z-plugin"))
+        .unwrap();
+    assert!(a < z);
+    assert!(
+        messages
+            .iter()
+            .all(|message| message.contains("cursor user"))
+    );
+}
+
+#[test]
+fn duplicate_plugin_ids_and_skill_slugs_are_explicit_errors() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true, true, false));
+    plugin(&fixture, "first", "cursor-demo", "hello");
+    plugin(&fixture, "second", "cursor-demo", "hello");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2, "{stdout}");
+    assert_eq!(stdout.matches("duplicate plugin identifier").count(), 2);
+    assert_eq!(stdout.matches("duplicate plugin skill slug").count(), 2);
+}
+
+#[test]
+fn invalid_cursor_plugin_manifest_is_topological_error() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false, false, false));
+    fixture.write_home(".cursor/plugins/local/broken/plugin.json", "not JSON\n");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("plugin broken"));
+    assert!(stdout.contains("topology=broken policy=unexpected"));
+    assert!(stdout.contains("plugin manifest is invalid JSON"));
+}
+
+#[test]
+fn unreadable_cursor_plugin_is_distinct_from_policy_and_read_only() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false, false, false));
+    plugin(&fixture, "unreadable", "cursor-demo", "hello");
+    let plugin_manifest = fixture
+        .home()
+        .join(".cursor/plugins/local/unreadable/plugin.json");
+    let before = fixture.snapshot();
+    fs::set_permissions(&plugin_manifest, fs::Permissions::from_mode(0o000)).unwrap();
+    let output = fixture.command(["doctor", "skills", "--agent", "cursor", "--scope", "user"]);
+    fs::set_permissions(&plugin_manifest, fs::Permissions::from_mode(0o644)).unwrap();
+
+    assert_eq!(fixture.snapshot(), before);
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("topology=unreadable policy=unexpected"));
+    assert!(stdout.contains("plugin manifest could not be read"));
+}

--- a/tooling/arnes/tests/external_cursor_plugins.rs
+++ b/tooling/arnes/tests/external_cursor_plugins.rs
@@ -56,10 +56,9 @@ fn active_allowlisted_cursor_plugin_and_skill_are_healthy() {
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("plugin cursor-demo origin=plugin ownership=external"));
-    assert!(stdout.contains("version=1.2.3 exposure=enabled topology=healthy policy=allowed"));
-    assert!(stdout.contains("skill hello origin=plugin ownership=external"));
-    assert!(stdout.contains("container=cursor-demo version=1.2.3"));
+    assert!(stdout.contains("cursor user plugin cursor-demo@1.2.3"));
+    assert!(stdout.contains("plugin · enabled · healthy · allowed"));
+    assert!(stdout.contains("skill hello · enabled · healthy · allowed"));
 }
 
 #[test]
@@ -74,10 +73,7 @@ fn active_unexpected_cursor_plugin_reports_plugin_and_skill() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert_eq!(
-        stdout.matches("drift skills: external cursor user").count(),
-        2
-    );
+    assert_eq!(stdout.matches("  drift       ").count(), 2);
     assert!(stdout.contains("plugin cursor-demo"));
     assert!(stdout.contains("skill hello"));
 }
@@ -100,8 +96,9 @@ fn managed_system_and_plugin_slug_collisions_remain_distinct() {
 
     assert_eq!(code, 0, "{stdout}");
     assert!(stdout.contains("managed cursor user skill alpha"));
-    assert!(stdout.contains("skill alpha origin=system ownership=external"));
-    assert!(stdout.contains("skill alpha origin=plugin ownership=external container=cursor-demo"));
+    assert!(stdout.contains("cursor user system skills"));
+    assert!(stdout.contains("alpha · enabled · healthy · allowed"));
+    assert!(stdout.contains("skill alpha · enabled · healthy · allowed"));
 }
 
 #[test]
@@ -173,7 +170,7 @@ fn invalid_cursor_plugin_manifest_is_topological_error() {
 
     assert_eq!(code, 2, "{stdout}");
     assert!(stdout.contains("plugin broken"));
-    assert!(stdout.contains("topology=broken policy=unexpected"));
+    assert!(stdout.contains("· broken · unexpected"));
     assert!(stdout.contains("plugin manifest is invalid JSON"));
 }
 
@@ -193,6 +190,6 @@ fn unreadable_cursor_plugin_is_distinct_from_policy_and_read_only() {
     assert_eq!(fixture.snapshot(), before);
     assert_eq!(output.status.code(), Some(2));
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("topology=unreadable policy=unexpected"));
+    assert!(stdout.contains("· unreadable · unexpected"));
     assert!(stdout.contains("plugin manifest could not be read"));
 }

--- a/tooling/arnes/tests/external_managed_skills.rs
+++ b/tooling/arnes/tests/external_managed_skills.rs
@@ -33,9 +33,8 @@ fn allowed_external_managed_skill_is_healthy_and_not_adopted() {
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("unmanaged codex user skill ponytail origin=managed"));
-    assert!(stdout.contains("ownership=external"));
-    assert!(stdout.contains("topology=healthy policy=allowed"));
+    assert!(stdout.contains("codex user external skills"));
+    assert!(stdout.contains("ponytail · managed · enabled · healthy · allowed"));
     assert!(!stdout.contains("local resource"));
 }
 
@@ -51,7 +50,7 @@ fn unexpected_external_managed_skill_is_policy_drift() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert!(stdout.contains("policy=unexpected"));
+    assert!(stdout.contains("· unexpected"));
 }
 
 #[test]
@@ -80,5 +79,5 @@ fn broken_allowed_external_managed_skill_is_topological_error() {
     );
 
     assert_eq!(code, 2, "{stdout}");
-    assert!(stdout.contains("topology=broken policy=allowed"));
+    assert!(stdout.contains("· broken · allowed"));
 }

--- a/tooling/arnes/tests/external_managed_skills.rs
+++ b/tooling/arnes/tests/external_managed_skills.rs
@@ -1,0 +1,84 @@
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use skill_support::{MANIFEST, configured_fixture, run};
+use std::os::unix::fs::symlink;
+
+fn manifest(allow: bool) -> String {
+    let skills = if allow {
+        "    - { agent: codex, scope: user, origin: managed, slug: ponytail }\n"
+    } else {
+        ""
+    };
+    MANIFEST.replacen(
+        "resources:",
+        &format!("external:\n  roots: []\n  plugins: []\n  skills:\n{skills}resources:"),
+        1,
+    )
+}
+
+#[test]
+fn allowed_external_managed_skill_is_healthy_and_not_adopted() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true));
+    fixture.write_home(
+        ".agents/skills/ponytail/SKILL.md",
+        "[missing](references/missing.md)\n",
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("unmanaged codex user skill ponytail origin=managed"));
+    assert!(stdout.contains("ownership=external"));
+    assert!(stdout.contains("topology=healthy policy=allowed"));
+    assert!(!stdout.contains("local resource"));
+}
+
+#[test]
+fn unexpected_external_managed_skill_is_policy_drift() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false));
+    fixture.write_home(".agents/skills/ponytail/SKILL.md", "ponytail\n");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 1, "{stdout}");
+    assert!(stdout.contains("policy=unexpected"));
+}
+
+#[test]
+fn absent_allowed_external_managed_skill_does_not_drift() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true));
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(!stdout.contains("skill ponytail"));
+}
+
+#[test]
+fn broken_allowed_external_managed_skill_is_topological_error() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(true));
+    symlink("missing", fixture.home().join(".agents/skills/ponytail")).unwrap();
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("topology=broken policy=allowed"));
+}

--- a/tooling/arnes/tests/external_system_skills.rs
+++ b/tooling/arnes/tests/external_system_skills.rs
@@ -36,10 +36,9 @@ fn codex_system_skills_report_policy_without_claiming_runtime_activation() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert!(stdout.contains("skill openai-docs origin=system ownership=external"));
-    assert!(stdout.contains("policy=allowed activation=available-not-runtime-observed"));
-    assert!(stdout.contains("skill surprise origin=system ownership=external"));
-    assert!(stdout.contains("policy=unexpected activation=available-not-runtime-observed"));
+    assert!(stdout.contains("codex user system skills"));
+    assert!(stdout.contains("openai-docs · enabled · healthy · allowed"));
+    assert!(stdout.contains("surprise · enabled · healthy · unexpected"));
     assert!(!stdout.contains("local resource"));
 }
 
@@ -62,9 +61,7 @@ fn disabled_system_skill_is_visible_but_not_active_or_drift() {
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("skill disabled"));
-    assert!(stdout.contains("exposure=disabled"));
-    assert!(stdout.contains("policy=unexpected activation=disabled"));
+    assert!(stdout.contains("disabled · disabled · healthy · unexpected"));
 }
 
 #[test]
@@ -93,8 +90,8 @@ fn undeclared_system_mechanism_is_explicitly_unsupported() {
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("unsupported skills: external codex user system skills inventory"));
-    assert!(stdout.contains("exposure=unknown topology=unknown"));
+    assert!(stdout.contains("codex user unsupported capabilities"));
+    assert!(stdout.contains("system skills inventory is unsupported"));
 }
 
 #[test]
@@ -113,8 +110,8 @@ fn external_inventory_runs_without_a_managed_projection() {
 
     assert_eq!(code, 0, "{stdout}");
     assert!(stdout.contains("skill projection is not declared or supported"));
-    assert!(stdout.contains("skill openai-docs origin=system"));
-    assert!(stdout.contains("policy=allowed"));
+    assert!(stdout.contains("openai-docs · enabled · healthy"));
+    assert!(stdout.contains("· allowed"));
 }
 
 #[test]
@@ -137,9 +134,9 @@ fn valid_absolute_and_relative_links_remain_inside_the_declared_root() {
     for slug in ["absolute", "relative"] {
         let line = stdout
             .lines()
-            .find(|line| line.contains(&format!("skill {slug} ")))
+            .find(|line| line.contains(&format!("{slug} · enabled")))
             .unwrap();
-        assert!(line.contains("topology=healthy"), "{line}");
+        assert!(line.contains("· healthy ·"), "{line}");
     }
 }
 
@@ -158,8 +155,8 @@ fn dangling_and_intermediate_escape_links_are_broken_without_traversal() {
         &["doctor", "skills", "--agent", "codex", "--scope", "user"],
     );
     assert_eq!(code, 2, "{stdout}");
-    assert!(stdout.contains("skill dangling"));
-    assert!(stdout.contains("topology=broken"));
+    assert!(stdout.contains("dangling · enabled · broken"));
+    assert!(stdout.contains("· broken ·"));
 
     let fixture = configured_fixture();
     fixture.write_home(".arnes.yaml", &manifest(""));

--- a/tooling/arnes/tests/external_system_skills.rs
+++ b/tooling/arnes/tests/external_system_skills.rs
@@ -1,0 +1,206 @@
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use skill_support::{MANIFEST, configured_fixture, run};
+use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
+
+fn manifest(skills: &str) -> String {
+    MANIFEST.replacen(
+        "resources:",
+        &format!(
+            "external:\n  roots:\n    - agent: codex\n      scope: user\n      origin: system\n      location: {{ root: home, path: .codex/skills/.system }}\n  skills:\n{skills}  plugins: []\nresources:"
+        ),
+        1,
+    )
+}
+
+fn allow(slug: &str) -> String {
+    format!("    - agent: codex\n      scope: user\n      origin: system\n      slug: {slug}\n")
+}
+
+#[test]
+fn codex_system_skills_report_policy_without_claiming_runtime_activation() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(&allow("openai-docs")));
+    fixture.write_home(
+        ".codex/skills/.system/openai-docs/SKILL.md",
+        "[missing](references/missing.md)\n",
+    );
+    fixture.write_home(".codex/skills/.system/surprise/SKILL.md", "surprise\n");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 1, "{stdout}");
+    assert!(stdout.contains("skill openai-docs origin=system ownership=external"));
+    assert!(stdout.contains("policy=allowed activation=available-not-runtime-observed"));
+    assert!(stdout.contains("skill surprise origin=system ownership=external"));
+    assert!(stdout.contains("policy=unexpected activation=available-not-runtime-observed"));
+    assert!(!stdout.contains("local resource"));
+}
+
+#[test]
+fn disabled_system_skill_is_visible_but_not_active_or_drift() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(""));
+    fixture.write_home(".codex/skills/.system/disabled/SKILL.md", "disabled\n");
+    fixture.write_home(
+        ".codex/config.toml",
+        &format!(
+            "[[skills.config]]\npath = \"{}/.codex/skills/.system/disabled/SKILL.md\"\nenabled = false\n",
+            fixture.home().display()
+        ),
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("skill disabled"));
+    assert!(stdout.contains("exposure=disabled"));
+    assert!(stdout.contains("policy=unexpected activation=disabled"));
+}
+
+#[test]
+fn absent_roots_and_allowed_skills_do_not_drift() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(&allow("openai-docs")));
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("system skills root ~/.codex/skills/.system"));
+    assert!(stdout.contains("exposure=absent topology=healthy"));
+    assert!(!stdout.contains("skill openai-docs"));
+}
+
+#[test]
+fn undeclared_system_mechanism_is_explicitly_unsupported() {
+    let fixture = configured_fixture();
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("unsupported skills: external codex user system skills inventory"));
+    assert!(stdout.contains("exposure=unknown topology=unknown"));
+}
+
+#[test]
+fn external_inventory_runs_without_a_managed_projection() {
+    let fixture = support::Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        "version: 1\nagents:\n  - id: codex\n    scopes: [user]\nskills: []\nexternal:\n  roots:\n    - { agent: codex, scope: user, origin: system, location: { root: home, path: .codex/skills/.system } }\n  plugins: []\n  skills:\n    - { agent: codex, scope: user, origin: system, slug: openai-docs }\nresources: []\n",
+    );
+    fixture.write_home(".codex/skills/.system/openai-docs/SKILL.md", "docs\n");
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("skill projection is not declared or supported"));
+    assert!(stdout.contains("skill openai-docs origin=system"));
+    assert!(stdout.contains("policy=allowed"));
+}
+
+#[test]
+fn valid_absolute_and_relative_links_remain_inside_the_declared_root() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(""));
+    for slug in ["absolute-target", "relative-target"] {
+        fixture.write_home(format!(".codex/skills/.system/{slug}/SKILL.md"), "skill\n");
+    }
+    let root = fixture.home().join(".codex/skills/.system");
+    symlink(root.join("absolute-target"), root.join("absolute")).unwrap();
+    symlink("relative-target", root.join("relative")).unwrap();
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+
+    assert_eq!(code, 1, "{stdout}");
+    for slug in ["absolute", "relative"] {
+        let line = stdout
+            .lines()
+            .find(|line| line.contains(&format!("skill {slug} ")))
+            .unwrap();
+        assert!(line.contains("topology=healthy"), "{line}");
+    }
+}
+
+#[test]
+fn dangling_and_intermediate_escape_links_are_broken_without_traversal() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(""));
+    fs::create_dir_all(fixture.home().join(".codex/skills/.system")).unwrap();
+    symlink(
+        "missing",
+        fixture.home().join(".codex/skills/.system/dangling"),
+    )
+    .unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("skill dangling"));
+    assert!(stdout.contains("topology=broken"));
+
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(""));
+    let outside = fixture.home().parent().unwrap().join("outside-codex");
+    fs::create_dir_all(outside.join("skills/.system/hidden")).unwrap();
+    fs::write(outside.join("skills/.system/hidden/SKILL.md"), "hidden\n").unwrap();
+    symlink("../outside-codex", fixture.home().join(".codex")).unwrap();
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("root resolves outside its scope"));
+    assert!(!stdout.contains("skill hidden"));
+}
+
+#[test]
+fn invalid_and_unreadable_system_roots_are_errors_and_read_only() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(""));
+    fixture.write_home(".codex/skills/.system", "not a directory\n");
+    let (code, stdout, _) = run(
+        &fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("root is not a directory"));
+
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(""));
+    let root = fixture.home().join(".codex/skills/.system");
+    fs::create_dir_all(&root).unwrap();
+    let before = fixture.snapshot();
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o000)).unwrap();
+    let output = fixture.command(["doctor", "skills", "--agent", "codex", "--scope", "user"]);
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap();
+    assert_eq!(fixture.snapshot(), before);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .contains("topology=unreadable")
+    );
+}

--- a/tooling/arnes/tests/manifest.rs
+++ b/tooling/arnes/tests/manifest.rs
@@ -189,7 +189,7 @@ fn external_error(external: &str) -> String {
 #[test]
 fn valid_external_policy_separates_roots_plugins_and_skills() {
     manifest::parse(
-        "version: 1\nagents:\n  - id: codex\n    scopes: [user]\nskills: []\nexternal:\n  roots:\n    - { agent: codex, scope: user, origin: system, location: { root: home, path: .codex/skills/.system } }\n  plugins:\n    - { agent: codex, scope: user, id: demo@marketplace }\n  skills:\n    - { agent: codex, scope: user, origin: system, slug: openai-docs }\n    - { agent: codex, scope: user, origin: plugin, plugin: demo@marketplace, slug: hello }\nresources: []\n",
+        "version: 1\nagents:\n  - id: codex\n    scopes: [user]\nskills: []\nexternal:\n  roots:\n    - { agent: codex, scope: user, origin: system, location: { root: home, path: .codex/skills/.system } }\n  plugins:\n    - { agent: codex, scope: user, id: demo@marketplace }\n  skills:\n    - { agent: codex, scope: user, origin: managed, slug: ponytail }\n    - { agent: codex, scope: user, origin: system, slug: openai-docs }\n    - { agent: codex, scope: user, origin: plugin, plugin: demo@marketplace, slug: hello }\nresources: []\n",
     )
     .unwrap();
 }
@@ -228,6 +228,10 @@ fn ambiguous_external_policy_is_rejected() {
         (
             "  roots: []\n  plugins: []\n  skills:\n    - { agent: codex, scope: user, origin: system, plugin: demo, slug: hello }\n",
             "external.skills[0].plugin: system skills cannot name a plugin",
+        ),
+        (
+            "  roots: []\n  plugins: []\n  skills:\n    - { agent: codex, scope: user, origin: managed, plugin: demo, slug: hello }\n",
+            "external.skills[0].plugin: managed external skills cannot name a plugin",
         ),
         (
             "  roots: []\n  plugins: []\n  skills:\n    - { agent: codex, scope: user, origin: plugin, plugin: demo, slug: hello }\n",

--- a/tooling/arnes/tests/manifest.rs
+++ b/tooling/arnes/tests/manifest.rs
@@ -24,6 +24,12 @@ fn valid_manifest_models_rooted_user_and_project_resources() {
 }
 
 #[test]
+fn repository_manifest_is_valid() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../home/.arnes.yaml");
+    manifest::parse(&fs::read_to_string(path).unwrap()).unwrap();
+}
+
+#[test]
 fn unsupported_version_precedes_resource_validation() {
     assert_eq!(
         error("unsupported-version.yaml"),
@@ -167,5 +173,67 @@ fn skill_declarations_are_normalized_and_unambiguous() {
         ),
     ] {
         assert_eq!(error(fixture), expected);
+    }
+}
+
+fn external_error(external: &str) -> String {
+    let input = format!(
+        "version: 1\nagents:\n  - id: codex\n    scopes: [user]\nskills: []\nexternal:\n{external}resources: []\n"
+    );
+    match manifest::parse(&input) {
+        Ok(_) => panic!("external policy unexpectedly passed validation"),
+        Err(error) => error.to_string(),
+    }
+}
+
+#[test]
+fn valid_external_policy_separates_roots_plugins_and_skills() {
+    manifest::parse(
+        "version: 1\nagents:\n  - id: codex\n    scopes: [user]\nskills: []\nexternal:\n  roots:\n    - { agent: codex, scope: user, origin: system, location: { root: home, path: .codex/skills/.system } }\n  plugins:\n    - { agent: codex, scope: user, id: demo@marketplace }\n  skills:\n    - { agent: codex, scope: user, origin: system, slug: openai-docs }\n    - { agent: codex, scope: user, origin: plugin, plugin: demo@marketplace, slug: hello }\nresources: []\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn duplicate_external_policy_entries_are_rejected() {
+    for (external, expected) in [
+        (
+            "  roots:\n    - &root { agent: codex, scope: user, origin: system, location: { root: home, path: .codex/skills/.system } }\n    - *root\n  plugins: []\n  skills: []\n",
+            "external.roots[1].location: duplicate external root",
+        ),
+        (
+            "  roots: []\n  plugins:\n    - &plugin { agent: codex, scope: user, id: demo@marketplace }\n    - *plugin\n  skills: []\n",
+            "external.plugins[1].id: duplicate external plugin",
+        ),
+        (
+            "  roots: []\n  plugins: []\n  skills:\n    - &skill { agent: codex, scope: user, origin: system, slug: openai-docs }\n    - *skill\n",
+            "external.skills[1].slug: duplicate external skill",
+        ),
+    ] {
+        assert_eq!(external_error(external), expected);
+    }
+}
+
+#[test]
+fn ambiguous_external_policy_is_rejected() {
+    for (external, expected) in [
+        (
+            "  roots:\n    - { agent: codex, scope: user, origin: plugin, location: { root: home, path: .codex/plugins } }\n  plugins: []\n  skills: []\n",
+            "external.roots[0].origin: external roots only support system skills",
+        ),
+        (
+            "  roots: []\n  plugins: []\n  skills:\n    - { agent: codex, scope: user, origin: plugin, slug: hello }\n",
+            "external.skills[0].plugin: plugin skills require a plugin identifier",
+        ),
+        (
+            "  roots: []\n  plugins: []\n  skills:\n    - { agent: codex, scope: user, origin: system, plugin: demo, slug: hello }\n",
+            "external.skills[0].plugin: system skills cannot name a plugin",
+        ),
+        (
+            "  roots: []\n  plugins: []\n  skills:\n    - { agent: codex, scope: user, origin: plugin, plugin: demo, slug: hello }\n",
+            "external.skills[0].plugin: plugin skill requires a matching allowed plugin",
+        ),
+    ] {
+        assert_eq!(external_error(external), expected);
     }
 }

--- a/tooling/arnes/tests/skill_adversarial.rs
+++ b/tooling/arnes/tests/skill_adversarial.rs
@@ -111,7 +111,7 @@ fn undeclared_aliases_of_managed_sources_remain_unmanaged() {
         &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
     );
 
-    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(code, 1, "{stdout}");
     assert!(stdout.contains("unmanaged cursor user skill plugin-owned"));
     assert_eq!(stdout.matches("managed cursor user skill alpha").count(), 1);
 }

--- a/tooling/arnes/tests/skill_adversarial.rs
+++ b/tooling/arnes/tests/skill_adversarial.rs
@@ -112,7 +112,7 @@ fn undeclared_aliases_of_managed_sources_remain_unmanaged() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert!(stdout.contains("unmanaged cursor user skill plugin-owned"));
+    assert!(stdout.contains("plugin-owned · managed · enabled · healthy · unexpected"));
     assert_eq!(stdout.matches("managed cursor user skill alpha").count(), 1);
 }
 

--- a/tooling/arnes/tests/skill_failures.rs
+++ b/tooling/arnes/tests/skill_failures.rs
@@ -139,7 +139,7 @@ fn unmanaged_installations_are_preserved_and_not_validated_as_owned() {
         &["doctor", "skills", "--agent", "claude", "--scope", "user"],
     );
 
-    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(code, 1, "{stdout}");
     assert!(stdout.contains("unmanaged claude user skill third-party"));
     assert!(!stdout.contains("local resource"));
     assert_eq!(fixture.snapshot(), before);
@@ -151,9 +151,9 @@ fn unmanaged_installations_are_preserved_and_not_validated_as_owned() {
         &fixture,
         &["doctor", "skills", "--agent", "claude", "--scope", "user"],
     );
-    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(code, 2, "{stdout}");
     assert!(stdout.contains("broken claude user skill dangling-third-party"));
-    assert!(stdout.contains("is unmanaged and not Arnes-owned"));
+    assert!(stdout.contains("detail=unmanaged and not Arnes-owned"));
 }
 
 #[test]

--- a/tooling/arnes/tests/skill_failures.rs
+++ b/tooling/arnes/tests/skill_failures.rs
@@ -122,7 +122,7 @@ fn project_discovery_survives_managed_skill_drift() {
 
     assert_eq!(code, 1, "{stdout}");
     assert!(stdout.contains("broken managed claude project skill alpha"));
-    assert!(stdout.contains("unmanaged claude project skill beta"));
+    assert!(stdout.contains("beta · managed · enabled · healthy · unexpected"));
     assert!(!stdout.contains("local resource references/missing.md"));
 }
 
@@ -140,7 +140,7 @@ fn unmanaged_installations_are_preserved_and_not_validated_as_owned() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert!(stdout.contains("unmanaged claude user skill third-party"));
+    assert!(stdout.contains("third-party · managed · enabled · healthy · unexpected"));
     assert!(!stdout.contains("local resource"));
     assert_eq!(fixture.snapshot(), before);
 
@@ -152,8 +152,7 @@ fn unmanaged_installations_are_preserved_and_not_validated_as_owned() {
         &["doctor", "skills", "--agent", "claude", "--scope", "user"],
     );
     assert_eq!(code, 2, "{stdout}");
-    assert!(stdout.contains("broken claude user skill dangling-third-party"));
-    assert!(stdout.contains("detail=unmanaged and not Arnes-owned"));
+    assert!(stdout.contains("dangling-third-party · managed · unknown · broken · unexpected"));
 }
 
 #[test]

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -12,17 +12,17 @@ fn declared_skills_are_managed_and_undeclared_project_skills_are_unmanaged() {
 
     assert_eq!(code, 1, "{stdout}");
     assert_eq!(stdout.matches("healthy skills: managed").count(), 6);
-    assert_eq!(stdout.matches("drift skills: unmanaged").count(), 3);
+    assert_eq!(stdout.matches("  drift       beta · managed").count(), 3);
     for expected in [
         "managed claude user skill alpha",
         "managed claude project skill alpha",
-        "unmanaged claude project skill beta",
+        "claude project external skills",
         "managed cursor user skill alpha",
         "managed cursor project skill alpha",
-        "unmanaged cursor project skill beta",
+        "cursor project external skills",
         "managed codex user skill alpha",
         "managed codex project skill alpha",
-        "unmanaged codex project skill beta",
+        "codex project external skills",
     ] {
         assert!(stdout.contains(expected), "missing {expected}: {stdout}");
     }
@@ -50,15 +50,24 @@ fn agent_and_scope_filters_isolate_skill_projections() {
     assert_eq!(
         stdout
             .lines()
-            .filter(|line| line.starts_with("drift skills: unmanaged cursor project"))
+            .filter(|line| line.contains("drift       beta · managed"))
             .count(),
         1
     );
-    assert!(stdout.lines().all(|line| line.contains("cursor project")));
+    assert!(stdout.lines().filter(|line| !line.is_empty()).all(|line| {
+        line.contains("cursor project")
+            || line.contains("beta · managed")
+            || line.starts_with("  unsupported")
+    }));
 
     let (code, stdout, _) = run(&fixture, &["doctor", "skills", "--scope", "user"]);
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.lines().all(|line| line.contains(" user ")));
+    assert!(
+        stdout
+            .lines()
+            .filter(|line| !line.is_empty() && !line.starts_with("  "))
+            .all(|line| line.contains(" user "))
+    );
 }
 
 #[test]

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -11,7 +11,6 @@ fn declared_skills_are_managed_and_undeclared_project_skills_are_unmanaged() {
     let (code, stdout, stderr) = run(&fixture, &["doctor", "skills"]);
 
     assert_eq!(code, 0, "{stdout}");
-    assert_eq!(stdout.lines().count(), 9);
     assert_eq!(stdout.matches("healthy skills: managed").count(), 6);
     assert_eq!(stdout.matches("unsupported skills: unmanaged").count(), 3);
     for expected in [
@@ -41,12 +40,24 @@ fn agent_and_scope_filters_isolate_skill_projections() {
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert_eq!(stdout.lines().count(), 2);
+    assert_eq!(
+        stdout
+            .lines()
+            .filter(|line| line.starts_with("healthy skills: managed cursor project"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        stdout
+            .lines()
+            .filter(|line| line.starts_with("unsupported skills: unmanaged cursor project"))
+            .count(),
+        1
+    );
     assert!(stdout.lines().all(|line| line.contains("cursor project")));
 
     let (code, stdout, _) = run(&fixture, &["doctor", "skills", "--scope", "user"]);
     assert_eq!(code, 0, "{stdout}");
-    assert_eq!(stdout.lines().count(), 3);
     assert!(stdout.lines().all(|line| line.contains(" user ")));
 }
 

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -10,9 +10,9 @@ fn declared_skills_are_managed_and_undeclared_project_skills_are_unmanaged() {
     let fixture = configured_fixture();
     let (code, stdout, stderr) = run(&fixture, &["doctor", "skills"]);
 
-    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(code, 1, "{stdout}");
     assert_eq!(stdout.matches("healthy skills: managed").count(), 6);
-    assert_eq!(stdout.matches("unsupported skills: unmanaged").count(), 3);
+    assert_eq!(stdout.matches("drift skills: unmanaged").count(), 3);
     for expected in [
         "managed claude user skill alpha",
         "managed claude project skill alpha",
@@ -39,7 +39,7 @@ fn agent_and_scope_filters_isolate_skill_projections() {
         ],
     );
 
-    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(code, 1, "{stdout}");
     assert_eq!(
         stdout
             .lines()
@@ -50,7 +50,7 @@ fn agent_and_scope_filters_isolate_skill_projections() {
     assert_eq!(
         stdout
             .lines()
-            .filter(|line| line.starts_with("unsupported skills: unmanaged cursor project"))
+            .filter(|line| line.starts_with("drift skills: unmanaged cursor project"))
             .count(),
         1
     );
@@ -99,7 +99,7 @@ fn skills_doctor_is_isolated_and_read_only() {
 
     let (code, _, _) = run(&fixture, &["doctor", "skills"]);
 
-    assert_eq!(code, 0);
+    assert_eq!(code, 1);
     assert_eq!(fixture.snapshot(), before);
 }
 


### PR DESCRIPTION
Closes #145

## Summary

- add durable per-agent, per-scope allowlists for external plugins and system/plugin skills
- inventory supported Codex system skills, Claude Code plugins, Cursor local plugins, and exposed plugin skills
- report ownership, origin, container/version, exposure, topology, policy, and runtime-observation limits without mutating HOME or the repository
- fail closed for unsupported activation sources, orphan caches, unreadable paths, duplicate identities, and symlink escapes
- document the supported contracts and allowlist openai-docs as a Codex system skill

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test (151 tests on Darwin arm64)
- git diff --check