### PR TITLE
feat(skills): strengthen merge-verdict review

### DIFF
--- a/.agents/skills/merge-verdict/SKILL.md
+++ b/.agents/skills/merge-verdict/SKILL.md
@@ -59,8 +59,8 @@ first, unless the request explicitly says to post directly.
    finding before the flow is traced end to end is forbidden: the mechanism is what makes a finding
    blocking, and you cannot name a mechanism you have not followed.
 
-3. **Sweep the failure classes.** Put every question in `references/failure-classes.md` to the diff.
-   Record, per class, one of: not applicable, holds because `<evidence>`, or broken by
+3. **Sweep the failure classes.** Put all ten questions in `references/failure-classes.md` to the
+   diff. Record, per class, one of: not applicable, holds because `<evidence>`, or broken by
    `<mechanism>`. Only the third form can become a blocker.
 
 4. **Run the barrier, then declare its holes.** Run lint, typecheck and tests the way the project
@@ -137,7 +137,7 @@ first, unless the request explicitly says to post directly.
 
 - [references/forges.md](references/forges.md) — forge detection and the GitHub/Bitbucket command
   parity table. Read in phase 1, before the first CLI call.
-- [references/failure-classes.md](references/failure-classes.md) — the eight failure classes as
+- [references/failure-classes.md](references/failure-classes.md) — the ten failure classes as
   questions to put to the diff. Read in phase 3.
 - [assets/verdict-template.md](assets/verdict-template.md) — the verdict skeleton with its required
   slots. Filled in phase 6.

--- a/.agents/skills/merge-verdict/references/failure-classes.md
+++ b/.agents/skills/merge-verdict/references/failure-classes.md
@@ -1,6 +1,6 @@
 # Failure Classes
 
-Eight questions to put to the diff in phase 3. Each is a question, not a checklist item to tick: the
+Ten questions to put to the diff in phase 3. Each is a question, not a checklist item to tick: the
 answer is a sentence about *this* diff. Record one of three outcomes per class.
 
 - **not applicable** — the diff does not touch that concern; say why in one clause.
@@ -10,6 +10,10 @@ answer is a sentence about *this* diff. Record one of three outcomes per class.
 Only the third outcome can become a blocking finding, and only when the mechanism is written out.
 "This looks racy" is not a mechanism; "request A snapshots at T1, request B writes at T2, A commits
 at T3 and B's row is absent from the successor" is.
+
+The same questions apply to a design document: the mechanism under review is what the document
+authorizes someone to build. A document that leaves a class open produces the defect during
+implementation instead of preventing it during review.
 
 ## 1. Atomicity and ordering
 
@@ -105,14 +109,37 @@ which is strictly worse than rejecting the input.
 **Lift:** the value is parsed into the type it claims to be, and the unparseable case is an error
 with a message naming what was received.
 
+## 9. Upstream control as a trust boundary
+
+**Ask:** does this diff keep validation or confinement at the trust boundary distinct from every
+upstream allowlist, index, internal view or owned schema?
+
+**Broken when:** an upstream control is treated as proof that its output is trustworthy, so the
+boundary guard does not run. The upstream mechanism controls selection or representation, not the
+validity or confinement of every value it emits, and its drift crosses the boundary unchecked.
+
+**Lift:** the boundary guard still validates the value or confines it against the canonical boundary
+when it is consumed, independently of the upstream control, and each mechanism remains explicit.
+
+## 10. Claim stronger than mechanism
+
+**Ask:** does every guarantee claimed by this diff match what its mechanism actually establishes?
+
+**Broken when:** the wording promotes a weaker property into a stronger outcome — intent into
+effect, integrity into legal proof, or proposal into authority. A reader then builds or relies on
+an assurance that no mechanism delivers.
+
+**Lift:** the claim uses the weaker term the mechanism supports when no external obligation requires
+more; otherwise the missing mechanism, evidence or authority makes the stronger guarantee true.
+
 ## Reporting
 
-Classes 1, 2, 3, 4, 5 and 7 name mechanisms that lose data, corrupt state or cross a security
-boundary: when broken, they block. Classes 6 and 8 are usually reservations — promote one to a
-blocker only when a concrete consumer or a concrete input path makes the consequence unbounded, and
-say which one.
+Classes 1, 2, 3, 4, 5, 7 and 9 name mechanisms that lose data, corrupt state or cross a security
+boundary: when broken, they block. Classes 6, 8 and 10 are usually reservations — promote class 6
+when a concrete consumer's retry path depends on the changed code, class 8 when the degraded value
+reaches a person or a legal act, and class 10 when the claim is legal, evidentiary or contractual.
 
-Findings outside these eight classes are legitimate but non-blocking by default: report at most three
+Findings outside these ten classes are legitimate but non-blocking by default: report at most three
 of them, one line each, labelled non-blocking, or drop them. The cap is what stops the sweep from
 turning into a second review that competes with the verdict — rank them by whether they would change
 a reviewer's decision and keep the top three. If the verdict runs past about thirty lines, that is

--- a/harness/USER.md
+++ b/harness/USER.md
@@ -32,8 +32,9 @@ transactions). Aucun rappel de fondamentaux sur ces sujets : aller au fait.
   comparaison sur pièces. Ne pas se contenter d'objecter, ne pas bloquer.
 - **Périmètre.** Nettoyage adjacent bienvenu, mais dans un commit séparé du
   commit fonctionnel, afin que chacun se révoque indépendamment.
-- **Barre de vérification.** Lint et types verts suffisent par défaut ; les
-  tests sont exécutés à la demande ou sur un chemin sensible.
+- **Barre de vérification.** Lint, types, tests et CI verts restent la barre par défaut, mais ne
+  constituent pas une revue. Avant de demander une revue sur une PR que vous ouvrez, passez
+  `merge-verdict` sur votre propre PR et corrigez ses constats bloquants avant de solliciter quiconque.
 
 ## Points de vigilance
 


### PR DESCRIPTION
## Description

- add failure classes for upstream controls mistaken for trust boundaries and guarantees stronger than their mechanisms
- extend the adverse sweep to design documents and promote legal-impact failures to blockers
- require `merge-verdict` on authored pull requests before requesting review

## Useful Links

- Issue: N/A

## How to Test

- run `git diff --check`
- validate `merge-verdict` against the local skill conventions
- exercise the new classes with upstream-trust, contractual-claim, and legal-recipient scenarios

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
