### PR TITLE
feat(merge-verdict): gate pull requests on a published self-verdict

### DIFF
--- a/.agents/skills/merge-verdict/SKILL.md
+++ b/.agents/skills/merge-verdict/SKILL.md
@@ -61,7 +61,9 @@ first, unless the request explicitly says to post directly.
 
 3. **Sweep the failure classes.** Put all ten questions in `references/failure-classes.md` to the
    diff. Record, per class, one of: not applicable, holds because `<evidence>`, or broken by
-   `<mechanism>`. Only the third form can become a blocker.
+   `<mechanism>`. Only the third form can become a blocker. When the head under review was written
+   in this session, delegate the sweep to a fresh context: the context that produced the diff shares
+   the blind spot that produced the defect, and records `holds` for the class it has just broken.
 
 4. **Run the barrier, then declare its holes.** Run lint, typecheck and tests the way the project
    runs them — including inside a container when the project requires it, since numbers from the
@@ -83,7 +85,7 @@ first, unless the request explicitly says to post directly.
    verdict if one exists. Never open a ticket solely to request or record a re-review: the new
    head-specific verdict comment is that record. Write one general comment from
    `assets/verdict-template.md`, prefixed with the idempotency marker
-   `<!-- merge-verdict:<pr>:<head-sha> -->` — not a rain of inline comments. Search the existing
+   `<!-- merge-verdict:<pr>:<head-sha-12> -->` — not a rain of inline comments. Search the existing
    comments for that marker first: a verdict carrying the same `<pr>:<sha>` is updated in place,
    never duplicated. Re-read before publishing — past about thirty lines, non-blocking remarks are
    posing as blockers. On GitHub, _changes required_ is published with
@@ -130,6 +132,7 @@ first, unless the request explicitly says to post directly.
 - Never open a review that is not anchored on a head SHA.
 - Never leave a limit of the evidence implicit; the barrier's gaps belong in the verdict text.
 - Never publish two verdicts for the same `<pr>:<sha>`; update the existing comment instead.
+- Never sweep the failure classes on a head you wrote in this session from the context that wrote it.
 - Never create a ticket solely to request, schedule or record a re-review.
 - Never publish without confirmation, unless the request explicitly says to post directly.
 

--- a/.agents/skills/merge-verdict/references/cases.md
+++ b/.agents/skills/merge-verdict/references/cases.md
@@ -18,8 +18,8 @@ index backs the uniqueness the service checks in code. Unit tests exist and pass
 
 **Pass criteria**
 
-- The verdict is anchored on the head SHA, and the marker `<!-- merge-verdict:<pr>:<sha> -->` is the
-  first line.
+- The verdict is anchored on the head SHA, and the marker
+  `<!-- merge-verdict:<pr>:<head-sha-12> -->` is the first line.
 - At least one blocker is stated as an ordered sequence ending in a broken invariant — the
   out-of-transaction read, the stale retry, or the missing constraint. Failure classes 1, 2 and 3.
 - The barrier paragraph gives counts _and_ states that the passing tests are sequential and therefore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -112,6 +112,7 @@ jobs:
             | grep -Fx 'This installer supports macOS only; Linux and GitHub Codespaces are unsupported.'
 
           tooling/agent-handoff-test
+          tooling/merge-verdict-gate-test
           tooling/upgrade-test
           tooling/ci-smoke-targets-test
           echo "✅ Shell scripts OK"

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ cursor: ~/.local/bin/cursor-agent ~/.cursor/skills/enforcement-code ~/.cursor/sk
 	${CREATE_SYMLINK}
 
 .PHONY: claude-code
-claude-code: ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/hooks/agent_handoff ~/.claude/rules/agent-instructions.md ~/.claude/skills/handoff ~/.claude/skills/enforcement-code ~/.claude/skills/merge-verdict
+claude-code: ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/hooks/agent_handoff ~/.claude/hooks/merge-verdict-gate ~/.claude/rules/agent-instructions.md ~/.claude/skills/handoff ~/.claude/skills/enforcement-code ~/.claude/skills/merge-verdict
 ${LOCAL_BIN}/claude:
 	curl -fsSL https://claude.ai/install.sh | bash -s latest
 ~/.claude:
