### PR TITLE
feat(harness): tighten writes, oracles and sources, and track pr-feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ cursor: ~/.local/bin/cursor-agent ~/.cursor/skills/enforcement-code ~/.cursor/sk
 	${CREATE_SYMLINK}
 
 .PHONY: claude-code
-claude-code: ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/hooks/agent_handoff ~/.claude/rules/agent-instructions.md ~/.claude/skills/handoff ~/.claude/skills/enforcement-code ~/.claude/skills/merge-verdict
+claude-code: ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/commands/pr-feedback.md ~/.claude/hooks/agent_handoff ~/.claude/rules/agent-instructions.md ~/.claude/skills/handoff ~/.claude/skills/enforcement-code ~/.claude/skills/merge-verdict
 ${LOCAL_BIN}/claude:
 	curl -fsSL https://claude.ai/install.sh | bash -s latest
 ~/.claude:
@@ -394,8 +394,10 @@ ${LOCAL_BIN}/claude:
 	${CREATE_SYMLINK}
 ~/.claude/USER.md: ${DOTFILES_PATH}/harness/USER.md | ~/.claude
 	${CREATE_SYMLINK}
-~/.claude/hooks ~/.claude/rules ~/.claude/skills: | ~/.claude
+~/.claude/commands ~/.claude/hooks ~/.claude/rules ~/.claude/skills: | ~/.claude
 	mkdir -p $@
+~/.claude/commands/pr-feedback.md: ${DOTFILES_PATH}/harness/commands/pr-feedback.md | ~/.claude/commands
+	${CREATE_SYMLINK}
 ~/.claude/hooks/agent_handoff: ${DOTFILES_PATH}/tooling/agent-handoff | ~/.claude/hooks
 	${CREATE_SYMLINK}
 ~/.claude/rules/agent-instructions.md: ${DOTFILES_PATH}/harness/rules/agent-instructions.md | ~/.claude/rules

--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -9,6 +9,9 @@ Before implementing any request:
 
 - Challenge unclear requirements and the assumptions behind them, not just the request
 - Point out if a request might conflict with existing code or architecture
+- Cite a source by its status, not its title: a proposal is not authority, and a dated
+  legal or specification reference must be the version in force before anything leans
+  on it.
 - Never record a workaround for a defect in code we own: fix it, or open a ticket and
   reference it. A memorized dance around our own bug guarantees the bug survives.
 - Before writing code that parses an external value, joins, maps errors or adds a persisted
@@ -47,6 +50,10 @@ Escalate only when the previous tier fails; never start above the first tier:
 - **Name the environment.** Every piece of evidence states where it was produced and is
   valid only there. Green on one platform, one shell or one image says nothing about the
   others the project supports: list the supported targets, say which you exercised.
+- **No guarantee without a green oracle.** A capability a contract offers — sealing, a
+  retention field, logical archiving, link revocation — is a proof structure, not the
+  guarantee. State what is held today, and gate every promise on a named end-to-end
+  check that runs.
 
 ## Code Style
 

--- a/harness/USER.md
+++ b/harness/USER.md
@@ -42,7 +42,11 @@ Signaler systématiquement, même sans être sollicité, les cas limites et les
 conséquences non voulues d'un changement — et en priorité :
 
 1. **Gestion d'erreur incomplète** — cas d'échec, délais d'attente, retours
-   vides et nuls.
+   vides et nuls. Sur une écriture ou un rappel venu de l'extérieur : clé
+   d'idempotence nommée, ordre attendu, et écriture atomique de toute valeur
+   dérivée du premier événement qualifiant. Une entrée inconnue est mise en
+   quarantaine avec sa charge brute et rejouable, jamais avalée ni dégradée en
+   avertissement.
 2. **Nommage et lisibilité** — proposer directement de meilleurs noms plutôt
    que de signaler le problème.
 3. **Dépendance de trop** — le réflexe est d'installer une bibliothèque là où

