### PR TITLE
feat(arnes): default doctor scope to user

### DIFF
--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -23,7 +23,7 @@ enum Command {
         resource: Option<Resource>,
         #[arg(long, value_enum)]
         agent: Option<Agent>,
-        #[arg(long, value_enum)]
+        #[arg(long, value_enum, default_value = "user")]
         scope: Option<Scope>,
         #[arg(long, value_enum, default_value_t)]
         format: Format,

--- a/tooling/arnes/tests/config.rs
+++ b/tooling/arnes/tests/config.rs
@@ -46,20 +46,17 @@ fn run(fixture: &Fixture, args: &[&str]) -> (i32, String, String) {
 }
 
 #[test]
-fn all_declared_agent_configurations_accept_unknown_keys() {
+fn user_scope_is_default_and_accepts_unknown_keys() {
     let fixture = configured_fixture();
     let (code, stdout, stderr) = run(&fixture, &["doctor", "config"]);
 
     assert_eq!(code, 0);
-    assert_eq!(stdout.lines().count(), 6);
+    assert_eq!(stdout.lines().count(), 3);
     assert!(stderr.is_empty());
     for expected in [
         "healthy config: claude user",
-        "healthy config: claude project",
         "healthy config: cursor user",
-        "healthy config: cursor project",
         "healthy config: codex user",
-        "healthy config: codex project",
     ] {
         assert!(stdout.contains(expected), "missing {expected}: {stdout}");
     }
@@ -78,8 +75,8 @@ fn agent_and_scope_filters_isolate_selected_configurations() {
         ),
         (
             vec!["doctor", "config", "--agent", "claude"],
-            2,
-            "healthy config: claude project",
+            1,
+            "healthy config: claude user",
         ),
     ] {
         let (code, stdout, stderr) = run(&fixture, &args);
@@ -103,8 +100,8 @@ fn missing_roots_and_files_are_drift() {
     fixture.write_home(".arnes.yaml", ALL_AGENTS);
     let (code, stdout, _) = run(&fixture, &["doctor", "config"]);
     assert_eq!(code, 1);
-    assert_eq!(stdout.matches("root ").count(), 6);
-    assert_eq!(stdout.matches("is missing").count(), 6);
+    assert_eq!(stdout.matches("root ").count(), 3);
+    assert_eq!(stdout.matches("is missing").count(), 3);
 
     for path in [".claude", ".cursor", ".codex"] {
         fs::create_dir_all(fixture.home().join(path)).unwrap();
@@ -112,8 +109,8 @@ fn missing_roots_and_files_are_drift() {
     }
     let (code, stdout, _) = run(&fixture, &["doctor", "config"]);
     assert_eq!(code, 1);
-    assert_eq!(stdout.matches("file ").count(), 6);
-    assert_eq!(stdout.matches("is missing").count(), 6);
+    assert_eq!(stdout.matches("file ").count(), 3);
+    assert_eq!(stdout.matches("is missing").count(), 3);
 }
 
 #[test]
@@ -233,7 +230,7 @@ fn empty_manifests_are_explicitly_unsupported() {
         assert_eq!(code, 0);
         assert_eq!(
             stdout,
-            "unsupported config: no configuration combinations are declared in the manifest\n"
+            "unsupported config: user configuration scope is not declared in the manifest\n"
         );
         assert!(stderr.is_empty());
     }

--- a/tooling/arnes/tests/instructions.rs
+++ b/tooling/arnes/tests/instructions.rs
@@ -7,23 +7,20 @@ use std::fs;
 use support::Fixture;
 
 #[test]
-fn supported_projections_are_healthy_and_native_projections_are_unsupported() {
+fn user_scope_is_default_for_supported_and_unsupported_projections() {
     let fixture = configured_fixture();
     let (code, stdout, stderr) = run(&fixture, &["doctor", "instructions"]);
 
     assert_eq!(code, 0);
-    assert_eq!(stdout.lines().count(), 8);
-    assert_eq!(stdout.matches("healthy instructions:").count(), 5);
-    assert_eq!(stdout.matches("unsupported instructions:").count(), 3);
+    assert_eq!(stdout.lines().count(), 5);
+    assert_eq!(stdout.matches("healthy instructions:").count(), 4);
+    assert_eq!(stdout.matches("unsupported instructions:").count(), 1);
     for expected in [
         "healthy instructions: claude user instructions claude-user-instructions",
         "healthy instructions: claude user instructions claude-user-soul",
         "healthy instructions: claude user instructions claude-user-preferences",
-        "healthy instructions: claude project instructions claude-project-instructions",
         "unsupported instructions: cursor user instruction projection",
-        "unsupported instructions: cursor project instruction projection",
         "healthy instructions: codex user instructions codex-user-instructions",
-        "unsupported instructions: codex project instruction projection",
     ] {
         assert!(stdout.contains(expected), "missing {expected}: {stdout}");
     }
@@ -52,7 +49,7 @@ fn agent_and_scope_filters_isolate_projections() {
 
     let (code, stdout, _) = run(&fixture, &["doctor", "instructions", "--agent", "cursor"]);
     assert_eq!(code, 0);
-    assert_eq!(stdout.matches("unsupported instructions:").count(), 2);
+    assert_eq!(stdout.matches("unsupported instructions:").count(), 1);
 
     let (code, stdout, _) = run(
         &fixture,
@@ -82,7 +79,7 @@ fn undeclared_filtered_combinations_are_unsupported() {
     assert_eq!(code, 0);
     assert_eq!(
         stdout,
-        "unsupported instructions: codex instruction projection is not declared or supported\n"
+        "unsupported instructions: codex user instruction projection is not declared or supported\n"
     );
     assert!(stderr.is_empty());
 }

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -6,23 +6,17 @@ use skill_support::{MANIFEST, configured_fixture, run};
 use support::Fixture;
 
 #[test]
-fn declared_skills_are_managed_and_undeclared_project_skills_are_unmanaged() {
+fn user_scope_is_default_for_declared_skills() {
     let fixture = configured_fixture();
     let (code, stdout, stderr) = run(&fixture, &["doctor", "skills"]);
 
-    assert_eq!(code, 1, "{stdout}");
-    assert_eq!(stdout.matches("healthy skills: managed").count(), 6);
-    assert_eq!(stdout.matches("  drift       beta · managed").count(), 3);
+    assert_eq!(code, 0, "{stdout}");
+    assert_eq!(stdout.matches("healthy skills: managed").count(), 3);
+    assert!(!stdout.contains(" project "));
     for expected in [
         "managed claude user skill alpha",
-        "managed claude project skill alpha",
-        "claude project external skills",
         "managed cursor user skill alpha",
-        "managed cursor project skill alpha",
-        "cursor project external skills",
         "managed codex user skill alpha",
-        "managed codex project skill alpha",
-        "codex project external skills",
     ] {
         assert!(stdout.contains(expected), "missing {expected}: {stdout}");
     }
@@ -108,7 +102,7 @@ fn skills_doctor_is_isolated_and_read_only() {
 
     let (code, _, _) = run(&fixture, &["doctor", "skills"]);
 
-    assert_eq!(code, 1);
+    assert_eq!(code, 0);
     assert_eq!(fixture.snapshot(), before);
 }
 


### PR DESCRIPTION
## Description

- Default `arnes doctor` resource diagnostics to the `user` scope when `--scope` is omitted.
- Preserve explicit `--scope project` behavior.
- Update config, instructions, and skills integration coverage for the new default.

This intentionally removes the previous implicit all-scopes invocation; project diagnostics now require `--scope project`.

## Useful Links

- Issue: N/A

## How to Test

- `cargo fmt --manifest-path tooling/arnes/Cargo.toml --check`
- `cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tooling/arnes/Cargo.toml`

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)