@@ -397,6 +397,10 @@ ${LOCAL_BIN}/claude:
 ~/.claude/hooks ~/.claude/rules ~/.claude/skills: | ~/.claude
 	mkdir -p $@
 ~/.claude/hooks/agent_handoff: ${DOTFILES_PATH}/tooling/agent-handoff | ~/.claude/hooks
+	${CREATE_SYMLINK}
+# Deploying the link does not register the hook: the PreToolUse entry lives in
+# ~/.claude/settings.json, deferred to arnes for all three harnesses (issues #120, #111).
+~/.claude/hooks/merge-verdict-gate: ${DOTFILES_PATH}/tooling/merge-verdict-gate | ~/.claude/hooks
 	${CREATE_SYMLINK}
 ~/.claude/rules/agent-instructions.md: ${DOTFILES_PATH}/harness/rules/agent-instructions.md | ~/.claude/rules
 	${CREATE_SYMLINK}

--- a/tooling/merge-verdict-gate
+++ b/tooling/merge-verdict-gate
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly MUTATES='(gh|bkt)[[:space:]]+pr[[:space:]]+(create|new|edit|update|ready|publish|merge)([[:space:]]|$)'
+readonly CREATES='(gh|bkt)[[:space:]]+pr[[:space:]]+(create|new)([[:space:]]|$)'
+readonly RAW_CALL='(^|[[:space:]])((gh|bkt)[[:space:]]+api|curl)([[:space:]]|$)'
+readonly PR_ROUTE='(pulls|pullrequests|pull-requests)/|requested_reviewers|requestReviews'
+readonly WRITE='--method[[:space:]]+(POST|PUT|PATCH|DELETE)|-X[[:space:]]+(POST|PUT|PATCH|DELETE)|mutation'
+readonly FOREIGN='(^|[[:space:]])(-R|--repo|--project|--workspace|-C)([[:space:]]|=)|://|(^|[[:space:]])cd[[:space:]]'
+readonly MIN_BODY=200
+
+refuse() {
+  printf 'merge-verdict gate: %s\n' "$*" >&2
+  exit 2
+}
+
+# A grep that cannot mean "no match" when it failed to run, and never through a pipe:
+# a match on a pipeline's right-hand side kills the writer with SIGPIPE, and pipefail
+# then reports 141 — which an `|| exit 0` reads as "nothing to gate".
+matches() { # pattern, subject
+  local status=0
+  grep -qE -e "$1" <<<"$2" || status=$?
+  [ "$status" -le 1 ] || refuse "cannot scan the command: grep exited ${status}."
+  [ "$status" = 0 ]
+}
+
+normalise() { # command
+  local flat
+  flat=$(tr '\n\t' '  ' <<<"$1")
+  flat=${flat//\\ / }
+  tr -s ' ' <<<"$flat"
+}
+
+forge_of_origin() {
+  local origin
+  origin=$(git remote get-url origin) ||
+    refuse 'no origin remote here: cannot establish which pull request this touches.'
+  case "$origin" in
+  *github.com*) printf 'gh' ;;
+  *bitbucket.org*) printf 'bkt' ;;
+  *) refuse "unknown forge for origin ${origin}." ;;
+  esac
+}
+
+pushed_branch() {
+  local upstream
+  upstream=$(git rev-parse --abbrev-ref '@{upstream}') ||
+    refuse 'no upstream branch: nothing is pushed, so no pull request can carry this work.'
+  printf '%s' "${upstream#*/}"
+}
+
+named_number() { # normalised command
+  local numbers count
+  numbers=$(grep -oE -e '[0-9]+' <<<"$1" | sort -u) || true
+  count=$(printf '%s\n' "$numbers" | grep -c '[0-9]') || true
+  [ "$count" -le 1 ] ||
+    refuse 'this command carries several numbers: the gate cannot tell which pull request it targets.'
+  printf '%s' "$numbers" | tr -d '\n'
+}
+
+github_target() { # named number, may be empty
+  local view number
+  view=$(gh pr view "$(pushed_branch)" --json number,headRefOid,comments) ||
+    refuse 'no pull request for the pushed branch on GitHub.'
+  number=$(jq -r '.number' <<<"$view") || refuse 'unreadable GitHub payload.'
+  [ -z "$1" ] || [ "$1" = "$number" ] ||
+    refuse "this command names pull request ${1} while the branch belongs to ${number}."
+  jq -c '{number: .number, head: .headRefOid, comments: [.comments[].body]}' <<<"$view" ||
+    refuse 'unreadable GitHub payload.'
+}
+
+bitbucket_target() { # named number
+  local branch view head comments
+  [ -n "$1" ] ||
+    refuse 'name the pull request id in the command: Bitbucket cannot resolve it from the branch here.'
+  branch=$(pushed_branch)
+  view=$(bkt pr view "$1" --json) || refuse "cannot read pull request ${1} on Bitbucket."
+  head=$(jq -r '.pull_request.source.commit.hash // empty' <<<"$view") ||
+    refuse 'unreadable Bitbucket payload.'
+  [ -n "$head" ] || refuse "no source commit in the Bitbucket payload for pull request ${1}."
+  [ "$(jq -r '.pull_request.source.branch.name // empty' <<<"$view")" = "$branch" ] ||
+    refuse "pull request ${1} does not carry the pushed branch ${branch}."
+  comments=$(bkt pr comments "$1" --json) ||
+    refuse "cannot read the comments of pull request ${1} on Bitbucket."
+  jq -c --arg n "$1" --arg h "$head" \
+    '{number: ($n | tonumber), head: $h, comments: [.comments[].content.raw]}' <<<"$comments" ||
+    refuse 'unreadable Bitbucket payload.'
+}
+
+verdict_covers_head() { # target json
+  local number head body marker sha
+  number=$(jq -r '.number' <<<"$1")
+  head=$(jq -r '.head' <<<"$1")
+  while IFS= read -r body; do
+    [ "${#body}" -ge "$MIN_BODY" ] || continue
+    marker=$(grep -oE -e "<!-- merge-verdict:${number}:[0-9a-f]{12,40} -->" <<<"$body" |
+      head -n 1) || true
+    [ -n "$marker" ] || continue
+    sha=${marker##*:}
+    sha=${sha%% -->}
+    case "$head" in "$sha"*) return 0 ;; esac
+    case "$sha" in "$head"*) return 0 ;; esac
+  done <<<"$(jq -r '.comments[]? | @json' <<<"$1")"
+  return 1
+}
+
+for tool in git grep jq; do
+  command -v "$tool" >/dev/null || refuse "${tool} absent: the gate cannot read the command."
+done
+
+payload=$(cat) || refuse 'cannot read the hook payload.'
+[ -n "$payload" ] || refuse 'empty hook payload.'
+shape=$(jq -r '.tool_input.command | type' <<<"$payload") || refuse 'unreadable hook payload.'
+[ "$shape" = string ] || refuse "unexpected hook payload: .tool_input.command is ${shape}."
+normalised=$(normalise "$(jq -r '.tool_input.command' <<<"$payload")")
+
+if matches "$MUTATES" "$normalised"; then
+  :
+elif matches "$RAW_CALL" "$normalised" && matches "$PR_ROUTE" "$normalised" &&
+  matches "$WRITE" "$normalised"; then
+  refuse 'a raw forge write on a pull request route cannot be attributed to a head: go through the
+pr subcommands, or publish the verdict first.'
+else
+  exit 0
+fi
+
+if matches "$CREATES" "$normalised"; then
+  refuse 'a pull request being created has no head to judge yet: open it without reviewers, run
+/merge-verdict on it, fix its blocking findings, then edit in the reviewer.'
+fi
+if matches "$FOREIGN" "$normalised"; then
+  refuse 'this command names a repository, a directory or a URL the gate cannot resolve: run it from
+the checkout of the pull request it targets, naming the id alone.'
+fi
+
+number=$(named_number "$normalised")
+forge=$(forge_of_origin)
+case "$forge" in
+gh) target=$(github_target "$number") ;;
+bkt) target=$(bitbucket_target "$number") ;;
+esac
+verdict_covers_head "$target" ||
+  refuse "no merge-verdict comment on pull request $(jq -r '.number' <<<"$target") for head
+$(jq -r '.head' <<<"$target"). USER.md requires your own verdict, with its blocking findings fixed,
+before a pull request leaves your hands. Run /merge-verdict from a fresh context, then retry."
+exit 0