--- a/harness/commands/pr-feedback.md
+++ b/harness/commands/pr-feedback.md
@@ -1,0 +1,169 @@
+---
+description: Analyse les retours de revue et les correctifs poussés par les relecteurs sur mes PR, puis en déduit les correctifs de harnais
+---
+
+Tu analyses les retours reçus sur mes pull requests pour en tirer des correctifs de harnais.
+Objectif : réduire le volume de retours sur les PR suivantes. Lecture seule — tu proposes, tu
+n'édites rien.
+
+## Portée
+
+`$ARGUMENTS` = liste de numéros de PR, ou un nombre de PR à remonter. Par défaut : les 10
+dernières PR fusionnées dont je suis l'auteur.
+
+## Forge
+
+Déduis la forge de `git remote get-url origin` et n'emploie que son client. `<slug>` désigne
+partout le chemin du dépôt lu sur ce remote (`<espace>/<dépôt>`) ; ne code jamais sa valeur en
+dur dans ce fichier.
+
+```bash
+bkt pr list --mine --state MERGED --limit 10 --json --jq '.pull_requests[] | "\(.id) | \(.title)"'
+gh pr list --author @me --state merged --limit 10 --json number,title
+```
+
+Pour toute autre forge, mappe les concepts ci-dessous sur son client (`glab`, `tea`, l'API
+brute) en vérifiant les options dans son aide. Les concepts ne changent pas ; les endpoints,
+si. N'invente pas une option que tu n'as pas lue.
+
+## Collecte, par PR
+
+Une fusion en **squash** efface les commits correctifs d'un relecteur : dans la branche cible
+ils réapparaissent sous mon nom. Le signal vit donc côté forge, dans trois endroits :
+
+**1. La séquence des poussées** — qui a poussé quoi, dans quel ordre :
+
+```bash
+bkt api "/repositories/<slug>/pullrequests/<id>/activity?pagelen=50" --json --jq '.values[] | select(.update) | "\(.update.date) | \(.update.author.display_name) | \(.update.source.commit.hash) | \(.update.state)"'
+gh pr view <id> --json commits --jq '.commits[] | "\(.committedDate) | \(.authors[0].login) | \(.oid[0:12]) | \(.messageHeadline)"'
+```
+
+Toute poussée par quelqu'un d'autre que moi, après ma dernière poussée, est un **correctif de
+relecteur**. C'est la source la plus riche : ce sont des retours qui n'ont jamais été écrits.
+
+**2. Le delta correctif** — ce que le relecteur a ajouté par-dessus mon travail.
+L'activité ne liste pas tous mes pushes, et une branche absorbe des fusions de la branche
+d'intégration ainsi que des PR fusionnées en squash **sous mon nom** : remonte la chaîne de
+commits avant de calculer le delta.
+
+```bash
+bkt api "/repositories/<slug>/commits/<sien>?pagelen=10" --json --jq '.values[] | "\(.hash[0:12]) | \(.author.user.display_name // .author.raw) | \(.message | split("\n")[0])"'
+gh api "repos/<slug>/commits?sha=<sien>&per_page=10" --jq '.[] | "\(.sha[0:12]) | \(.author.login // .commit.author.name) | \(.commit.message | split("\n")[0])"'
+```
+
+La borne basse est le commit qui précède **le premier commit du relecteur** — la fusion de la
+branche d'intégration s'il y en a une —, jamais le SHA lu dans l'activité. Vérifie-la sur le
+récapitulatif de fichiers avant de demander le `diff`, et filtre par fichier : un delta qui
+touche des fichiers étrangers au sujet de la PR est le signe que la borne est mauvaise.
+
+```bash
+bkt api "/repositories/<slug>/diffstat/<sien>..<borne>?pagelen=100" --json --jq '.values[] | "\(.status) +\(.lines_added) -\(.lines_removed) \(.new.path // .old.path)"'
+bkt api "/repositories/<slug>/diff/<sien>..<borne>?path=<fichier>"
+gh api "repos/<slug>/compare/<borne>...<sien>" --jq '.files[] | "\(.status) +\(.additions) -\(.deletions) \(.filename)"'
+gh api "repos/<slug>/compare/<borne>...<sien>" --jq '.files[] | select(.filename == "<fichier>") | .patch'
+```
+
+Lis ce diff en entier : chaque hunk est un manque de la conception initiale.
+
+**3. Les commentaires et les tâches** :
+
+```bash
+bkt pr comments <id> --json --jq '.comments[] | "\(.user.display_name) | \(.inline.path // "general"):\(.inline.to // "") | \(.content.raw)"'
+bkt pr task list <id> --json
+gh pr view <id> --json comments,reviews --jq '(.comments[], (.reviews[] | select(.body != ""))) | "\(.author.login) | \(.body)"'
+gh api "repos/<slug>/pulls/<id>/comments" --jq '.[] | "\(.user.login) | \(.path):\(.line) | \(.body)"'
+```
+
+Trois émetteurs à distinguer, ne les mélange pas :
+
+- **humain** — un relecteur ; poids maximal ;
+- **revue IA** (posté par la CI, souvent sous mon compte) ; poids moyen, souvent bruyant ;
+- **moi-même** (notes de rebase, auto-commentaires) ; à écarter.
+
+## Analyse, par constat
+
+Pour chaque hunk correctif et chaque commentaire retenu, réponds à **deux** questions. La
+seconde est celle qui produit le correctif de harnais ; un constat sans elle n'a aucune valeur.
+
+1. **Qu'est-ce qui manquait ?** Une phrase, en termes de comportement, pas de diff.
+2. **Pourquoi était-ce absent du développement initial ?** Une catégorie, et une seule :
+
+   | Catégorie | Signification | Correctif visé |
+   | --- | --- | --- |
+   | `non-appliquée` | La règle existait, écrite, et n'a pas été suivie | Un contrôle automatique |
+   | `non-chargée` | La règle existait, mais dans une couche jamais lue sur ce chemin | Un déplacement de couche |
+   | `inconnue` | Aucune règle n'existait | Une règle neuve, à la couche la moins chère |
+   | `angle-mort` | Cas limite non pensé : erreur, nul, vide, délai, concurrence, multiplicité | Une étape de skill ou un test canonique |
+   | `arbitrage` | Divergence de jugement légitime, pas une erreur | Rien. Le noter et passer |
+
+   Vérifie avant de classer : `grep` la règle supposée dans `AGENTS.md`, `.agents/rules/`,
+   `.agents/skills/`, `MEMORY.md`. Une règle que tu supposes existante sans l'avoir trouvée est
+   `inconnue`, pas `non-appliquée`.
+
+## Correctifs de harnais — échelle
+
+Un constat récurrent mérite le **barreau le plus bas qui tient**, jamais plus haut :
+
+1. **Un contrôle automatique** — règle de linter, hook pre-commit, étape CI, contrainte de
+   schéma, type. Le seul barreau qui ne dépend pas de la mémoire d'un agent. Vise-le d'abord.
+2. **Une règle `.agents/rules/*.mdc` à glob étroit** — si le manque ne concerne qu'une famille de
+   fichiers.
+3. **Une étape dans un skill existant** — si le manque est procédural et que le skill est déjà
+   invoqué sur ce chemin. Ne crée pas un skill neuf pour une étape.
+4. **Une ligne dans `AGENTS.md`** — seulement si la règle s'applique partout et à plus de 80 % des
+   tours. Le budget de lignes est celui que fixe le dépôt : toute ligne ajoutée en chasse une
+   autre, dis laquelle.
+5. **Une entrée `MEMORY.md`** — pour un piège découvert, non dérivable du code. Descriptif, pas
+   prescriptif.
+
+Une seule proposition par constat. Si deux barreaux tiennent, prends le plus bas et n'évoque pas
+l'autre.
+
+## Seuil de récurrence
+
+Ne propose un changement durable que si le constat apparaît **au moins deux fois, sur deux PR
+distinctes**, ou une seule fois avec conséquence sévère (perte de données, faille, donnée
+personnelle, contrat cassé). Le reste va dans une liste « vu une fois » sans proposition — un
+harnais gonflé par des cas isolés coûte plus qu'il ne rapporte.
+
+## Sortie
+
+```
+## Correctifs de relecteur, par PR
+- PR <id> — <relecteur> a poussé <n> hunk(s) après mon dernier SHA
+  - <fichier> — <ce qui manquait> → `<catégorie>`
+```
+
+```
+## Thèmes récurrents
+| # | Thème | Occurrences (PR) | Catégorie dominante |
+```
+
+```
+## Propositions, du barreau le plus bas au plus haut
+### <barreau> — <thème>
+- Preuve : <PR + fichier, deux occurrences minimum>
+- Changement : <fichier de harnais visé, et le texte exact à coller>
+- Coût : <ce que ça retire, ou la ligne d'AGENTS.md que ça remplace>
+```
+
+```
+## Vu une fois — pas de règle
+- <constat> (PR <id>)
+```
+
+```
+## Arbitrages — rien à corriger
+- <constat> (PR <id>)
+```
+
+Une section vide s'écrit `_néant_`. Pas de préambule, pas de conclusion.
+
+## Contraintes d'exécution
+
+- Une commande par appel : le garde-fou de worktree refuse les boucles shell, les
+  substitutions `$(...)` et les heredocs.
+- Avec `bkt`, `--jq` exige `--json` dans la même commande.
+- Chaque texte à coller respecte la langue de son fichier cible : anglais pour `AGENTS.md`,
+  `.agents/rules/`, `.agents/skills/`, `MEMORY.md` ; français pour un ADR.
+- Ne modifie aucun fichier. La décision de promouvoir reste à moi.

