### PR TITLE
feat(harness): put the failure classes on the writing path

### DIFF
--- a/.agents/skills/merge-verdict/SKILL.md
+++ b/.agents/skills/merge-verdict/SKILL.md
@@ -61,7 +61,10 @@ first, unless the request explicitly says to post directly.
 
 3. **Sweep the failure classes.** Put all ten questions in `references/failure-classes.md` to the
    diff. Record, per class, one of: not applicable, holds because `<evidence>`, or broken by
-   `<mechanism>`. Only the third form can become a blocker.
+   `<mechanism>`. Only the third form can become a blocker. When the head under review was written
+   in this session, delegate this sweep to a fresh context, read-only and scoped to the diff: the
+   context that produced the diff shares the blind spot that produced the defect, and records
+   `holds` for the class it has just broken.
 
 4. **Run the barrier, then declare its holes.** Run lint, typecheck and tests the way the project
    runs them — including inside a container when the project requires it, since numbers from the
@@ -83,7 +86,7 @@ first, unless the request explicitly says to post directly.
    verdict if one exists. Never open a ticket solely to request or record a re-review: the new
    head-specific verdict comment is that record. Write one general comment from
    `assets/verdict-template.md`, prefixed with the idempotency marker
-   `<!-- merge-verdict:<pr>:<head-sha> -->` — not a rain of inline comments. Search the existing
+   `<!-- merge-verdict:<pr>:<head-sha-12> -->` — not a rain of inline comments. Search the existing
    comments for that marker first: a verdict carrying the same `<pr>:<sha>` is updated in place,
    never duplicated. Re-read before publishing — past about thirty lines, non-blocking remarks are
    posing as blockers. On GitHub, _changes required_ is published with
@@ -130,6 +133,7 @@ first, unless the request explicitly says to post directly.
 - Never open a review that is not anchored on a head SHA.
 - Never leave a limit of the evidence implicit; the barrier's gaps belong in the verdict text.
 - Never publish two verdicts for the same `<pr>:<sha>`; update the existing comment instead.
+- Never sweep the failure classes on a head you wrote in this session from the context that wrote it.
 - Never create a ticket solely to request, schedule or record a re-review.
 - Never publish without confirmation, unless the request explicitly says to post directly.
 

--- a/.agents/skills/merge-verdict/references/cases.md
+++ b/.agents/skills/merge-verdict/references/cases.md
@@ -18,8 +18,8 @@ index backs the uniqueness the service checks in code. Unit tests exist and pass
 
 **Pass criteria**
 
-- The verdict is anchored on the head SHA, and the marker `<!-- merge-verdict:<pr>:<sha> -->` is the
-  first line.
+- The verdict is anchored on the head SHA, and the marker
+  `<!-- merge-verdict:<pr>:<head-sha-12> -->` is the first line.
 - At least one blocker is stated as an ordered sequence ending in a broken invariant — the
   out-of-transaction read, the stale retry, or the missing constraint. Failure classes 1, 2 and 3.
 - The barrier paragraph gives counts _and_ states that the passing tests are sequential and therefore

--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -7,12 +7,13 @@
 
 Before implementing any request:
 
-- Challenge assumptions and unclear requirements
-- Question the "why" behind requests, not just implementing them
-- Verify alignment with project patterns and best practices
+- Challenge unclear requirements and the assumptions behind them, not just the request
 - Point out if a request might conflict with existing code or architecture
 - Never record a workaround for a defect in code we own: fix it, or open a ticket and
   reference it. A memorized dance around our own bug guarantees the bug survives.
+- Before writing code that parses an external value, joins, maps errors or adds a persisted
+  field, put `.agents/skills/merge-verdict/references/failure-classes.md` to the design; the
+  failure-path test ships in the same commit.
 
 Raising a concern never blocks delivery: state it, then proceed as described
 in `USER.md`.