--- a/tooling/merge-verdict-gate-test
+++ b/tooling/merge-verdict-gate-test
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bypass list this file exists to cover, from the enforcement-code sweep and the two
+# adversarial passes: SIGPIPE on a long command, tab and quote-split flags, attached
+# shorthand, line continuation, the pr create aliases, bkt publish and default
+# reviewers, the REST and GraphQL review-request routes, curl to the same routes, a
+# foreign repository or directory, an ambiguous pull request number, a marker that is
+# undelimited, too short, in a URL field or on a superseded head, an unreadable or
+# non-string payload, and a missing jq or grep.
+
+here=$(cd "$(dirname "$0")" && pwd)
+gate="$here/merge-verdict-gate"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+bin="$tmp/bin"
+nogrep="$tmp/nogrep"
+nojq="$tmp/nojq"
+mkdir -p "$bin" "$nogrep" "$nojq" "$tmp/plain"
+for tool in bash cat env git head jq sort tr; do
+  ln -s "$(command -v "$tool")" "$nogrep/$tool"
+done
+for tool in bash cat env git grep head sort tr; do
+  ln -s "$(command -v "$tool")" "$nojq/$tool"
+done
+
+cat >"$bin/gh" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "${FAKE_FORGE_FAIL:-}" ]; then
+  exit 3
+fi
+case "$*" in
+"pr view "*"--json number,headRefOid,comments") cat "${FAKE_GH_VIEW:?}" ;;
+*)
+  printf 'unexpected gh call: %s\n' "$*" >&2
+  exit 9
+  ;;
+esac
+FAKE
+cat >"$bin/bkt" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "${FAKE_FORGE_FAIL:-}" ]; then
+  exit 3
+fi
+case "$*" in
+"pr view "*"--json") cat "${FAKE_BKT_VIEW:?}" ;;
+"pr comments "*"--json") cat "${FAKE_BKT_COMMENTS:?}" ;;
+*)
+  printf 'unexpected bkt call: %s\n' "$*" >&2
+  exit 9
+  ;;
+esac
+FAKE
+chmod +x "$bin/gh" "$bin/bkt"
+export PATH="$bin:$PATH"
+export GIT_AUTHOR_DATE=2026-01-01T00:00:00Z
+export GIT_COMMITTER_DATE=2026-01-01T00:00:00Z
+
+make_repo() { # directory, origin url
+  git init -q -b main "$1"
+  git -C "$1" config user.email test@example.com
+  git -C "$1" config user.name Test
+  git -C "$1" commit -q --allow-empty -m init
+  git -C "$1" remote add origin "$2"
+}
+
+track_origin() { # directory, pushed branch — deliberately not the local branch name
+  git -C "$1" update-ref "refs/remotes/origin/$2" HEAD
+  git -C "$1" branch --set-upstream-to="origin/$2" >/dev/null
+}
+
+github="$tmp/github"
+bitbucket="$tmp/bitbucket"
+gitlab="$tmp/gitlab"
+untracked="$tmp/untracked"
+make_repo "$github" https://github.com/owner/repo.git
+make_repo "$bitbucket" git@bitbucket.org:workspace/repo.git
+make_repo "$gitlab" git@gitlab.com:owner/repo.git
+make_repo "$untracked" https://github.com/owner/repo.git
+track_origin "$github" feat/pushed-name
+track_origin "$bitbucket" feat/pushed-name
+track_origin "$gitlab" feat/pushed-name
+
+head40=$(git -C "$github" rev-parse HEAD)
+head12=${head40:0:12}
+prose='Independent verdict. The barrier ran on this exact head and the failure classes were swept one
+by one; what it does not cover is stated below, at length, so that this body is unmistakably a
+verdict and not a bare token dropped into the thread to satisfy a check.'
+
+verdict_body() { # marker text
+  printf '%s\n\n%s\n' "$1" "$prose"
+}
+
+# GitHub view payloads: number, 40-character head, comment bodies.
+gh_view() { # file, body
+  jq -n --arg b "$2" --arg h "$head40" \
+    '{number: 154, headRefOid: $h, comments: [{body: $b}]}' >"$1"
+}
+gh_view "$tmp/gh-absent.json" "$(verdict_body 'no marker here')"
+gh_view "$tmp/gh-current.json" "$(verdict_body "<!-- merge-verdict:154:${head12} -->")"
+gh_view "$tmp/gh-superseded.json" "$(verdict_body '<!-- merge-verdict:154:000000000000 -->')"
+gh_view "$tmp/gh-truncated.json" "$(verdict_body "<!-- merge-verdict:154:${head12:0:7} -->")"
+gh_view "$tmp/gh-undelimited.json" "$(verdict_body "I have not run merge-verdict:154:${head12} yet")"
+gh_view "$tmp/gh-other-pr.json" "$(verdict_body "<!-- merge-verdict:1:${head12} -->")"
+printf '{"body":"<!-- merge-verdict:154:%s -->"}' "$head12" >"$tmp/marker-only-body.json"
+jq -n --arg h "$head40" --slurpfile c "$tmp/marker-only-body.json" \
+  '{number: 154, headRefOid: $h, comments: $c}' >"$tmp/gh-marker-only.json"
+jq -n --arg h "$head40" --arg u "https://x/c#<!-- merge-verdict:154:${head12} -->" \
+  '{number: 154, headRefOid: $h, comments: [{body: "short", url: $u}]}' >"$tmp/gh-url-field.json"
+
+# Bitbucket view payloads: Cloud returns a 12-character source hash.
+jq -n --arg h "$head12" \
+  '{pull_request: {id: 561, source: {commit: {hash: $h}, branch: {name: "feat/pushed-name"}}}}' \
+  >"$tmp/bkt-view.json"
+jq -n --arg h "$head12" \
+  '{pull_request: {id: 561, source: {commit: {hash: $h}, branch: {name: "other"}}}}' \
+  >"$tmp/bkt-view-other-branch.json"
+jq -n --arg b "$(verdict_body "<!-- merge-verdict:561:${head40} -->")" \
+  '{comments: [{content: {raw: $b}}]}' >"$tmp/bkt-current.json"
+jq -n --arg b "$(verdict_body 'no marker here')" \
+  '{comments: [{content: {raw: $b}}]}' >"$tmp/bkt-absent.json"
+
+export FAKE_GH_VIEW="$tmp/gh-absent.json"
+export FAKE_BKT_VIEW="$tmp/bkt-view.json"
+export FAKE_BKT_COMMENTS="$tmp/bkt-absent.json"
+
+expect() { # label, repository, payload file, expected status, stderr fragment, gate PATH
+  local status=0 gate_path=${6:-$PATH}
+  (cd "$2" && PATH="$gate_path" "$gate" <"$3") >"$tmp/out" 2>"$tmp/err" || status=$?
+  if [ "$status" != "$4" ]; then
+    printf 'FAIL %s: status %s, expected %s\n' "$1" "$status" "$4" >&2
+    cat "$tmp/err" >&2
+    exit 1
+  fi
+  if [ -n "${5:-}" ] && ! grep -qF -e "$5" "$tmp/err"; then
+    printf 'FAIL %s: stderr lacks %s\n' "$1" "$5" >&2
+    cat "$tmp/err" >&2
+    exit 1
+  fi
+  if [ "$4" = 0 ] && [ -s "$tmp/err" ]; then
+    printf 'FAIL %s: allowed, but the gate wrote to stderr\n' "$1" >&2
+    cat "$tmp/err" >&2
+    exit 1
+  fi
+}
+
+payload() { # name, command
+  jq -n --arg c "$2" '{tool_name: "Bash", tool_input: {command: $c}}' >"$tmp/$1.json"
+}
+
+payload benign 'git status --short'
+payload read-only 'gh pr view 154 --json comments'
+payload listing 'gh pr list --state open'
+payload api-read 'gh api /repos/owner/repo/pulls/154'
+payload solicit 'gh pr edit 154 --add-reviewer alice'
+payload merge 'gh pr merge --squash --delete-branch'
+payload create 'gh pr create --title t --reviewer alice'
+payload create-alias 'gh pr new --title t -ralice'
+payload several-numbers 'sleep 5 && gh pr edit 154 --add-reviewer alice'
+payload foreign-repo 'gh pr edit -R owner/other 154 --add-reviewer alice'
+payload foreign-url 'gh pr edit https://github.com/o/r/pull/999 --add-reviewer alice'
+payload foreign-cd 'cd ../other && gh pr edit 154 --add-reviewer alice'
+payload wrong-number 'gh pr edit 999 --add-reviewer alice'
+payload rest-route 'gh api --method POST /repos/o/r/pulls/154/requested_reviewers -f reviewers[]=bob'
+payload graphql-route 'gh api graphql -f query=mutation{requestReviews(input:{})}'
+payload bkt-solicit 'bkt pr edit 561 --reviewer alice'
+payload bkt-defaults 'bkt pr edit 561 --with-default-reviewers'
+payload bkt-publish 'bkt pr publish 561'
+payload bkt-update 'bkt pr update 561 --reviewer alice'
+payload bkt-api 'bkt api -X PUT /2.0/repositories/w/r/pullrequests/561 --field reviewers=alice'
+payload bkt-no-number 'bkt pr edit --reviewer alice'
+printf 'gh pr edit 154 --add-reviewer\talice' >"$tmp/tab.txt"
+jq -n --rawfile c "$tmp/tab.txt" '{tool_name: "Bash", tool_input: {command: $c}}' >"$tmp/tab.json"
+printf 'gh pr \\\n  create --title t --reviewer alice' >"$tmp/continued.txt"
+jq -n --rawfile c "$tmp/continued.txt" '{tool_name: "Bash", tool_input: {command: $c}}' \
+  >"$tmp/continued.json"
+{
+  printf 'gh pr edit 154 --add-reviewer alice && cat > notes.md <<EOF\n'
+  i=0
+  while [ "$i" -lt 3000 ]; do
+    printf 'padding line without digits aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'
+    i=$((i + 1))
+  done
+  printf 'EOF\n'
+} >"$tmp/long.txt"
+jq -n --rawfile c "$tmp/long.txt" '{tool_name: "Bash", tool_input: {command: $c}}' >"$tmp/long.json"
+printf '{"tool_input": {"command": "gh pr edit 154 --add-reviewer alice"' >"$tmp/malformed.json"
+jq -n '{tool_name: "Bash", tool_input: {command: ["gh", "pr", "edit", "154"]}}' >"$tmp/array.json"
+: >"$tmp/empty.json"
+
+expect benign "$github" "$tmp/benign.json" 0
+expect read-only-verb "$github" "$tmp/read-only.json" 0
+expect listing "$github" "$tmp/listing.json" 0
+expect api-read "$github" "$tmp/api-read.json" 0
+
+expect no-verdict "$github" "$tmp/solicit.json" 2 'no merge-verdict comment on pull request 154'
+expect tab-separated-flag "$github" "$tmp/tab.json" 2 'no merge-verdict comment'
+expect long-command "$github" "$tmp/long.json" 2 'no merge-verdict comment'
+expect merge-without-verdict "$github" "$tmp/merge.json" 2 'no merge-verdict comment'
+expect create-with-reviewer "$github" "$tmp/create.json" 2 'no head to judge yet'
+expect create-alias "$github" "$tmp/create-alias.json" 2 'no head to judge yet'
+expect line-continuation "$github" "$tmp/continued.json" 2 'no head to judge yet'
+expect several-numbers "$github" "$tmp/several-numbers.json" 2 'several numbers'
+expect foreign-repo "$github" "$tmp/foreign-repo.json" 2 'names a repository'
+expect foreign-url "$github" "$tmp/foreign-url.json" 2 'names a repository'
+expect foreign-cd "$github" "$tmp/foreign-cd.json" 2 'names a repository'
+expect rest-route "$github" "$tmp/rest-route.json" 2 'raw forge write'
+expect graphql-route "$github" "$tmp/graphql-route.json" 2 'raw forge write'
+expect bkt-api-route "$bitbucket" "$tmp/bkt-api.json" 2 'raw forge write'
+expect bkt-defaults "$bitbucket" "$tmp/bkt-defaults.json" 2 'no merge-verdict comment'
+expect bkt-publish "$bitbucket" "$tmp/bkt-publish.json" 2 'no merge-verdict comment'
+expect bkt-update-alias "$bitbucket" "$tmp/bkt-update.json" 2 'no merge-verdict comment'
+expect bkt-no-number "$bitbucket" "$tmp/bkt-no-number.json" 2 'name the pull request id'
+expect unknown-forge "$gitlab" "$tmp/solicit.json" 2 'unknown forge'
+expect no-upstream "$untracked" "$tmp/solicit.json" 2 'no upstream branch'
+expect no-repository "$tmp/plain" "$tmp/solicit.json" 2 'no origin remote'
+expect malformed-payload "$github" "$tmp/malformed.json" 2 'unreadable hook payload'
+expect array-command "$github" "$tmp/array.json" 2 '.tool_input.command is array'
+expect empty-payload "$github" "$tmp/empty.json" 2 'empty hook payload'
+expect wrong-number "$github" "$tmp/wrong-number.json" 2 'while the branch belongs to 154'
+
+FAKE_GH_VIEW="$tmp/gh-superseded.json"
+expect superseded-marker "$github" "$tmp/solicit.json" 2 'no merge-verdict comment'
+FAKE_GH_VIEW="$tmp/gh-truncated.json"
+expect truncated-marker "$github" "$tmp/solicit.json" 2 'no merge-verdict comment'
+FAKE_GH_VIEW="$tmp/gh-undelimited.json"
+expect undelimited-marker "$github" "$tmp/solicit.json" 2 'no merge-verdict comment'
+FAKE_GH_VIEW="$tmp/gh-other-pr.json"
+expect marker-for-another-pr "$github" "$tmp/solicit.json" 2 'no merge-verdict comment'
+FAKE_GH_VIEW="$tmp/gh-marker-only.json"
+expect marker-only-comment "$github" "$tmp/solicit.json" 2 'no merge-verdict comment'
+FAKE_GH_VIEW="$tmp/gh-url-field.json"
+expect marker-in-url-field "$github" "$tmp/solicit.json" 2 'no merge-verdict comment'
+
+FAKE_GH_VIEW="$tmp/gh-current.json"
+expect current-marker "$github" "$tmp/solicit.json" 0
+expect merge-with-verdict "$github" "$tmp/merge.json" 0
+
+FAKE_BKT_COMMENTS="$tmp/bkt-current.json"
+expect bkt-current-marker "$bitbucket" "$tmp/bkt-solicit.json" 0
+FAKE_BKT_VIEW="$tmp/bkt-view-other-branch.json"
+expect bkt-branch-mismatch "$bitbucket" "$tmp/bkt-solicit.json" 2 'does not carry the pushed branch'
+FAKE_BKT_VIEW="$tmp/bkt-view.json"
+
+export FAKE_FORGE_FAIL=1
+expect failing-probe "$github" "$tmp/solicit.json" 2 'no pull request for the pushed branch'
+unset FAKE_FORGE_FAIL
+
+expect grep-absent "$github" "$tmp/solicit.json" 2 'grep absent' "$nogrep"
+expect jq-absent "$github" "$tmp/solicit.json" 2 'jq absent' "$nojq"
+
+echo ok