--- a/harness/commands/pr-feedback.md
+++ b/harness/commands/pr-feedback.md
@@ -15,12 +15,17 @@ dernières PR fusionnées dont je suis l'auteur.
 
 Déduis la forge de `git remote get-url origin` et n'emploie que son client. `<slug>` désigne
 partout le chemin du dépôt lu sur ce remote (`<espace>/<dépôt>`) ; ne code jamais sa valeur en
-dur dans ce fichier.
+dur dans ce fichier. Avec `gh api`, écris littéralement `{owner}/{repo}` : le client les
+substitue depuis le remote, et la dérivation manuelle devient inutile.
 
 ```bash
 bkt pr list --mine --state MERGED --limit 10 --json --jq '.pull_requests[] | "\(.id) | \(.title)"'
 gh pr list --author @me --state merged --limit 10 --json number,title
 ```
+
+Les deux n'ont pas la même portée : sans dépôt, `bkt pr list --mine` remonte **tous** les
+dépôts de l'espace, là où `gh pr list` se limite au dépôt courant. Sur Bitbucket, écarte les PR
+d'un autre dépôt avant de compter les occurrences.
 
 Pour toute autre forge, mappe les concepts ci-dessous sur son client (`glab`, `tea`, l'API
 brute) en vérifiant les options dans son aide. Les concepts ne changent pas ; les endpoints,