@@ -20,7 +21,6 @@ in `USER.md`.
 ## Context Management
 
 - For open-ended exploration, research, or multi-file searches, delegate to the Explore or general-purpose agent instead of reading files directly in the main thread.
-- For independent multi-step tasks (especially 2+ unrelated ones), dispatch parallel subagents rather than doing them serially inline.
 - Keep the main thread for orchestration/decisions; push bulk reading, grepping, and exploration into subagents.
 
 ## Web Fetching


### PR DESCRIPTION
Remplace #154, fermée : un garde en bash qui décidait en analysant une chaîne shell, contourné
28 fois en deux passes adversariales, et qui refusait autant de commandes légitimes qu'il n'en
bloquait de fautives. Le constat mesuré est dans son commentaire de fermeture.

## Le vrai défaut

Deux PR consécutives d'un autre dépôt ont été fusionnées après qu'un relecteur a poussé les
correctifs par-dessus mon dernier SHA : colonne ajoutée recopiée sans validation, `Schema.parse` brut
laissant fuir une `ZodError` là où le module importé documente son helper, deux valeurs source
concurrentes réduites en silence à la première par `ORDER BY … LIMIT 1`, aucun test sur les chemins
d'échec des colonnes ajoutées.

Les dix classes d'échec de `.agents/skills/merge-verdict/references/failure-classes.md` **nomment
chacun de ces défauts**. Elles n'ont jamais été lues : le seul skill qui les lit tourne en revue.
Le manque n'est donc pas une règle absente, c'est une règle posée dans une couche que le chemin
d'écriture ne charge jamais. Ce n'est pas non plus une affaire de garde : aucun contrôle placé après
l'écriture ne rattrape une conception qui n'a pas vu la question.

## Les deux changements

**`harness/AGENTS.md`** — la référence est routée depuis le seul fichier chargé à chaque tour :

> Before writing code that parses an external value, joins, maps errors or adds a persisted field,
> put `.agents/skills/merge-verdict/references/failure-classes.md` to the design; the failure-path
> test ships in the same commit.

Budget tenu à la ligne : 57 lignes avant, 57 après. Trois lignes ajoutées, trois payées — « Verify
alignment with project patterns and best practices » part parce que le `AGENTS.md` du dépôt le dit
concrètement en §Code Structure ; les deux premiers points fusionnent parce que contester une
hypothèse et demander pourquoi sont le même acte ; et « dispatch parallel subagents » part parce que
cette session est la mesure qui l'accuse — trois passes en contexte frais de 13, 25 et 32 minutes là
où une passe bornée suffisait.

**`merge-verdict`** — la phase 3 délègue le balayage à un contexte frais quand le head a été écrit
dans la même session, **en lecture seule et borné au diff**. Sans cette borne, la passe coûte une
demi-heure, et une étape à une demi-heure finit par ne plus être lancée. Plus l'alignement du
marqueur sur les 12 caractères que `assets/verdict-template.md` imposait déjà : une longueur écrite,
plus trois.

## Ce que ça vaut, et ce que ça ne vaut pas

La clause de contexte frais est le seul levier de cette session dont l'effet est mesuré : appliquée
au garde de #154, elle a nommé 28 familles de défauts que son auteur venait de déclarer verts, dont
celle qui invalidait sa prétention à l'échec fermé.

La ligne de `harness/AGENTS.md`, elle, **n'est pas mesurée** : c'est de la prose chargée à chaque
tour, et l'histoire de ce dépôt dit que ce barreau échoue quand la règle ne se voit pas appliquée.
Sa maison durable est un skill invoqué à l'écriture — inscrit sur #84, dont la première étape lira
ces classes. Cette ligne est le relais en attendant, pas la solution.

Aucun script ajouté, aucun hook, aucun mécanisme à maintenir. Si un contrôle mécanique redevient
souhaitable, sa place est `arnes` (#119, #120) : typé, couvert par `cargo test` en CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xg9VPqUREnsHCWmQkXCuBn