### PR DESCRIPTION
## Pourquoi

Deux PR consécutives d'un autre dépôt ont été fusionnées après qu'un relecteur a poussé les
correctifs par-dessus mon dernier SHA — validation absente sur une colonne ajoutée, `ZodError` qui
fuit, deux valeurs concurrentes réduites en silence, tests des chemins d'échec écrits par le
relecteur. `USER.md` exigeait déjà de passer `merge-verdict` sur ma propre PR avant qu'elle quitte
mes mains : la règle est chargée à chaque tour, et aucun marqueur de verdict n'existe sur ces deux
PR. Une règle écrite, non suivie deux fois, appelle un contrôle — pas de la prose supplémentaire.

## Ce que fait le garde

`tooling/merge-verdict-gate` est un hook `PreToolUse` qui refuse toute commande Bash faisant avancer
une PR — `create`, `new`, `edit`, `update`, `ready`, `publish`, `merge`, ou une écriture brute
`gh api` / `bkt api` / `curl` sur une route de PR — tant qu'aucun commentaire de cette PR ne porte
`<!-- merge-verdict:<pr>:<head-sha-12> -->` au head que la forge rapporte.

Il matche le **verbe** de la commande, pas l'orthographe d'un drapeau. Une première version calée sur
`--reviewer` a été contournée par une tabulation, une coupure de guillemets, une valeur courte
accolée, une continuation de ligne, `bkt pr publish`, `--with-default-reviewers` et la route
`requested_reviewers` de GitHub. Le sur-refus est le coût accepté — changer le titre d'une PR
demandera un verdict — parce que l'étape enforçante est une seule lecture de forge.