@@ -35,7 +40,7 @@ ils réapparaissent sous mon nom. Le signal vit donc côté forge, dans trois en
 
 ```bash
 bkt api "/repositories/<slug>/pullrequests/<id>/activity?pagelen=50" --json --jq '.values[] | select(.update) | "\(.update.date) | \(.update.author.display_name) | \(.update.source.commit.hash) | \(.update.state)"'
-gh pr view <id> --json commits --jq '.commits[] | "\(.committedDate) | \(.authors[0].login) | \(.oid[0:12]) | \(.messageHeadline)"'
+gh pr view <id> --json commits --jq '.commits[] | "\(.committedDate) | \(.authors[0] | if (.login // "") == "" then .name else .login end) | \(.oid[0:12]) | \(.messageHeadline)"'
 ```
 
 Toute poussée par quelqu'un d'autre que moi, après ma dernière poussée, est un **correctif de


### PR DESCRIPTION
Quatre correctifs dérivés de ce qu'un relecteur a dû pousser par-dessus mon travail sur deux PR
d'un dépôt professionnel. Aucun contenu de ce dépôt n'est repris ici : les constats sont
reformulés, et le seul fichier qui adressait une forge nommée en est expurgé (voir plus bas).

## Les quatre constats

Le relecteur a dû ajouter, sur deux PR distinctes :

1. clés d'idempotence, ordre monotone et écriture atomique d'une valeur dérivée du premier
   événement qualifiant ;
2. la quarantaine d'une entrée inconnue au lieu d'un rejet silencieux ;
3. un oracle nommé avant toute promesse tirée d'une capacité d'API ;
4. la lecture du **statut** d'une source citée, pas de son seul titre.

Les trois premiers barreaux visés sont de la prose chargée à chaque tour, le quatrième aussi.
C'est le barreau le plus faible de l'échelle — voir la réserve en fin de description.

## Les trois règles

**`harness/USER.md`, point de vigilance 1** — l'erreur incomplète ne s'arrête plus aux retours
vides et nuls : sur une écriture ou un rappel venu de l'extérieur, la clé d'idempotence est
nommée, l'ordre attendu est dit, la valeur dérivée du premier événement qualifiant s'écrit
atomiquement, et l'entrée inconnue part en quarantaine avec sa charge brute, rejouable — jamais
avalée ni dégradée en avertissement.

**`harness/AGENTS.md`, §Verification Claims** — une capacité offerte par un contrat (scellement,
champ de rétention, archivage logique, révocation de lien) est une structure de preuve, pas la
garantie. Toute promesse est adossée à un contrôle de bout en bout nommé, qui tourne.