Trois propriétés qui n'étaient pas là au premier jet :

- **Aucune décision ne passe par un tube.** `printf | grep -q` inversait le garde au-delà de 65 536
  octets : `grep -q` sort à la première correspondance, `printf` meurt en SIGPIPE, `pipefail` remonte
  141, et le `|| exit 0` lisait 141 comme « rien à garder ». La même commande était refusée à
  157 octets et **autorisée à 157 954**.
- **Toute entrée illisible refuse** : charge utile vide, JSON invalide, `command` non textuel, `git`,
  `grep` ou `jq` absent, sonde de forge en échec. Dans ce harnais, tout statut autre que 2 laisse
  passer la commande, donc une sortie 5 était un trou au même titre qu'une sortie 0.
- **Le numéro et le head viennent de la forge**, jamais de git ni de la chaîne de commande. Un couple
  local `HEAD`/`@{upstream}` reste cohérent après qu'un tiers a déplacé le head — l'incident même qui
  motive ce garde — et le premier nombre d'une commande appartient au moins aussi souvent à `sleep 5`
  qu'à une PR. Cloud renvoie un hash de 12 caractères, GitHub un oid de 40 : le marqueur convient dès
  que l'un est préfixe de l'autre. La résolution passe par la branche **amont**, pas par le nom local
  — dans ce dépôt les worktrees poussent sous un autre nom.

## Vérifications — macOS 26.5.2, `/bin/bash` 3.2.57, shellcheck 0.11.0

- `shellcheck --severity=error` (la porte CI) : 0 constat ; sévérité par défaut : 0 également.
- `tooling/merge-verdict-gate-test` : 42 cas, un par contournement mesuré, verts sous bash 3.2.
  Canaris : garde remplacé par `exit 0` → `FAIL no-verdict` ; par `exit 2` → `FAIL benign`.
- Contre la forge réelle sur cette PR : la sollicitation courte, la même avec 195 ko de queue, la
  variante à tabulation et la route REST `requested_reviewers` refusent toutes ; `gh pr view --json`
  passe ; deux sondes sont tombées sur un `HTTP 503` de GitHub et ont **refusé**, ce qui vérifie
  l'échec fermé sur panne réelle.
- Formes de payload confirmées en lecture seule contre Bitbucket Cloud :
  `.pull_request.source.commit.hash` (12 caractères), `.pull_request.source.branch.name`,
  `.comments[].content.raw`. La forme Data Center reste non vérifiée.
- Découverte CI : 18 scripts, les deux nouveaux dedans, `tooling/merge-verdict-gate-test` câblé dans
  `lint.yml` (`macos-latest`).

**Trous du barrage** : `actionlint` n'est pas installé ici, l'édition de `lint.yml` n'est validée
qu'en CI. Le job « Shell scripts » est `macos-latest` seulement : ce test ne tournera jamais sous
Linux. Le chemin Bitbucket est exercé contre des stubs, pas contre une vraie PR ouverte.

## Reports déclarés

- **Enregistrement du hook** : l'entrée `PreToolUse` vit dans `~/.claude/settings.json`, hors gestion
  de ce dépôt. `make claude-code` pose donc un garde que rien n'appelle encore. Confié à arnes pour
  les trois harnais — issues #120 et #111 — plutôt que trois mécanismes à maintenir à la main. Levée :
  `arnes doctor hooks` diagnostique l'entrée manquante.
- **Cursor et Codex** portent l'obligation `USER.md` sans hook équivalent, même condition de levée.
- **Le marqueur est un jeton de coordination, pas d'authentification** : un tiers qui le cite dans un
  commentaire assez long lève le garde. Levée : contrôle d'auteur, quand `bkt` exposera une identité
  comparable à celle de `gh`.
- **L'interface web** reste hors de portée par construction.

## Contexte frais

La phase 3 de `merge-verdict` délègue désormais le balayage à un contexte frais quand le head a été
écrit dans la même session. Cette clause a trouvé les six défauts ci-dessus **sur son propre auteur**,
en une passe, alors que le barrage était vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xg9VPqUREnsHCWmQkXCuBn