**`harness/AGENTS.md`, §Critical Analysis** — une source se cite par son statut : une proposition
n'est pas une autorité, et une référence légale ou normative datée doit être la version en
vigueur avant que quoi que ce soit s'y appuie.

## `pr-feedback` sous version, et débitumée de sa forge

La commande vivait en `~/.claude/commands/pr-feedback.md`, fichier réel non suivi : aucune
histoire, aucun déploiement, perdue à la prochaine machine. Elle entre dans `harness/commands/`
avec trois changements :

**La borne du delta correctif était fausse.** Elle prenait le SHA lu dans l'activité de la PR
comme borne basse. L'activité ne liste pas toutes mes poussées, et une branche absorbe des
fusions de la branche d'intégration ainsi que des PR fusionnées en squash **sous mon nom** : la
borne tombait au milieu du travail d'autrui et le diff mélangeait des fichiers étrangers au sujet.
La borne est maintenant le commit qui précède le premier commit du relecteur, obtenue en remontant
la chaîne de commits, et vérifiée sur le récapitulatif de fichiers avant de demander le diff.

**Plus aucun identifiant d'employeur.** Le chemin de dépôt était codé en dur dans six commandes.
Il est lu du remote (`<slug>`). `git grep -niE 'septeo|modelo|immobilier'` sur le diff de branche
ne renvoie rien.

**Plus une seule forge.** Chaque point de collecte donne la commande Bitbucket (`bkt`) *et*
GitHub (`gh`). Pour les autres forges, la section « Forge » demande de mapper les concepts sur le
client concerné en vérifiant ses options dans son aide — je n'ai pas écrit de commande `glab` ou
`tea` que je ne peux pas exécuter ici. Les deux clients écrits n'ont pas la même portée par
défaut, et le fichier le dit désormais : `bkt pr list --mine` remonte tous les dépôts de l'espace,
`gh pr list --author @me` seulement le dépôt courant.

## Câblage

`make claude-code` pose désormais le lien `~/.claude/commands/pr-feedback.md`, sur la forme des
cibles voisines (`${CREATE_SYMLINK}`, répertoire en prérequis d'ordre seul).

`tooling/ci-smoke-targets` n'énumère pas les chemins déployés : il remonte les lignes changées du
`Makefile` à la cible `.PHONY` englobante. `tooling/ci-smoke-targets main HEAD` renvoie
`["claude-code"]`, et `test.yml` lance `make claude-code` deux fois — la nouvelle cible est
couverte, idempotence comprise. Rien à y ajouter.

## Ce que ça coûte, et que je ne paie pas

`harness/AGENTS.md` passe de **57 à 64 lignes**, `harness/USER.md` de **56 à 60**. #156 avait tenu
son budget à la ligne, en payant trois lignes ajoutées par trois retirées. Cette PR ajoute onze
lignes à la couche chargée à chaque tour **sans en retirer aucune**. C'est une dette assumée, pas
un oubli : je n'ai pas trouvé de ligne existante que ces quatre constats rendraient redondante.

Réserve de fond, la même qu'en #156 : aucune de ces trois règles n'est mesurée. C'est de la prose,
et l'histoire de ce dépôt dit que ce barreau échoue quand la règle ne se voit pas appliquée. Les
constats 1 et 2 ont une maison plus durable — les classes d'échec de `merge-verdict`, déjà routées
depuis `AGENTS.md` par #156 — mais elles décrivent la conception, pas la sortie livrée, et c'est la
sortie que le relecteur a corrigée.

## `arnes` classe cette représentation « unsupported » — pourquoi elle reste

`tooling/arnes/src/prompts/capability.rs` déclare `.claude/commands` comme registre des prompts
réutilisables (Claude, User), et `prompts.rs:60-69` renvoie `State::Unsupported` — « symlink
projections have no stable agent contract » — pour une projection déclarée `symlink` ; le test
`symlink_representation_is_unsupported_without_inspecting_its_source` fige ce choix. Ce validateur
a atterri en `3703100` (#155), **un commit avant la base de cette PR**. Cette PR déploie
exactement cette représentation : la contradiction doit être dite, pas laissée à trouver.

Elle reste, pour trois raisons, et une seule est solide :

1. L'ADR-003 fait du lien symbolique le mécanisme de déploiement de **tout** le dépôt. Une
   exception pour les commandes demanderait à superséder l'ADR, pas à contourner arnes.
2. `Unsupported` est une phrase sur ce qu'arnes **sait valider**, pas sur ce que Claude Code sait
   charger — le nom du test le dit : il refuse *sans inspecter la source*. Ce n'est pas un constat
   d'échec du mécanisme.
3. Rien n'est observable aujourd'hui : `home/.arnes.yaml` n'a aucune section `prompts:`, donc
   arnes n'inspecte jamais cette destination. Le conflit naîtra à la déclaration.

La décision de fond — état `symlink` sain, `Unsupported` documenté, ou `rendered` — est sortie
sur #158 plutôt que tranchée ici.

**Ce que je n'ai pas prouvé :** qu'une *commande* se charge à travers un lien. La preuve adjacente
existe pour les *skills* — `~/.claude/skills/merge-verdict` est un lien posé par ce `Makefile`, et
le skill se charge — mais elle ne transporte pas jusqu'à `.claude/commands`. C'est le trou que la
règle « No guarantee without a green oracle », ajoutée par cette même PR, désigne dans son propre
câblage.

## Vérification

GNU Make 3.81 sur macOS 25.5.0 arm64, depuis un worktree — pas BSD make, contrairement à ce que
disait une version antérieure de cette description. Les autres cibles supportées (Linux dans
`test-deployment.yml`) ne sont exercées que par la CI.

- `tooling/makefile-test`, `tooling/ci-smoke-targets-test`, `tooling/fish-deployment-test`,
  `tooling/agent-handoff-test`, `tooling/upgrade-test` : 5/5 suites vertes.
  `shellcheck --severity=error` : 0 erreur. `actionlint` n'a tourné qu'en CI.
- En CI sur le head : le job `Install claude-code` a créé le lien sur un runner neuf, puis rejoué
  `make claude-code` sans erreur — idempotence prouvée par la porte qui bloque la fusion, sur
  macOS seulement.
- Déploiement dans un `HOME` bac à sable, deux passes : lien correct, `~/.codex/AGENTS.md`
  inchangé au second tour, `grep -c oracle` = 1, les puces `USER.md` et §Critical Analysis
  traversent l'assemblage Codex.
- Chemin d'échec : `${CREATE_SYMLINK}` **refuse** un fichier régulier préexistant (`make: ***
  Error 1`) sans le modifier. Vérifié.
- Correctifs de revue vérifiés à l'exécution : `.login // .name` en jq **ne se déclenche pas** sur
  une chaîne vide (`echo '{"login":"","name":"Jane"}' | jq -r '.login // .name'` rend `""`), d'où
  la forme conditionnelle ; les deux branches sont exécutées contre l'API réelle.

**Ce que rien ne couvre :** aucun linter ni correcteur n'atteint `harness/commands/pr-feedback.md`
— la liste CSpell de `lint.yml` est explicite et anglaise, et y ajouter ce fichier sort 543 mots
inconnus faute de dictionnaire français. Aucun test n'exécute une seule des commandes `bkt` ou
`gh` qu'il documente ; elles ont été vérifiées à la main contre l'API, une fois, par un relecteur
en contexte frais.

## Précondition de fusion — pas une étape optionnelle

`~/.claude/commands/pr-feedback.md` existe en fichier régulier, daté du 17 août 11:24, plus ancien
que le futur checkout. Make jugera donc la cible périmée, lancera la recette, `test ! -e`
échouera, et **GNU Make 3.81 sans `-k` abandonne `ai` avant `codex`** : `~/.codex/AGENTS.md` n'est
pas régénéré et les trois puces d'instruction de cette PR n'atteignent jamais Codex — un des buts
déclarés. `tooling/upgrade:29` sort `0` malgré l'abandon, défaut préexistant de ce script qui
transforme un échec bruyant en échec silencieux.

À faire dans la même opération que la fusion, avant tout `make` :

```sh
rm ~/.claude/commands/pr-feedback.md && make -C ~/.dotfiles claude-code codex
```

Le contenu n'est pas perdu : la copie suivie de cette PR est la même, correctifs en plus. À noter
que `~/.claude/rules/` n'existe pas encore sur ma machine — ce `make` sera aussi le premier à
déployer la règle de #150.

Aucun commentaire ajouté, ni dans le `Makefile` ni ailleurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWX7ghWceinLHgnAzS56aw
