### PR TITLE
feat(arnes): validate command bindings with doctor commands

### DIFF
--- a/docs/superpowers/plans/2026-08-18-arnes-command-bindings.md
+++ b/docs/superpowers/plans/2026-08-18-arnes-command-bindings.md
@@ -1,0 +1,1392 @@
+# Arnes Command Binding Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implémenter `arnes doctor commands` pour valider les commandes logiques et leurs bindings
+Claude, tout en signalant Cursor et Codex `unsupported`.
+
+**Architecture:** Ajouter `commands[]` au manifeste sous forme de commandes logiques à bindings
+imbriqués. L'orchestrateur filtre les bindings avant toute I/O, réutilise la validation ciblée des
+projections de prompts, puis contrôle uniquement la destination et la description propres au
+binding. Parsing, validation statique, capacité, metadata et orchestration restent séparés.
+
+**Tech Stack:** Rust 2024, Clap, Serde, `serde_yaml_ng`, tests d'intégration Cargo, fixtures
+`tempfile`, macOS local et CI Ubuntu existante.
+
+---
+
+## Cartographie des fichiers
+
+- Créer `tooling/arnes/src/manifest/commands.rs` : déclarations YAML et vues empruntées.
+- Créer `tooling/arnes/src/manifest/validation/commands.rs` : invariants statiques purs.
+- Modifier `tooling/arnes/src/manifest.rs` et `tooling/arnes/src/manifest/validation.rs` : câblage du
+  schéma normalisé.
+- Créer `tooling/arnes/src/commands.rs` : filtres, ordre et diagnostics.
+- Créer `tooling/arnes/src/commands/capability.rs` : matrice agent/scope et destination dérivée.
+- Créer `tooling/arnes/src/commands/binding.rs` : parsing du frontmatter et description.
+- Modifier `tooling/arnes/src/prompts.rs` et `tooling/arnes/src/prompts/projection.rs` : primitive
+  interne réutilisable et réexport du tracker existant, sans changement CLI.
+- Modifier `tooling/arnes/src/lib.rs` et `tooling/arnes/src/main.rs` : exposition et routage.
+- Créer `tooling/arnes/tests/manifest_commands.rs`, `tooling/arnes/tests/support/commands.rs`,
+  `tooling/arnes/tests/commands.rs`, `tooling/arnes/tests/command_failures.rs` et
+  `tooling/arnes/tests/command_topology.rs` : couverture séparée sous le seuil de 250 lignes.
+
+### Tâche 1: Normaliser et valider `commands[]`
+
+**Fichiers :**
+- Créer : `tooling/arnes/src/manifest/commands.rs`
+- Créer : `tooling/arnes/src/manifest/validation/commands.rs`
+- Créer : `tooling/arnes/tests/manifest_commands.rs`
+- Modifier : `tooling/arnes/src/manifest.rs`
+- Modifier : `tooling/arnes/src/manifest/validation.rs`
+
+- [ ] **Étape 1: Écrire les tests RED du modèle emprunté et de sa compatibilité v1**
+
+Commencer `tests/manifest_commands.rs` par ce helper autonome :
+
+```rust
+use arnes::manifest::{self, Agent, Scope};
+
+fn input(commands: &str) -> String {
+    format!(
+        "version: 1
+agents:
+  - id: claude
+    scopes: [user, project]
+  - id: cursor
+    scopes: [project]
+  - id: codex
+    scopes: [user, project]
+prompts:
+  - id: deploy
+    source: {{ root: repository, path: harness/prompts/deploy.md }}
+    includes: []
+    variables: []
+    projections: []
+commands:{commands}
+resources: []
+"
+    )
+}
+
+fn error(commands: &str) -> String {
+    manifest::parse(&input(commands)).err().unwrap().to_string()
+}
+```
+
+Ajouter ensuite :
+
+```rust
+#[test]
+fn command_getters_preserve_command_and_binding_order() {
+    let manifest = manifest::parse(&input(
+        "\n  - name: deploy\n    description: Deploy safely\n    prompt: deploy\n    bindings:\n      - { agent: claude, scope: user }\n      - { agent: cursor, scope: project }",
+    ))
+    .unwrap();
+    let commands = manifest.commands().collect::<Vec<_>>();
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].name(), "deploy");
+    assert_eq!(commands[0].description(), "Deploy safely");
+    assert_eq!(commands[0].prompt(), "deploy");
+    let bindings = commands[0].bindings().collect::<Vec<_>>();
+    assert_eq!((bindings[0].agent, bindings[0].scope), (Agent::Claude, Scope::User));
+    assert_eq!((bindings[1].agent, bindings[1].scope), (Agent::Cursor, Scope::Project));
+    assert_eq!(bindings[1].name(), "deploy");
+    assert_eq!(bindings[1].description(), "Deploy safely");
+    assert_eq!(bindings[1].prompt(), "deploy");
+}
+
+#[test]
+fn absent_commands_remain_compatible_with_manifest_v1() {
+    let manifest = manifest::parse(&input(" []")).unwrap();
+    assert_eq!(manifest.commands().count(), 0);
+}
+```
+
+- [ ] **Étape 2: Exécuter les tests et constater l'échec attendu**
+
+```bash
+cd tooling/arnes
+cargo test --test manifest_commands
+```
+
+Attendu : FAIL à la compilation, `Manifest::commands` et les types de commande n'existent pas.
+
+- [ ] **Étape 3: Ajouter le modèle et ses vues aplaties sans dupliquer les chaînes**
+
+Implémenter dans `manifest/commands.rs` :
+
+```rust
+use super::{Agent, Scope};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CommandDeclaration {
+    pub(super) name: String,
+    pub(super) description: String,
+    pub(super) prompt: String,
+    pub(super) bindings: Vec<CommandBindingDeclaration>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CommandBindingDeclaration {
+    pub(super) agent: Agent,
+    pub(super) scope: Scope,
+}
+
+#[derive(Clone, Copy)]
+pub struct Command<'a> {
+    declaration: &'a CommandDeclaration,
+}
+
+#[derive(Clone, Copy)]
+pub struct CommandBinding<'a> {
+    command: &'a CommandDeclaration,
+    pub agent: Agent,
+    pub scope: Scope,
+}
+
+impl<'a> From<&'a CommandDeclaration> for Command<'a> {
+    fn from(declaration: &'a CommandDeclaration) -> Self { Self { declaration } }
+}
+
+impl<'a> Command<'a> {
+    pub fn name(self) -> &'a str { &self.declaration.name }
+    pub fn description(self) -> &'a str { &self.declaration.description }
+    pub fn prompt(self) -> &'a str { &self.declaration.prompt }
+    pub fn bindings(self) -> impl ExactSizeIterator<Item = CommandBinding<'a>> {
+        self.declaration.bindings.iter().map(move |binding| CommandBinding {
+            command: self.declaration,
+            agent: binding.agent,
+            scope: binding.scope,
+        })
+    }
+}
+
+impl<'a> CommandBinding<'a> {
+    pub fn name(self) -> &'a str { &self.command.name }
+    pub fn description(self) -> &'a str { &self.command.description }
+    pub fn prompt(self) -> &'a str { &self.command.prompt }
+}
+```
+
+Dans `manifest.rs`, déclarer/réexporter le module, ajouter
+`#[serde(default)] commands: Vec<commands::CommandDeclaration>` à `Manifest`, puis exposer
+`commands()` par `self.commands.iter().map(Command::from)`.
+
+- [ ] **Étape 4: Ajouter les tests RED de validation statique**
+
+Ajouter ces tests table-driven ; les chaînes sont complètes et ne dépendent d'aucune fixture externe :
+
+```rust
+#[test]
+fn command_fields_are_normalized() {
+    for (commands, expected) in [
+        ("\n  - name: ''\n    description: Deploy safely\n    prompt: deploy\n    bindings: [{ agent: claude, scope: user }]", "commands[0].name: must be lowercase ASCII kebab-case"),
+        ("\n  - name: Deploy\n    description: Deploy safely\n    prompt: deploy\n    bindings: [{ agent: claude, scope: user }]", "commands[0].name: must be lowercase ASCII kebab-case"),
+        ("\n  - name: deploy_now\n    description: Deploy safely\n    prompt: deploy\n    bindings: [{ agent: claude, scope: user }]", "commands[0].name: must be lowercase ASCII kebab-case"),
+        ("\n  - name: deploy--now\n    description: Deploy safely\n    prompt: deploy\n    bindings: [{ agent: claude, scope: user }]", "commands[0].name: must be lowercase ASCII kebab-case"),
+        ("\n  - name: deploy\n    description: '  '\n    prompt: deploy\n    bindings: [{ agent: claude, scope: user }]", "commands[0].description: description cannot be blank"),
+        ("\n  - name: deploy\n    description: Deploy safely\n    prompt: missing\n    bindings: [{ agent: claude, scope: user }]", "commands[0].prompt: referenced prompt is not declared"),
+        ("\n  - name: deploy\n    description: Deploy safely\n    prompt: deploy\n    bindings: []", "commands[0].bindings: at least one binding is required"),
+        ("\n  - name: deploy\n    description: Deploy safely\n    prompt: deploy\n    bindings:\n      - { agent: claude, scope: user }\n      - { agent: claude, scope: user }", "commands[0].bindings[1].agent: duplicates commands[0].bindings[0]"),
+        ("\n  - name: deploy\n    description: One\n    prompt: deploy\n    bindings: [{ agent: claude, scope: user }]\n  - name: deploy\n    description: Two\n    prompt: deploy\n    bindings: [{ agent: claude, scope: user }]", "commands[1].bindings[0].agent: duplicates commands[0].bindings[0]"),
+    ] {
+        assert_eq!(error(commands), expected);
+    }
+}
+
+#[test]
+fn command_targets_must_be_declared() {
+    let command = "\n  - name: deploy\n    description: Deploy safely\n    prompt: deploy\n    bindings: [{ agent: cursor, scope: project }]";
+    let without_cursor = input(command).replace(
+        "  - id: cursor\n    scopes: [project]\n",
+        "",
+    );
+    assert_eq!(
+        manifest::parse(&without_cursor).err().unwrap().to_string(),
+        "commands[0].bindings[0].agent: agent is not declared"
+    );
+    let wrong_scope = command.replace("scope: project", "scope: user");
+    assert_eq!(
+        error(&wrong_scope),
+        "commands[0].bindings[0].scope: scope is not declared for this agent"
+    );
+}
+```
+
+Ajouter séparément ces assertions :
+
+```rust
+#[test]
+fn the_same_name_is_allowed_across_agents_and_scopes() {
+    manifest::parse(&input(
+        "\n  - name: deploy\n    description: Deploy safely\n    prompt: deploy\n    bindings:\n      - { agent: claude, scope: user }\n      - { agent: claude, scope: project }\n      - { agent: cursor, scope: project }",
+    ))
+    .unwrap();
+}
+
+#[test]
+fn legacy_command_resources_are_rejected() {
+    let error = manifest::parse(&input(" []").replace(
+        "resources: []",
+        "resources:\n  - id: deploy\n    kind: commands\n    agent: claude\n    scope: project\n    source: { root: repository, path: prompt.md }\n    destination: { root: repository, path: .claude/commands/deploy.md }",
+    ))
+    .err()
+    .unwrap();
+    assert_eq!(error.to_string(), "resources[0].kind: commands must use normalized top-level declarations");
+}
+```
+
+Ajouter enfin :
+
+```rust
+#[test]
+fn unknown_command_and_binding_fields_are_rejected() {
+    let command = "\n  - name: deploy\n    description: Deploy safely\n    prompt: deploy\n    extra: value\n    bindings: [{ agent: claude, scope: user }]";
+    assert!(error(command).contains("unknown field `extra`"));
+    let binding = "\n  - name: deploy\n    description: Deploy safely\n    prompt: deploy\n    bindings: [{ agent: claude, scope: user, extra: value }]";
+    assert!(error(binding).contains("unknown field `extra`"));
+}
+```
+
+- [ ] **Étape 5: Implémenter la validation pure minimale**
+
+Créer `manifest/validation/commands.rs` avec :
+
+```rust
+use super::super::commands::CommandDeclaration;
+use super::super::prompts::PromptDeclaration;
+use super::super::{Agent, ManifestError, Scope};
+use std::collections::{HashMap, HashSet};
+
+pub(super) fn validate(
+    commands: &[CommandDeclaration],
+    prompts: &[PromptDeclaration],
+    agents: &HashMap<Agent, HashSet<Scope>>,
+) -> Result<(), ManifestError> {
+    let prompts = prompts.iter().map(|prompt| prompt.id.as_str()).collect::<HashSet<_>>();
+    let mut identities = HashMap::new();
+    for (command_index, command) in commands.iter().enumerate() {
+        let field = |name: &str| format!("commands[{command_index}].{name}");
+        if !valid_name(&command.name) {
+            return Err(ManifestError::new(field("name"), "must be lowercase ASCII kebab-case"));
+        }
+        if command.description.trim().is_empty() {
+            return Err(ManifestError::new(field("description"), "description cannot be blank"));
+        }
+        if !prompts.contains(command.prompt.as_str()) {
+            return Err(ManifestError::new(field("prompt"), "referenced prompt is not declared"));
+        }
+        if command.bindings.is_empty() {
+            return Err(ManifestError::new(field("bindings"), "at least one binding is required"));
+        }
+        for (binding_index, binding) in command.bindings.iter().enumerate() {
+            let binding_field = |name: &str| {
+                format!("commands[{command_index}].bindings[{binding_index}].{name}")
+            };
+            super::validate_target(&binding_field, binding.agent, binding.scope, agents)?;
+            let identity = (binding.agent, binding.scope, command.name.as_str());
+            if let Some((previous_command, previous_binding)) =
+                identities.insert(identity, (command_index, binding_index))
+            {
+                return Err(ManifestError::new(
+                    binding_field("agent"),
+                    format!("duplicates commands[{previous_command}].bindings[{previous_binding}]"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.split('-').all(|segment| {
+            !segment.is_empty()
+                && segment.bytes().all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        })
+}
+```
+
+Rendre `PromptDeclaration::id` accessible à ce module avec `pub(super)` déjà présent. Dans
+`validation.rs`, déclarer `mod commands`, appeler cette validation après `prompts::validate`, et
+refuser `ResourceKind::Commands` au même endroit que `ResourceKind::Prompts`.
+
+- [ ] **Étape 6: Vérifier la tranche et les régressions du manifeste**
+
+```bash
+cargo test --test manifest_commands
+cargo test --test manifest --test manifest_prompts
+```
+
+Attendu : PASS pour les trois binaires de test.
+
+- [ ] **Étape 7: Committer le schéma normalisé**
+
+```bash
+git add tooling/arnes/src/manifest.rs tooling/arnes/src/manifest/commands.rs tooling/arnes/src/manifest/validation.rs tooling/arnes/src/manifest/validation/commands.rs tooling/arnes/tests/manifest_commands.rs
+git diff --cached --check
+git commit -m "feat(arnes): declare command bindings"
+```
+
+### Tâche 2: Exposer une validation de projection réutilisable
+
+**Fichiers :**
+- Modifier : `tooling/arnes/src/prompts.rs`
+- Modifier : `tooling/arnes/src/prompts/projection.rs`
+
+- [ ] **Étape 1: Établir la caractérisation GREEN de #109**
+
+```bash
+cd tooling/arnes
+cargo test --test prompts --test prompt_failures --test prompt_topology --test prompt_adversarial
+```
+
+Attendu : PASS avant le refactor ; conserver la sortie dans le journal d'exécution.
+
+- [ ] **Étape 2: Faire retourner le contenu effectivement comparé sans seconde lecture**
+
+Changer `projection::validate` en `Result<String, Failure>` et terminer par :
+
+```rust
+if actual == *expected {
+    Ok(actual)
+} else {
+    Err(stale(projection))
+}
+```
+
+Dans `prompts.rs`, extraire la logique actuelle dans :
+
+```rust
+pub(crate) fn validate_projection(
+    roots: &Roots,
+    prompt: Prompt<'_>,
+    projection: PromptProjection<'_>,
+) -> Result<String, Failure> {
+    if projection.representation == PromptRepresentation::Symlink {
+        return Err(Failure::new(
+            State::Unsupported,
+            "symlink projections have no stable agent contract",
+            "symlink projection unsupported",
+        ));
+    }
+    let expected = source::validate(roots, prompt)?;
+    projection::validate(roots, projection, &expected)
+}
+```
+
+`diagnose_projection` appelle cette fonction et transforme `Ok(_)` en son diagnostic `healthy`
+actuel. Rendre `Failure`, ses trois champs et `Failure::new` `pub(crate)`. Réexporter
+`pub(crate) use topology::Tracker as ProjectionTracker`; conserver `Tracker::new` et
+`Tracker::validate` publics dans le crate uniquement.
+
+- [ ] **Étape 3: Relancer strictement la caractérisation**
+
+```bash
+cargo test --test prompts --test prompt_failures --test prompt_topology --test prompt_adversarial
+```
+
+Attendu : mêmes tests PASS, mêmes états et messages ; aucun changement fonctionnel du CLI prompts.
+
+- [ ] **Étape 4: Committer le refactor interne isolé**
+
+```bash
+git add tooling/arnes/src/prompts.rs tooling/arnes/src/prompts/projection.rs
+git diff --cached --check
+git commit -m "refactor(arnes): expose prompt projection validation"
+```
+
+### Tâche 3: Livrer la tranche verticale Claude et le routage CLI
+
+**Fichiers :**
+- Créer : `tooling/arnes/src/commands.rs`
+- Créer : `tooling/arnes/src/commands/capability.rs`
+- Créer : `tooling/arnes/src/commands/binding.rs`
+- Créer : `tooling/arnes/tests/support/commands.rs`
+- Créer : `tooling/arnes/tests/commands.rs`
+- Modifier : `tooling/arnes/src/lib.rs`
+- Modifier : `tooling/arnes/src/main.rs`
+
+- [ ] **Étape 1: Écrire une fixture read-only à deux scopes**
+
+Créer ce support complet dans `tests/support/commands.rs` :
+
+```rust
+use crate::support::Fixture;
+use std::process::Output;
+
+pub const DESCRIPTION: &str = "Deploy safely";
+pub const CONTENTS: &str = "---\ndescription: Deploy safely\n---\nDeploy now\n";
+
+pub fn manifest(prompts: &str, commands: &str) -> String {
+    format!(
+        "version: 1
+agents:
+  - id: claude
+    scopes: [user, project]
+  - id: cursor
+    scopes: [user, project]
+  - id: codex
+    scopes: [user, project]
+prompts:
+{prompts}commands:
+{commands}resources: []
+"
+    )
+}
+
+pub fn prompt(id: &str, agent: &str, scope: &str, representation: &str, destination: &str) -> String {
+    let root = if scope == "user" { "home" } else { "repository" };
+    format!(
+        "  - id: {id}\n    source: {{ root: repository, path: harness/prompts/{id}.md }}\n    includes: []\n    variables: []\n    projections:\n      - agent: {agent}\n        scope: {scope}\n        representation: {representation}\n        destination: {{ root: {root}, path: {destination} }}\n"
+    )
+}
+
+pub fn command(name: &str, prompt: &str, bindings: &str) -> String {
+    format!(
+        "  - name: {name}\n    description: {DESCRIPTION}\n    prompt: {prompt}\n    bindings:\n{bindings}"
+    )
+}
+
+pub fn configured_fixture() -> Fixture {
+    let fixture = Fixture::new();
+    let prompts = "  - id: deploy
+    source: { root: repository, path: harness/prompts/deploy.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: rendered
+        destination: { root: home, path: .claude/commands/deploy.md }
+      - agent: claude
+        scope: project
+        representation: file
+        destination: { root: repository, path: .claude/commands/deploy.md }
+";
+    let commands = command(
+        "deploy",
+        "deploy",
+        "      - { agent: claude, scope: user }\n      - { agent: claude, scope: project }\n",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(prompts, &commands));
+    fixture.write_repository("harness/prompts/deploy.md", CONTENTS);
+    fixture.write_home(".claude/commands/deploy.md", CONTENTS);
+    fixture.write_repository(".claude/commands/deploy.md", CONTENTS);
+    fixture
+}
+
+pub fn run(fixture: &Fixture, args: &[&str]) -> (i32, String, String) {
+    let before = fixture.snapshot();
+    let output = fixture.command(args);
+    assert_eq!(fixture.snapshot(), before);
+    output_tuple(output)
+}
+
+pub fn output_tuple(output: Output) -> (i32, String, String) {
+    (
+        output.status.code().unwrap(),
+        String::from_utf8(output.stdout).unwrap(),
+        String::from_utf8(output.stderr).unwrap(),
+    )
+}
+```
+
+- [ ] **Étape 2: Écrire les tests CLI RED de la tranche saine**
+
+Ajouter dans `tests/commands.rs` :
+
+```rust
+#[path = "support/commands.rs"]
+pub mod command_support;
+pub mod support;
+
+use command_support::{configured_fixture, output_tuple, run};
+use std::process::Command;
+
+#[test]
+fn claude_user_and_project_bindings_are_healthy() {
+    for scope in ["user", "project"] {
+        let fixture = configured_fixture();
+        let (code, stdout, stderr) = run(
+            &fixture,
+            &["doctor", "commands", "--agent", "claude", "--scope", scope],
+        );
+        assert_eq!(code, 0, "{stdout}");
+        assert!(stdout.contains(&format!("claude {scope} commands")));
+        assert!(stdout.contains("healthy     deploy · current"));
+        assert!(stderr.is_empty());
+    }
+}
+
+#[test]
+fn command_diagnostics_are_json_and_read_only() {
+    let fixture = configured_fixture();
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &["doctor", "commands", "--agent", "claude", "--scope", "project", "--format", "json"],
+    );
+    let diagnostics: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(diagnostics[0]["resource"], "commands");
+    assert_eq!(diagnostics[0]["state"], "healthy");
+    assert!(stderr.is_empty());
+}
+```
+
+Ajouter dans le même fichier :
+
+```rust
+#[test]
+fn doctor_commands_routes_root_errors_to_commands() {
+    let fixture = configured_fixture();
+    let output = Command::new(env!("CARGO_BIN_EXE_arnes"))
+        .args(["doctor", "commands"])
+        .current_dir(fixture.repository())
+        .env_clear()
+        .output()
+        .unwrap();
+    let (code, stdout, stderr) = output_tuple(output);
+    assert_eq!(code, 2);
+    assert!(stdout.starts_with("error commands:"));
+    assert!(stderr.is_empty());
+}
+```
+
+- [ ] **Étape 3: Exécuter la tranche et observer RED**
+
+```bash
+cargo test --test commands
+```
+
+Attendu : FAIL, sortie vide pour `doctor commands` et exit code incorrect sans `HOME`.
+
+- [ ] **Étape 4: Implémenter la capacité et le parseur de metadata**
+
+Dans `commands/capability.rs` :
+
+```rust
+use crate::manifest::{Agent, Scope};
+use std::path::{Path, PathBuf};
+
+pub(super) fn destination(agent: Agent, scope: Scope, name: &str) -> Option<PathBuf> {
+    match (agent, scope) {
+        (Agent::Claude, Scope::User | Scope::Project) => {
+            Some(Path::new(".claude/commands").join(format!("{name}.md")))
+        }
+        _ => None,
+    }
+}
+```
+
+Dans `commands/binding.rs`, normaliser CRLF vers LF, exiger deux lignes délimitrices `---`, puis
+désérialiser sans `deny_unknown_fields` :
+
+```rust
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Metadata {
+    description: Option<String>,
+}
+
+pub(super) fn validate(contents: &str, expected: &str) -> Result<(), &'static str> {
+    let normalized = contents.replace("\r\n", "\n");
+    let frontmatter = normalized
+        .strip_prefix("---\n")
+        .and_then(|contents| contents.split_once("\n---\n").map(|(yaml, _)| yaml))
+        .ok_or("frontmatter missing or malformed")?;
+    let metadata: Metadata =
+        serde_yaml_ng::from_str(frontmatter).map_err(|_| "frontmatter missing or malformed")?;
+    match metadata.description.as_deref() {
+        Some(description) if description == expected => Ok(()),
+        Some(_) => Err("description differs from manifest"),
+        None => Err("description is missing"),
+    }
+}
+```
+
+- [ ] **Étape 5: Implémenter l'orchestrateur avec les frontières approuvées**
+
+Dans `commands.rs`, déclarer `mod binding; mod capability;` et exposer :
+
+```rust
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, CommandBinding, Manifest, Prompt, PromptProjection, Scope};
+use crate::prompts::{self, Failure};
+use std::path::Path;
+
+mod binding;
+mod capability;
+
+pub fn diagnose(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    let selected = manifest
+        .commands()
+        .flat_map(|command| command.bindings())
+        .filter(|binding| agent.is_none_or(|agent| agent == binding.agent))
+        .filter(|binding| scope.is_none_or(|scope| scope == binding.scope))
+        .collect::<Vec<_>>();
+    if selected.is_empty() {
+        return vec![unsupported(agent, scope, None)];
+    }
+    let prompts = manifest.prompts().collect::<Vec<_>>();
+    selected
+        .into_iter()
+        .map(|binding| diagnose_binding(roots, binding, &prompts))
+        .collect()
+}
+
+fn diagnose_binding(
+    roots: &Roots,
+    command: CommandBinding<'_>,
+    prompts: &[Prompt<'_>],
+) -> Diagnostic {
+    let Some(expected_destination) =
+        capability::destination(command.agent, command.scope, command.name())
+    else {
+        return unsupported(Some(command.agent), Some(command.scope), Some(command.name()));
+    };
+    let (prompt, projection) = match resolve_projection(command, prompts, &expected_destination) {
+        Ok(binding) => binding,
+        Err(diagnostic) => return diagnostic,
+    };
+    match prompts::validate_projection(roots, prompt, projection) {
+        Err(failure) => broken(command, failure),
+        Ok(contents) => match binding::validate(&contents, command.description()) {
+            Ok(()) => diagnostic(command, State::Healthy, "binding is current", "current"),
+            Err(message) => diagnostic(command, State::Drift, message, "binding stale"),
+        },
+    }
+}
+
+fn resolve_projection<'a>(
+    command: CommandBinding<'a>,
+    prompts: &[Prompt<'a>],
+    expected_destination: &Path,
+) -> Result<(Prompt<'a>, PromptProjection<'a>), Diagnostic> {
+    let Some(prompt) = prompts
+        .iter()
+        .copied()
+        .find(|prompt| prompt.id() == command.prompt())
+    else {
+        return Err(diagnostic(
+            command,
+            State::Error,
+            format!("referenced prompt {} is not declared", command.prompt()),
+            "prompt missing",
+        ));
+    };
+    let Some(projection) = prompt
+        .projections()
+        .find(|projection| projection.agent == command.agent && projection.scope == command.scope)
+    else {
+        return Err(diagnostic(
+            command,
+            State::Error,
+            "referenced prompt has no projection for this binding",
+            "projection missing",
+        ));
+    };
+    if projection.destination != expected_destination {
+        return Err(diagnostic(
+            command,
+            State::Error,
+            format!(
+                "prompt projection destination {} does not match {}",
+                projection.destination.display(),
+                expected_destination.display()
+            ),
+            "projection destination incompatible",
+        ));
+    }
+    Ok((prompt, projection))
+}
+
+fn unsupported(
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+    name: Option<&str>,
+) -> Diagnostic {
+    let subject = match (agent, scope, name) {
+        (Some(agent), Some(scope), Some(name)) => format!("{agent} {scope} command {name}"),
+        (Some(agent), Some(scope), None) => format!("{agent} {scope} commands"),
+        (Some(agent), None, None) => format!("{agent} commands"),
+        (None, Some(scope), None) => format!("{scope} command scope"),
+        _ => "command bindings".to_owned(),
+    };
+    let group = match (agent, scope) {
+        (Some(agent), Some(scope)) => format!("{agent} {scope} commands"),
+        _ => "commands".to_owned(),
+    };
+    Diagnostic::new(
+        "commands",
+        State::Unsupported,
+        format!("{subject} is not declared or has no stable command contract"),
+    )
+    .with_human(group, "capability · unsupported")
+}
+
+fn broken(command: CommandBinding<'_>, failure: Failure) -> Diagnostic {
+    diagnostic(
+        command,
+        failure.state,
+        failure.message,
+        failure.summary,
+    )
+}
+
+fn diagnostic(
+    command: CommandBinding<'_>,
+    state: State,
+    message: impl Into<String>,
+    summary: impl Into<String>,
+) -> Diagnostic {
+    Diagnostic::new(
+        "commands",
+        state,
+        format!("{}: {}", subject(command), message.into()),
+    )
+    .with_human(
+        format!("{} {} commands", command.agent, command.scope),
+        format!("{} · {}", command.name(), summary.into()),
+    )
+}
+
+fn subject(command: CommandBinding<'_>) -> String {
+    let destination = capability::destination(command.agent, command.scope, command.name())
+        .expect("supported bindings have a destination");
+    format!(
+        "managed {} {} command {} at {}",
+        command.agent,
+        command.scope,
+        command.name(),
+        destination.display()
+    )
+}
+```
+
+Ce code filtre avant toute I/O, ne résout jamais un prompt pour Cursor ou Codex, et transpose les
+échecs de `prompts` sans changer leur état. Le tracker topologique reste volontairement absent afin
+que les tests de collision de Tâche 4 établissent leur RED avant son branchement.
+
+- [ ] **Étape 6: Router le module dans la bibliothèque et le binaire**
+
+Ajouter `pub mod commands;` à `lib.rs`. Dans `main.rs`, importer `arnes::commands`, ajouter un bras
+`Some(Resource::Commands)` symétrique à `Prompts`, puis :
+
+```rust
+fn diagnose_commands(
+    roots: &Roots,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    match manifest::load(roots.home()) {
+        Ok(manifest) => commands::diagnose(roots, &manifest, agent, scope),
+        Err(error) => vec![Diagnostic::new("commands", State::Error, error.to_string())],
+    }
+}
+```
+
+- [ ] **Étape 7: Vérifier GREEN et les régressions directes**
+
+```bash
+cargo test --test commands
+cargo test --test prompts --test prompt_failures --test prompt_topology --test prompt_adversarial
+```
+
+Attendu : PASS ; `doctor commands` produit un diagnostic par binding sélectionné et ne mute aucune
+fixture ; tous les tests prompts restent PASS.
+
+- [ ] **Étape 8: Committer la tranche verticale**
+
+```bash
+git add tooling/arnes/src/commands.rs tooling/arnes/src/commands tooling/arnes/src/lib.rs tooling/arnes/src/main.rs tooling/arnes/tests/commands.rs tooling/arnes/tests/support/commands.rs
+git diff --cached --check
+git commit -m "feat(arnes): diagnose Claude command bindings"
+```
+
+### Tâche 4: Fermer les cas limites, filtres et collisions
+
+**Fichiers :**
+- Modifier : `tooling/arnes/tests/commands.rs`
+- Créer : `tooling/arnes/tests/command_failures.rs`
+- Créer : `tooling/arnes/tests/command_topology.rs`
+- Modifier : `tooling/arnes/src/commands.rs`
+- Modifier : `tooling/arnes/src/commands/binding.rs`
+
+- [ ] **Étape 1: Ajouter la matrice RED des capacités et filtres**
+
+Dans `commands.rs`, tester Cursor user/project et Codex user/project : exit `0`, résumé
+`capability · unsupported`, aucune mention d'une source de prompt volontairement absente. Tester une
+sélection sans binding, puis un filtre Claude project qui exclut un binding Claude user dont la
+source manque. Ajouter deux commandes dans l'ordre `zeta`, `alpha`, chacune avec deux bindings, et
+affirmer l'ordre commande puis binding en humain et JSON. Créer aussi
+`.claude/commands/unmanaged.md` et `.claude/commands/opsx/plugin.md`, puis affirmer leur absence de la
+sortie et l'identité du snapshot.
+
+Remplacer l'import `command_support` de Tâche 3 par celui-ci, ajouter `Fixture`, puis utiliser ces
+tests complets :
+
+```rust
+use command_support::{
+    CONTENTS, command, configured_fixture, manifest, output_tuple, prompt, run,
+};
+use support::Fixture;
+
+#[test]
+fn cursor_and_codex_are_unsupported_without_prompt_io() {
+    for (agent, scope) in [
+        ("cursor", "user"),
+        ("cursor", "project"),
+        ("codex", "user"),
+        ("codex", "project"),
+    ] {
+        let fixture = Fixture::new();
+        let prompts = prompt(
+            "deploy",
+            "claude",
+            "project",
+            "file",
+            ".claude/commands/deploy.md",
+        );
+        let bindings = format!("      - {{ agent: {agent}, scope: {scope} }}\n");
+        let commands = command("deploy", "deploy", &bindings);
+        fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+        let (code, stdout, stderr) = run(
+            &fixture,
+            &["doctor", "commands", "--agent", agent, "--scope", scope],
+        );
+        assert_eq!(code, 0, "{stdout}");
+        assert!(stdout.contains("capability · unsupported"));
+        assert!(!stdout.contains("source"));
+        assert!(stderr.is_empty());
+    }
+}
+
+#[test]
+fn filters_exclude_bindings_before_io() {
+    let fixture = Fixture::new();
+    let prompts = format!(
+        "{}{}",
+        prompt("missing", "claude", "user", "file", ".claude/commands/missing.md"),
+        prompt("selected", "claude", "project", "file", ".claude/commands/selected.md"),
+    );
+    let commands = format!(
+        "{}{}",
+        command("missing", "missing", "      - { agent: claude, scope: user }\n"),
+        command("selected", "selected", "      - { agent: claude, scope: project }\n"),
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+    fixture.write_repository("harness/prompts/selected.md", CONTENTS);
+    fixture.write_repository(".claude/commands/selected.md", CONTENTS);
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &["doctor", "commands", "--agent", "claude", "--scope", "project"],
+    );
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("selected · current"));
+    assert!(!stdout.contains("missing"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn an_empty_filtered_selection_is_unsupported() {
+    let fixture = configured_fixture();
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &["doctor", "commands", "--agent", "cursor", "--scope", "project"],
+    );
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("capability · unsupported"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn diagnostics_preserve_command_then_binding_order() {
+    let fixture = Fixture::new();
+    let prompts = format!(
+        "{}{}",
+        prompt("zeta", "claude", "user", "file", ".claude/commands/zeta.md"),
+        prompt("alpha", "claude", "user", "file", ".claude/commands/alpha.md"),
+    );
+    let bindings = "      - { agent: claude, scope: user }\n      - { agent: cursor, scope: user }\n";
+    let commands = format!(
+        "{}{}",
+        command("zeta", "zeta", bindings),
+        command("alpha", "alpha", bindings),
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+    for name in ["zeta", "alpha"] {
+        fixture.write_repository(format!("harness/prompts/{name}.md"), CONTENTS);
+        fixture.write_home(format!(".claude/commands/{name}.md"), CONTENTS);
+    }
+    let (_, human, _) = run(&fixture, &["doctor", "commands", "--scope", "user"]);
+    let positions = ["zeta · current", "capability · unsupported", "alpha · current"]
+        .map(|needle| human.find(needle).unwrap());
+    assert!(positions[0] < positions[1] && positions[1] < positions[2]);
+    let (_, json, _) = run(
+        &fixture,
+        &["doctor", "commands", "--scope", "user", "--format", "json"],
+    );
+    let diagnostics: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+    assert!(diagnostics[0]["message"].as_str().unwrap().contains("zeta"));
+    assert_eq!(diagnostics[1]["state"], "unsupported");
+    assert!(diagnostics[2]["message"].as_str().unwrap().contains("alpha"));
+    assert_eq!(diagnostics[3]["state"], "unsupported");
+}
+
+#[test]
+fn unmanaged_and_plugin_neighbors_are_ignored() {
+    let fixture = configured_fixture();
+    fixture.write_home(".claude/commands/unmanaged.md", "ignored\n");
+    fixture.write_home(".claude/commands/opsx/plugin.md", "ignored\n");
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &["doctor", "commands", "--agent", "claude", "--scope", "user"],
+    );
+    assert_eq!(code, 0, "{stdout}");
+    assert!(!stdout.contains("unmanaged"));
+    assert!(!stdout.contains("opsx"));
+    assert!(stderr.is_empty());
+}
+```
+
+- [ ] **Étape 2: Ajouter la matrice RED des erreurs et metadata**
+
+Dans `command_failures.rs`, utiliser une fonction `assert_state(fixture, expected_code, expected)`
+et couvrir : projection Claude absente ; destination déclarée différente de
+`.claude/commands/<name>.md` ; destination absente, répertoire, symlink, périmée ou illisible ; source
+absente ou illisible ; include absent ; variable non déclarée ; représentation `symlink` ;
+frontmatter absent, non fermé ou YAML invalide ; description absente, non-string ou différente.
+Pour les cas metadata, écrire le même contenu altéré dans la source et la projection afin que la
+validation du prompt soit saine et que le contrôle du binding soit effectivement atteint.
+
+Commencer `command_failures.rs` avec :
+
+```rust
+#[path = "support/commands.rs"]
+pub mod command_support;
+pub mod support;
+
+use command_support::{
+    CONTENTS, command, configured_fixture, manifest, output_tuple, prompt, run,
+};
+use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use support::Fixture;
+
+const CLAUDE_PROJECT: &[&str] = &[
+    "doctor", "commands", "--agent", "claude", "--scope", "project",
+];
+
+fn assert_state(fixture: &Fixture, code: i32, expected: &str) {
+    let (actual, stdout, stderr) = run(fixture, CLAUDE_PROJECT);
+    assert_eq!(actual, code, "{stdout}");
+    assert!(stdout.contains(expected), "missing {expected}: {stdout}");
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn missing_wrong_type_stale_and_symlink_destinations_are_drift() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.repository().join(".claude/commands/deploy.md")).unwrap();
+    assert_state(&fixture, 1, "is missing");
+
+    let fixture = configured_fixture();
+    let destination = fixture.repository().join(".claude/commands/deploy.md");
+    fs::remove_file(&destination).unwrap();
+    fs::create_dir(&destination).unwrap();
+    assert_state(&fixture, 1, "is not a regular file");
+
+    let fixture = configured_fixture();
+    fixture.write_repository(".claude/commands/deploy.md", "stale\n");
+    assert_state(&fixture, 1, "is stale");
+
+    let fixture = configured_fixture();
+    let destination = fixture.repository().join(".claude/commands/deploy.md");
+    fs::remove_file(&destination).unwrap();
+    symlink("../../harness/prompts/deploy.md", &destination).unwrap();
+    assert_state(&fixture, 1, "is a symlink");
+}
+
+#[test]
+fn unreadable_source_and_destination_are_errors() {
+    for relative in ["harness/prompts/deploy.md", ".claude/commands/deploy.md"] {
+        let fixture = configured_fixture();
+        let path = fixture.repository().join(relative);
+        let permissions = fs::metadata(&path).unwrap().permissions();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        let output = fixture.command(CLAUDE_PROJECT);
+        fs::set_permissions(&path, permissions).unwrap();
+        let (code, stdout, stderr) = output_tuple(output);
+        assert_eq!(code, 2, "{stdout}");
+        assert!(stdout.contains("could not be read"));
+        assert!(stderr.is_empty());
+    }
+}
+
+#[test]
+fn projection_contract_failures_are_explicit() {
+    let fixture = Fixture::new();
+    let no_projection = prompt("deploy", "cursor", "project", "file", ".cursor/commands/deploy.md");
+    let commands = command("deploy", "deploy", "      - { agent: claude, scope: project }\n");
+    fixture.write_home(".arnes.yaml", &manifest(&no_projection, &commands));
+    assert_state(&fixture, 2, "projection missing");
+
+    let fixture = Fixture::new();
+    let incompatible = prompt(
+        "deploy",
+        "claude",
+        "project",
+        "file",
+        ".claude/commands/not-deploy.md",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&incompatible, &commands));
+    assert_state(&fixture, 2, "projection destination incompatible");
+
+    let fixture = Fixture::new();
+    let symlinked = prompt(
+        "deploy",
+        "claude",
+        "project",
+        "symlink",
+        ".claude/commands/deploy.md",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&symlinked, &commands));
+    assert_state(&fixture, 0, "symlink projection unsupported");
+}
+
+#[test]
+fn source_include_and_variable_failures_are_transposed() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.repository().join("harness/prompts/deploy.md")).unwrap();
+    assert_state(&fixture, 2, "source harness/prompts/deploy.md is missing");
+
+    let fixture = Fixture::new();
+    let prompts = "  - id: deploy
+    source: { root: repository, path: harness/prompts/deploy.md }
+    includes: [missing.md]
+    variables: []
+    projections:
+      - agent: claude
+        scope: project
+        representation: file
+        destination: { root: repository, path: .claude/commands/deploy.md }
+";
+    let commands = command("deploy", "deploy", "      - { agent: claude, scope: project }\n");
+    fixture.write_home(".arnes.yaml", &manifest(prompts, &commands));
+    fixture.write_repository("harness/prompts/deploy.md", "@missing.md\nDeploy\n");
+    fixture.write_repository(".claude/commands/deploy.md", "@missing.md\nDeploy\n");
+    assert_state(&fixture, 2, "include harness/prompts/missing.md is missing");
+
+    let fixture = configured_fixture();
+    let contents = format!("{CONTENTS}Deploy $undeclared\n");
+    fixture.write_repository("harness/prompts/deploy.md", &contents);
+    fixture.write_repository(".claude/commands/deploy.md", &contents);
+    assert_state(&fixture, 2, "variables undeclared are referenced but not declared");
+}
+
+#[test]
+fn frontmatter_and_description_mismatches_are_drift() {
+    for (contents, expected) in [
+        ("Deploy now\n", "frontmatter missing or malformed"),
+        ("---\ndescription: Deploy safely\nDeploy now\n", "frontmatter missing or malformed"),
+        ("---\ndescription: [\n---\nDeploy now\n", "frontmatter missing or malformed"),
+        ("---\nother: value\n---\nDeploy now\n", "description is missing"),
+        ("---\ndescription: 42\n---\nDeploy now\n", "frontmatter missing or malformed"),
+        ("---\ndescription: Deploy unsafely\n---\nDeploy now\n", "description differs from manifest"),
+    ] {
+        let fixture = configured_fixture();
+        fixture.write_repository("harness/prompts/deploy.md", contents);
+        fixture.write_repository(".claude/commands/deploy.md", contents);
+        assert_state(&fixture, 1, expected);
+    }
+}
+
+#[test]
+fn unrelated_frontmatter_keys_are_ignored() {
+    let fixture = configured_fixture();
+    let contents = "---\ndescription: Deploy safely\nallowed-tools: Bash\n---\nDeploy now\n";
+    fixture.write_repository("harness/prompts/deploy.md", contents);
+    fixture.write_repository(".claude/commands/deploy.md", contents);
+    assert_state(&fixture, 0, "deploy · current");
+}
+```
+
+Ajouter ce test de priorité :
+
+```rust
+#[test]
+fn the_highest_state_controls_the_exit_code() {
+    let fixture = Fixture::new();
+    let prompts = "  - id: cursor-command
+    source: { root: repository, path: harness/prompts/cursor-command.md }
+    includes: []
+    variables: []
+    projections: []
+  - id: drifting
+    source: { root: repository, path: harness/prompts/drifting.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: file
+        destination: { root: home, path: .claude/commands/drifting.md }
+  - id: broken
+    source: { root: repository, path: harness/prompts/broken.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: file
+        destination: { root: home, path: .claude/commands/broken.md }
+";
+    let commands = "  - name: cursor-command
+    description: Deploy safely
+    prompt: cursor-command
+    bindings: [{ agent: cursor, scope: user }]
+  - name: drifting
+    description: Deploy safely
+    prompt: drifting
+    bindings: [{ agent: claude, scope: user }]
+  - name: broken
+    description: Deploy safely
+    prompt: broken
+    bindings: [{ agent: claude, scope: user }]
+";
+    fixture.write_home(".arnes.yaml", &manifest(prompts, commands));
+    fixture.write_repository("harness/prompts/drifting.md", CONTENTS);
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "commands"]);
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("unsupported"));
+    assert!(stdout.contains("drift"));
+    assert!(stdout.contains("error"));
+    assert!(stderr.is_empty());
+}
+```
+
+- [ ] **Étape 3: Ajouter les collisions topologiques RED**
+
+Dans `command_topology.rs`, créer deux prompts et bindings Claude project dont les destinations
+lexicales diffèrent mais dont les parents symlinkent le même répertoire réel ; attendre exit `2` et
+`aliases managed destination`. Ajouter un cas où la destination du binding alias une destination de
+resource préchargée dans le tracker. Les deux bindings en collision doivent être sélectionnés ; un
+binding filtré ne doit jamais être lu ni enregistré par le tracker.
+
+Créer le fichier avec cet en-tête et ces tests :
+
+```rust
+#[path = "support/commands.rs"]
+pub mod command_support;
+pub mod support;
+
+use command_support::{CONTENTS, command, manifest, prompt, run};
+use std::os::unix::fs::symlink;
+use support::Fixture;
+
+#[test]
+fn selected_command_destinations_cannot_alias_each_other() {
+    let fixture = Fixture::new();
+    let prompts = format!(
+        "{}{}",
+        prompt("one", "claude", "project", "file", ".claude/commands/one.md"),
+        prompt("two", "claude", "project", "file", ".claude/commands/two.md"),
+    );
+    let commands = format!(
+        "{}{}",
+        command("one", "one", "      - { agent: claude, scope: project }\n"),
+        command("two", "two", "      - { agent: claude, scope: project }\n"),
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+    for name in ["one", "two"] {
+        fixture.write_repository(format!("harness/prompts/{name}.md"), CONTENTS);
+    }
+    fixture.write_repository(".claude/commands/shared.md", CONTENTS);
+    symlink("shared.md", fixture.repository().join(".claude/commands/one.md")).unwrap();
+    symlink("shared.md", fixture.repository().join(".claude/commands/two.md")).unwrap();
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &["doctor", "commands", "--agent", "claude", "--scope", "project"],
+    );
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("aliases managed destination"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn command_destinations_cannot_alias_managed_resources() {
+    let fixture = Fixture::new();
+    let prompts = prompt(
+        "deploy",
+        "claude",
+        "project",
+        "file",
+        ".claude/commands/deploy.md",
+    );
+    let commands = command("deploy", "deploy", "      - { agent: claude, scope: project }\n");
+    let manifest = manifest(&prompts, &commands).replace(
+        "resources: []",
+        "resources:\n  - id: managed\n    kind: instructions\n    agent: claude\n    scope: project\n    source: { root: repository, path: harness/AGENTS.md }\n    destination: { root: repository, path: .claude/commands/resource.md }",
+    );
+    fixture.write_home(".arnes.yaml", &manifest);
+    fixture.write_repository("harness/prompts/deploy.md", CONTENTS);
+    fixture.write_repository(".claude/commands/shared.md", CONTENTS);
+    symlink("shared.md", fixture.repository().join(".claude/commands/deploy.md")).unwrap();
+    symlink("shared.md", fixture.repository().join(".claude/commands/resource.md")).unwrap();
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &["doctor", "commands", "--agent", "claude", "--scope", "project"],
+    );
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("aliases managed destination resource"));
+    assert!(stderr.is_empty());
+}
+```
+
+Le test `filters_exclude_bindings_before_io` de `commands.rs` couvre le troisième invariant : le
+tracker est créé après filtrage et ne voit jamais le binding exclu.
+
+- [ ] **Étape 4: Exécuter les nouveaux tests et observer les échecs précis**
+
+```bash
+cargo test --test commands --test command_failures --test command_topology
+```
+
+Attendu : les cas fonctionnels sont déjà GREEN grâce à la tranche verticale ; les deux collisions
+topologiques sont RED parce que le tracker n'est pas encore branché. Aucune panique ni lecture du
+vrai `HOME`.
+
+- [ ] **Étape 5: Brancher le tracker uniquement sur les bindings sélectionnés**
+
+Importer `ProjectionTracker`, le créer après le filtre, le passer à `diagnose_binding`, puis ajouter
+ce bloc immédiatement avant `prompts::validate_projection` :
+
+```rust
+if let Err(failure) = topology.validate(roots, prompt, projection) {
+    return broken(command, failure);
+}
+```
+
+La signature devient :
+
+```rust
+fn diagnose_binding(
+    roots: &Roots,
+    command: CommandBinding<'_>,
+    prompts: &[Prompt<'_>],
+    topology: &mut ProjectionTracker,
+) -> Diagnostic
+```
+
+Dans `diagnose`, utiliser exactement :
+
+```rust
+let mut topology = ProjectionTracker::new(roots, manifest);
+selected
+    .into_iter()
+    .map(|binding| diagnose_binding(roots, binding, &prompts, &mut topology))
+    .collect()
+```
+
+Les helpers `unsupported`, `broken`, `diagnostic` et `subject` de Tâche 3 restent inchangés : ils
+préservent déjà les états prompt, classent les erreurs du parseur de binding en `Drift` et évitent
+toute I/O pour une capacité absente. Ne pas ajouter scan, retry, fallback ou dépendance.
+
+- [ ] **Étape 6: Faire passer chaque matrice puis toutes les régressions Arnes**
+
+```bash
+cargo test --test commands --test command_failures --test command_topology
+cargo test --test manifest_commands --test manifest --test manifest_prompts
+cargo test --test prompts --test prompt_failures --test prompt_topology --test prompt_adversarial
+```
+
+Attendu : PASS pour tous les binaires listés ; les snapshots avant/après restent identiques.
+
+- [ ] **Étape 7: Committer les cas limites**
+
+```bash
+git add tooling/arnes/src/commands.rs tooling/arnes/src/commands/binding.rs tooling/arnes/tests/commands.rs tooling/arnes/tests/command_failures.rs tooling/arnes/tests/command_topology.rs
+git diff --cached --check
+git commit -m "test(arnes): cover command binding failures"
+```
+
+### Tâche 5: Exécuter la barrière finale et auditer la cohésion
+
+**Fichiers :**
+- Modifier uniquement les fichiers nommés par un échec reproductible du formateur, de Clippy ou des
+  tests causé par les tâches 1 à 4.
+
+- [ ] **Étape 1: Formater puis vérifier le format**
+
+```bash
+cd tooling/arnes
+cargo fmt
+cargo fmt --check
+```
+
+Attendu : PASS sur macOS ; inspecter le diff du formateur avant de poursuivre.
+
+- [ ] **Étape 2: Exécuter lint et tests complets dans l'environnement local**
+
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Attendu : PASS sur macOS Darwin arm64. Cette preuve ne couvre pas Ubuntu.
+
+- [ ] **Étape 3: Vérifier les extensions et la taille des unités réellement touchées**
+
+```bash
+git diff --check origin/main...HEAD
+find src tests -type f -name '*.rs' -print0 | xargs -0 wc -l | sort -n
+git diff --name-only origin/main...HEAD
+```
+
+Attendu : aucun whitespace error ; chaque nouveau fichier manuscrit reste sous 250 lignes. Inspecter
+chaque fonction modifiée ; toute fonction dépassant 50 lignes doit être découpée par responsabilité
+ou justifiée explicitement dans la livraison.
+
+- [ ] **Étape 4: Vérifier la CI Ubuntu seulement après publication autorisée**
+
+Le workflow `.github/workflows/test-arnes.yml` exécute la barrière Rust sur Ubuntu. Après push ou PR
+explicitement autorisé, attendre son résultat avec `gh pr checks --watch` et ne déclarer Ubuntu vert
+que si ce run précis réussit. Sans publication, noter Ubuntu « non exercé ».
+
+- [ ] **Étape 5: Committer uniquement les corrections mécaniques finales si nécessaire**
+
+```bash
+git status --short
+git diff --check
+git add tooling/arnes
+git commit -m "chore(arnes): satisfy command validation gates"
+```
+
+Attendu : créer ce commit seulement si `cargo fmt` ou Clippy a produit une correction ; sinon garder
+les quatre commits précédents sans commit vide.
+
+## Critères de livraison
+
+- `doctor commands` ne tombe plus dans le fallback vide et respecte les filtres avant I/O.
+- Les commandes logiques évitent la duplication multi-agent et restent uniques par
+  `(agent, scope, name)`.
+- Claude réutilise exactement le snapshot de projection validé par `prompts`; aucune seconde lecture
+  ni duplication de validation du corps.
+- Cursor et Codex valident le manifeste puis retournent `unsupported` sans inspecter le disque.
+- Aucun répertoire unmanaged ou plugin n'est parcouru, aucune mutation ni dépendance n'est ajoutée.
+- Les preuves locales nomment macOS ; Ubuntu n'est revendiqué qu'après le workflow réel.
+- Aucun commentaire de code n'est prévu.

--- a/tooling/arnes/src/commands.rs
+++ b/tooling/arnes/src/commands.rs
@@ -49,12 +49,23 @@ fn diagnose_with_tracker(
             .collect();
     }
     let prompts = manifest.prompts().collect::<Vec<_>>();
-    let scopes = combinations
+    let selected_scopes = combinations
         .iter()
         .map(|(_, scope)| *scope)
         .collect::<Vec<_>>();
+    let scopes = ProjectionTracker::relevant_scopes(roots, &selected_scopes);
+    let topology_combinations = combinations
+        .iter()
+        .flat_map(|(agent, _)| scopes.iter().map(|scope| (*agent, *scope)))
+        .collect::<HashSet<_>>();
     let mut topology = create_tracker(&scopes);
-    seed_unbound_projections(roots, &selected, &prompts, &combinations, &mut topology);
+    seed_unbound_projections(
+        roots,
+        &selected,
+        &prompts,
+        &topology_combinations,
+        &mut topology,
+    );
     selected
         .into_iter()
         .map(|binding| diagnose_binding(roots, binding, &prompts, &mut topology))

--- a/tooling/arnes/src/commands.rs
+++ b/tooling/arnes/src/commands.rs
@@ -2,16 +2,31 @@ use crate::Roots;
 use crate::diagnostic::{Diagnostic, State};
 use crate::manifest::{Agent, CommandBinding, Manifest, Prompt, PromptProjection, Scope};
 use crate::prompts::{self, Failure, ProjectionTracker};
+use std::collections::HashSet;
 use std::path::Path;
 
 mod binding;
 mod capability;
+#[cfg(test)]
+mod tests;
 
 pub fn diagnose(
     roots: &Roots,
     manifest: &Manifest,
     agent: Option<Agent>,
     scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    diagnose_with_tracker(roots, manifest, agent, scope, |scopes| {
+        ProjectionTracker::new_for_scopes(roots, manifest, scopes)
+    })
+}
+
+fn diagnose_with_tracker(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+    create_tracker: impl FnOnce(&[Scope]) -> ProjectionTracker,
 ) -> Vec<Diagnostic> {
     let selected = manifest
         .commands()
@@ -22,12 +37,50 @@ pub fn diagnose(
     if selected.is_empty() {
         return vec![unsupported(agent, scope, None)];
     }
+    let combinations = selected
+        .iter()
+        .filter(|binding| capability::supported(binding.agent, binding.scope))
+        .map(|binding| (binding.agent, binding.scope))
+        .collect::<HashSet<_>>();
+    if combinations.is_empty() {
+        return selected
+            .into_iter()
+            .map(|binding| unsupported_binding(binding))
+            .collect();
+    }
     let prompts = manifest.prompts().collect::<Vec<_>>();
-    let mut topology = ProjectionTracker::new(roots, manifest);
+    let scopes = combinations
+        .iter()
+        .map(|(_, scope)| *scope)
+        .collect::<Vec<_>>();
+    let mut topology = create_tracker(&scopes);
+    seed_unbound_projections(roots, &selected, &prompts, &combinations, &mut topology);
     selected
         .into_iter()
         .map(|binding| diagnose_binding(roots, binding, &prompts, &mut topology))
         .collect()
+}
+
+fn seed_unbound_projections(
+    roots: &Roots,
+    selected: &[CommandBinding<'_>],
+    prompts: &[Prompt<'_>],
+    combinations: &HashSet<(Agent, Scope)>,
+    topology: &mut ProjectionTracker,
+) {
+    let referenced = selected
+        .iter()
+        .filter(|binding| combinations.contains(&(binding.agent, binding.scope)))
+        .map(|binding| (binding.prompt(), binding.agent, binding.scope))
+        .collect::<HashSet<_>>();
+    for prompt in prompts {
+        for projection in prompt.projections().filter(|projection| {
+            combinations.contains(&(projection.agent, projection.scope))
+                && !referenced.contains(&(prompt.id(), projection.agent, projection.scope))
+        }) {
+            topology.seed_projection_destination(roots, *prompt, projection);
+        }
+    }
 }
 
 fn diagnose_binding(
@@ -122,6 +175,14 @@ fn unsupported(agent: Option<Agent>, scope: Option<Scope>, name: Option<&str>) -
         format!("{subject} is not declared or has no stable command contract"),
     )
     .with_human(group, "capability · unsupported")
+}
+
+fn unsupported_binding(command: CommandBinding<'_>) -> Diagnostic {
+    unsupported(
+        Some(command.agent),
+        Some(command.scope),
+        Some(command.name()),
+    )
 }
 
 fn broken(command: CommandBinding<'_>, failure: Failure) -> Diagnostic {

--- a/tooling/arnes/src/commands.rs
+++ b/tooling/arnes/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::Roots;
 use crate::diagnostic::{Diagnostic, State};
 use crate::manifest::{Agent, CommandBinding, Manifest, Prompt, PromptProjection, Scope};
-use crate::prompts::{self, Failure};
+use crate::prompts::{self, Failure, ProjectionTracker};
 use std::path::Path;
 
 mod binding;
@@ -23,9 +23,10 @@ pub fn diagnose(
         return vec![unsupported(agent, scope, None)];
     }
     let prompts = manifest.prompts().collect::<Vec<_>>();
+    let mut topology = ProjectionTracker::new(roots, manifest);
     selected
         .into_iter()
-        .map(|binding| diagnose_binding(roots, binding, &prompts))
+        .map(|binding| diagnose_binding(roots, binding, &prompts, &mut topology))
         .collect()
 }
 
@@ -33,6 +34,7 @@ fn diagnose_binding(
     roots: &Roots,
     command: CommandBinding<'_>,
     prompts: &[Prompt<'_>],
+    topology: &mut ProjectionTracker,
 ) -> Diagnostic {
     let Some(expected_destination) =
         capability::destination(command.agent, command.scope, command.name())
@@ -47,6 +49,9 @@ fn diagnose_binding(
         Ok(binding) => binding,
         Err(diagnostic) => return diagnostic,
     };
+    if let Err(failure) = topology.validate(roots, prompt, projection) {
+        return broken(command, failure);
+    }
     match prompts::validate_projection(roots, prompt, projection) {
         Err(failure) => broken(command, failure),
         Ok(contents) => match binding::validate(&contents, command.description()) {

--- a/tooling/arnes/src/commands.rs
+++ b/tooling/arnes/src/commands.rs
@@ -1,0 +1,153 @@
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, CommandBinding, Manifest, Prompt, PromptProjection, Scope};
+use crate::prompts::{self, Failure};
+use std::path::Path;
+
+mod binding;
+mod capability;
+
+pub fn diagnose(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    let selected = manifest
+        .commands()
+        .flat_map(|command| command.bindings())
+        .filter(|binding| agent.is_none_or(|agent| agent == binding.agent))
+        .filter(|binding| scope.is_none_or(|scope| scope == binding.scope))
+        .collect::<Vec<_>>();
+    if selected.is_empty() {
+        return vec![unsupported(agent, scope, None)];
+    }
+    let prompts = manifest.prompts().collect::<Vec<_>>();
+    selected
+        .into_iter()
+        .map(|binding| diagnose_binding(roots, binding, &prompts))
+        .collect()
+}
+
+fn diagnose_binding(
+    roots: &Roots,
+    command: CommandBinding<'_>,
+    prompts: &[Prompt<'_>],
+) -> Diagnostic {
+    let Some(expected_destination) =
+        capability::destination(command.agent, command.scope, command.name())
+    else {
+        return unsupported(
+            Some(command.agent),
+            Some(command.scope),
+            Some(command.name()),
+        );
+    };
+    let (prompt, projection) = match resolve_projection(command, prompts, &expected_destination) {
+        Ok(binding) => binding,
+        Err(diagnostic) => return diagnostic,
+    };
+    match prompts::validate_projection(roots, prompt, projection) {
+        Err(failure) => broken(command, failure),
+        Ok(contents) => match binding::validate(&contents, command.description()) {
+            Ok(()) => diagnostic(command, State::Healthy, "binding is current", "current"),
+            Err(message) => diagnostic(command, State::Drift, message, "binding stale"),
+        },
+    }
+}
+
+fn resolve_projection<'a>(
+    command: CommandBinding<'a>,
+    prompts: &[Prompt<'a>],
+    expected_destination: &Path,
+) -> Result<(Prompt<'a>, PromptProjection<'a>), Diagnostic> {
+    let Some(prompt) = prompts
+        .iter()
+        .copied()
+        .find(|prompt| prompt.id() == command.prompt())
+    else {
+        return Err(diagnostic(
+            command,
+            State::Error,
+            format!("referenced prompt {} is not declared", command.prompt()),
+            "prompt missing",
+        ));
+    };
+    let Some(projection) = prompt
+        .projections()
+        .find(|projection| projection.agent == command.agent && projection.scope == command.scope)
+    else {
+        return Err(diagnostic(
+            command,
+            State::Error,
+            "referenced prompt has no projection for this binding",
+            "projection missing",
+        ));
+    };
+    if projection.destination != expected_destination {
+        return Err(diagnostic(
+            command,
+            State::Error,
+            format!(
+                "prompt projection destination {} does not match {}",
+                projection.destination.display(),
+                expected_destination.display()
+            ),
+            "projection destination incompatible",
+        ));
+    }
+    Ok((prompt, projection))
+}
+
+fn unsupported(agent: Option<Agent>, scope: Option<Scope>, name: Option<&str>) -> Diagnostic {
+    let subject = match (agent, scope, name) {
+        (Some(agent), Some(scope), Some(name)) => format!("{agent} {scope} command {name}"),
+        (Some(agent), Some(scope), None) => format!("{agent} {scope} commands"),
+        (Some(agent), None, None) => format!("{agent} commands"),
+        (None, Some(scope), None) => format!("{scope} command scope"),
+        _ => "command bindings".to_owned(),
+    };
+    let group = match (agent, scope) {
+        (Some(agent), Some(scope)) => format!("{agent} {scope} commands"),
+        _ => "commands".to_owned(),
+    };
+    Diagnostic::new(
+        "commands",
+        State::Unsupported,
+        format!("{subject} is not declared or has no stable command contract"),
+    )
+    .with_human(group, "capability · unsupported")
+}
+
+fn broken(command: CommandBinding<'_>, failure: Failure) -> Diagnostic {
+    diagnostic(command, failure.state, failure.message, failure.summary)
+}
+
+fn diagnostic(
+    command: CommandBinding<'_>,
+    state: State,
+    message: impl Into<String>,
+    summary: impl Into<String>,
+) -> Diagnostic {
+    Diagnostic::new(
+        "commands",
+        state,
+        format!("{}: {}", subject(command), message.into()),
+    )
+    .with_human(
+        format!("{} {} commands", command.agent, command.scope),
+        format!("{} · {}", command.name(), summary.into()),
+    )
+}
+
+fn subject(command: CommandBinding<'_>) -> String {
+    let destination = capability::destination(command.agent, command.scope, command.name())
+        .expect("supported bindings have a destination");
+    format!(
+        "managed {} {} command {} at {}",
+        command.agent,
+        command.scope,
+        command.name(),
+        destination.display()
+    )
+}

--- a/tooling/arnes/src/commands/binding.rs
+++ b/tooling/arnes/src/commands/binding.rs
@@ -1,8 +1,9 @@
 use serde::Deserialize;
+use serde_yaml_ng::Value;
 
 #[derive(Deserialize)]
 struct Metadata {
-    description: Option<String>,
+    description: Option<Value>,
 }
 
 pub(super) fn validate(contents: &str, expected: &str) -> Result<(), &'static str> {
@@ -17,9 +18,10 @@ pub(super) fn validate(contents: &str, expected: &str) -> Result<(), &'static st
         .ok_or("frontmatter missing or malformed")?;
     let metadata: Metadata =
         serde_yaml_ng::from_str(frontmatter).map_err(|_| "frontmatter missing or malformed")?;
-    match metadata.description.as_deref() {
-        Some(description) if description == expected => Ok(()),
-        Some(_) => Err("description differs from manifest"),
+    match metadata.description {
+        Some(Value::String(description)) if description == expected => Ok(()),
+        Some(Value::String(_)) => Err("description differs from manifest"),
+        Some(_) => Err("description must be a string"),
         None => Err("description is missing"),
     }
 }

--- a/tooling/arnes/src/commands/binding.rs
+++ b/tooling/arnes/src/commands/binding.rs
@@ -1,0 +1,25 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Metadata {
+    description: Option<String>,
+}
+
+pub(super) fn validate(contents: &str, expected: &str) -> Result<(), &'static str> {
+    let normalized = contents.replace("\r\n", "\n");
+    let frontmatter = normalized
+        .strip_prefix("---\n")
+        .and_then(|contents| {
+            contents
+                .split_once("\n---\n")
+                .map(|(frontmatter, _)| frontmatter)
+        })
+        .ok_or("frontmatter missing or malformed")?;
+    let metadata: Metadata =
+        serde_yaml_ng::from_str(frontmatter).map_err(|_| "frontmatter missing or malformed")?;
+    match metadata.description.as_deref() {
+        Some(description) if description == expected => Ok(()),
+        Some(_) => Err("description differs from manifest"),
+        None => Err("description is missing"),
+    }
+}

--- a/tooling/arnes/src/commands/binding.rs
+++ b/tooling/arnes/src/commands/binding.rs
@@ -1,10 +1,4 @@
-use serde::Deserialize;
-use serde_yaml_ng::Value;
-
-#[derive(Deserialize)]
-struct Metadata {
-    description: Option<Value>,
-}
+use serde_yaml_ng::{Mapping, Value};
 
 pub(super) fn validate(contents: &str, expected: &str) -> Result<(), &'static str> {
     let normalized = contents.replace("\r\n", "\n");
@@ -16,9 +10,9 @@ pub(super) fn validate(contents: &str, expected: &str) -> Result<(), &'static st
                 .map(|(frontmatter, _)| frontmatter)
         })
         .ok_or("frontmatter missing or malformed")?;
-    let metadata: Metadata =
+    let metadata: Mapping =
         serde_yaml_ng::from_str(frontmatter).map_err(|_| "frontmatter missing or malformed")?;
-    match metadata.description {
+    match metadata.get("description") {
         Some(Value::String(description)) if description == expected => Ok(()),
         Some(Value::String(_)) => Err("description differs from manifest"),
         Some(_) => Err("description must be a string"),

--- a/tooling/arnes/src/commands/capability.rs
+++ b/tooling/arnes/src/commands/capability.rs
@@ -2,10 +2,12 @@ use crate::manifest::{Agent, Scope};
 use std::path::{Path, PathBuf};
 
 pub(super) fn destination(agent: Agent, scope: Scope, name: &str) -> Option<PathBuf> {
-    match (agent, scope) {
-        (Agent::Claude, Scope::User | Scope::Project) => {
-            Some(Path::new(".claude/commands").join(format!("{name}.md")))
-        }
-        _ => None,
-    }
+    supported(agent, scope).then(|| Path::new(".claude/commands").join(format!("{name}.md")))
+}
+
+pub(super) fn supported(agent: Agent, scope: Scope) -> bool {
+    matches!(
+        (agent, scope),
+        (Agent::Claude, Scope::User | Scope::Project)
+    )
 }

--- a/tooling/arnes/src/commands/capability.rs
+++ b/tooling/arnes/src/commands/capability.rs
@@ -1,0 +1,11 @@
+use crate::manifest::{Agent, Scope};
+use std::path::{Path, PathBuf};
+
+pub(super) fn destination(agent: Agent, scope: Scope, name: &str) -> Option<PathBuf> {
+    match (agent, scope) {
+        (Agent::Claude, Scope::User | Scope::Project) => {
+            Some(Path::new(".claude/commands").join(format!("{name}.md")))
+        }
+        _ => None,
+    }
+}

--- a/tooling/arnes/src/commands/tests.rs
+++ b/tooling/arnes/src/commands/tests.rs
@@ -1,0 +1,39 @@
+use super::*;
+use crate::manifest;
+
+#[test]
+fn unsupported_bindings_do_not_initialize_topology() {
+    let manifest = manifest::parse(
+        "version: 1
+agents:
+  - id: cursor
+    scopes: [project]
+prompts:
+  - id: deploy
+    source: { root: repository, path: prompt.md }
+    includes: []
+    variables: []
+    projections: []
+commands:
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings:
+      - { agent: cursor, scope: project }
+resources: []
+",
+    )
+    .unwrap();
+    let roots = Roots::new("/missing/repository", "/missing/home");
+
+    let diagnostics = diagnose_with_tracker(
+        &roots,
+        &manifest,
+        Some(Agent::Cursor),
+        Some(Scope::Project),
+        |_| panic!("topology initialized for an unsupported binding"),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].state, State::Unsupported);
+}

--- a/tooling/arnes/src/files/paths.rs
+++ b/tooling/arnes/src/files/paths.rs
@@ -2,13 +2,29 @@ use crate::Roots;
 use crate::manifest::Scope;
 use std::fs;
 use std::io::ErrorKind;
+use std::os::unix::fs::MetadataExt;
 use std::path::{Component, Path, PathBuf};
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+pub struct FileIdentity {
+    device: u64,
+    inode: u64,
+}
 
 pub fn canonical_within(path: &Path, root: &Path) -> Option<PathBuf> {
     let canonical_root = fs::canonicalize(root).ok()?;
     symlinks_within(path, root, &canonical_root, &mut Vec::new())
         .then(|| fs::canonicalize(path).ok())?
         .filter(|path| path.starts_with(canonical_root))
+}
+
+pub fn file_identity_within(path: &Path, root: &Path) -> Option<FileIdentity> {
+    let canonical = canonical_within(path, root)?;
+    let metadata = fs::metadata(canonical).ok()?;
+    Some(FileIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
 }
 
 fn symlinks_within(

--- a/tooling/arnes/src/lib.rs
+++ b/tooling/arnes/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod commands;
 pub mod config;
 pub mod diagnostic;
 mod files;

--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::process::ExitCode;
 
 use arnes::Roots;
+use arnes::commands;
 use arnes::config;
 use arnes::diagnostic::{Diagnostic, Report, State};
 use arnes::instructions;
@@ -87,6 +88,10 @@ fn main() -> ExitCode {
             Ok(roots) => diagnose_prompts(&roots, agent, scope),
             Err(error) => vec![Diagnostic::new("prompts", State::Error, error.to_string())],
         },
+        Some(Resource::Commands) => match Roots::from_environment() {
+            Ok(roots) => diagnose_commands(&roots, agent, scope),
+            Err(error) => vec![Diagnostic::new("commands", State::Error, error.to_string())],
+        },
         _ => Vec::new(),
     };
     let report = Report::new(diagnostics);
@@ -160,5 +165,12 @@ fn diagnose_prompts(roots: &Roots, agent: Option<Agent>, scope: Option<Scope>) -
     match manifest::load(roots.home()) {
         Ok(manifest) => prompts::diagnose(roots, &manifest, agent, scope),
         Err(error) => vec![Diagnostic::new("prompts", State::Error, error.to_string())],
+    }
+}
+
+fn diagnose_commands(roots: &Roots, agent: Option<Agent>, scope: Option<Scope>) -> Vec<Diagnostic> {
+    match manifest::load(roots.home()) {
+        Ok(manifest) => commands::diagnose(roots, &manifest, agent, scope),
+        Err(error) => vec![Diagnostic::new("commands", State::Error, error.to_string())],
     }
 }

--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -63,7 +63,26 @@ fn main() -> ExitCode {
         format,
     } = command;
 
-    let diagnostics = match resource {
+    let diagnostics = diagnose(resource, agent, scope);
+    let report = Report::new(diagnostics);
+    let output = match format {
+        Format::Human => report.human(),
+        Format::Json => report.json().expect("diagnostics are JSON serializable"),
+    };
+
+    if let Err(error) = write_output(&output) {
+        eprintln!("output: could not write diagnostics: {error}");
+        return ExitCode::from(2);
+    }
+    ExitCode::from(report.exit_code())
+}
+
+fn diagnose(
+    resource: Option<Resource>,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    match resource {
         None | Some(Resource::Manifest) => match Roots::from_environment() {
             Ok(roots) => vec![diagnose_manifest(&roots)],
             Err(error) => vec![Diagnostic::new("manifest", State::Error, error.to_string())],
@@ -93,18 +112,7 @@ fn main() -> ExitCode {
             Err(error) => vec![Diagnostic::new("commands", State::Error, error.to_string())],
         },
         _ => Vec::new(),
-    };
-    let report = Report::new(diagnostics);
-    let output = match format {
-        Format::Human => report.human(),
-        Format::Json => report.json().expect("diagnostics are JSON serializable"),
-    };
-
-    if let Err(error) = write_output(&output) {
-        eprintln!("output: could not write diagnostics: {error}");
-        return ExitCode::from(2);
     }
-    ExitCode::from(report.exit_code())
 }
 
 fn write_output(output: &str) -> io::Result<()> {

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -3,11 +3,13 @@ use serde::Deserialize;
 use std::fmt::{self, Display};
 use std::path::{Path, PathBuf};
 
+mod commands;
 mod external;
 mod parsing;
 mod prompts;
 mod validation;
 
+pub use commands::{Command, CommandBinding};
 pub use external::{ExternalOrigin, ExternalRoot, ExternalSkill};
 pub use parsing::{load, parse};
 pub use prompts::{Prompt, PromptProjection, PromptRepresentation};
@@ -50,6 +52,8 @@ pub struct Manifest {
     external: external::ExternalPolicy,
     #[serde(default)]
     prompts: Vec<prompts::PromptDeclaration>,
+    #[serde(default)]
+    commands: Vec<commands::CommandDeclaration>,
     resources: Vec<ResourceDeclaration>,
 }
 
@@ -120,6 +124,10 @@ impl Manifest {
 
     pub fn prompts(&self) -> impl Iterator<Item = Prompt<'_>> {
         self.prompts.iter().map(Prompt::from)
+    }
+
+    pub fn commands(&self) -> impl Iterator<Item = Command<'_>> {
+        self.commands.iter().map(Command::from)
     }
 
     pub(crate) fn resource_destinations(&self) -> impl Iterator<Item = (Scope, &Path)> {

--- a/tooling/arnes/src/manifest/commands.rs
+++ b/tooling/arnes/src/manifest/commands.rs
@@ -1,0 +1,75 @@
+use super::{Agent, Scope};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CommandDeclaration {
+    pub(super) name: String,
+    pub(super) description: String,
+    pub(super) prompt: String,
+    pub(super) bindings: Vec<CommandBindingDeclaration>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CommandBindingDeclaration {
+    pub(super) agent: Agent,
+    pub(super) scope: Scope,
+}
+
+#[derive(Clone, Copy)]
+pub struct Command<'a> {
+    declaration: &'a CommandDeclaration,
+}
+
+#[derive(Clone, Copy)]
+pub struct CommandBinding<'a> {
+    command: &'a CommandDeclaration,
+    pub agent: Agent,
+    pub scope: Scope,
+}
+
+impl<'a> From<&'a CommandDeclaration> for Command<'a> {
+    fn from(declaration: &'a CommandDeclaration) -> Self {
+        Self { declaration }
+    }
+}
+
+impl<'a> Command<'a> {
+    pub fn name(self) -> &'a str {
+        &self.declaration.name
+    }
+
+    pub fn description(self) -> &'a str {
+        &self.declaration.description
+    }
+
+    pub fn prompt(self) -> &'a str {
+        &self.declaration.prompt
+    }
+
+    pub fn bindings(self) -> impl ExactSizeIterator<Item = CommandBinding<'a>> {
+        self.declaration
+            .bindings
+            .iter()
+            .map(move |binding| CommandBinding {
+                command: self.declaration,
+                agent: binding.agent,
+                scope: binding.scope,
+            })
+    }
+}
+
+impl<'a> CommandBinding<'a> {
+    pub fn name(self) -> &'a str {
+        &self.command.name
+    }
+
+    pub fn description(self) -> &'a str {
+        &self.command.description
+    }
+
+    pub fn prompt(self) -> &'a str {
+        &self.command.prompt
+    }
+}

--- a/tooling/arnes/src/manifest/validation.rs
+++ b/tooling/arnes/src/manifest/validation.rs
@@ -3,6 +3,7 @@ use serde_yaml_ng::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path};
 
+mod commands;
 mod external;
 mod prompts;
 mod skills;
@@ -78,6 +79,7 @@ pub(super) fn validate(manifest: &Manifest) -> Result<(), ManifestError> {
 
     validate_resources(&manifest.resources, &agents)?;
     prompts::validate(&manifest.prompts, &manifest.resources, &agents)?;
+    commands::validate(&manifest.commands, &manifest.prompts, &agents)?;
     skills::validate(&manifest.skills, &manifest.resources, &agents)?;
     external::validate(&manifest.external, &agents)
 }
@@ -117,6 +119,12 @@ fn validate_resources(
             return Err(ManifestError::new(
                 field("kind"),
                 "prompts must use normalized top-level declarations",
+            ));
+        }
+        if resource.kind == super::ResourceKind::Commands {
+            return Err(ManifestError::new(
+                field("kind"),
+                "commands must use normalized top-level declarations",
             ));
         }
         validate_resource_paths(resource, index)?;

--- a/tooling/arnes/src/manifest/validation.rs
+++ b/tooling/arnes/src/manifest/validation.rs
@@ -115,18 +115,7 @@ fn validate_resources(
                 "scope is not declared for this agent",
             ));
         }
-        if resource.kind == super::ResourceKind::Prompts {
-            return Err(ManifestError::new(
-                field("kind"),
-                "prompts must use normalized top-level declarations",
-            ));
-        }
-        if resource.kind == super::ResourceKind::Commands {
-            return Err(ManifestError::new(
-                field("kind"),
-                "commands must use normalized top-level declarations",
-            ));
-        }
+        validate_normalized_resource_kind(resource, index)?;
         validate_resource_paths(resource, index)?;
         validate_resource_layout(resource, index)?;
         if resource.kind == super::ResourceKind::Skills
@@ -146,6 +135,21 @@ fn validate_resources(
         }
     }
     Ok(())
+}
+
+fn validate_normalized_resource_kind(
+    resource: &ResourceDeclaration,
+    index: usize,
+) -> Result<(), ManifestError> {
+    let name = match resource.kind {
+        super::ResourceKind::Prompts => "prompts",
+        super::ResourceKind::Commands => "commands",
+        _ => return Ok(()),
+    };
+    Err(ManifestError::new(
+        format!("resources[{index}].kind"),
+        format!("{name} must use normalized top-level declarations"),
+    ))
 }
 
 fn validate_resource_layout(

--- a/tooling/arnes/src/manifest/validation/commands.rs
+++ b/tooling/arnes/src/manifest/validation/commands.rs
@@ -1,0 +1,87 @@
+use super::super::commands::CommandDeclaration;
+use super::super::prompts::PromptDeclaration;
+use super::super::{Agent, ManifestError, Scope};
+use std::collections::{HashMap, HashSet};
+
+pub(super) fn validate(
+    commands: &[CommandDeclaration],
+    prompts: &[PromptDeclaration],
+    agents: &HashMap<Agent, HashSet<Scope>>,
+) -> Result<(), ManifestError> {
+    let prompt_ids = prompts
+        .iter()
+        .map(|prompt| prompt.id.as_str())
+        .collect::<HashSet<_>>();
+    let mut identities = HashMap::new();
+    for (command_index, command) in commands.iter().enumerate() {
+        validate_command(command, command_index, &prompt_ids)?;
+        validate_bindings(command, command_index, agents, &mut identities)?;
+    }
+    Ok(())
+}
+
+fn validate_command(
+    command: &CommandDeclaration,
+    index: usize,
+    prompt_ids: &HashSet<&str>,
+) -> Result<(), ManifestError> {
+    let field = |name: &str| format!("commands[{index}].{name}");
+    if !valid_name(&command.name) {
+        return Err(ManifestError::new(
+            field("name"),
+            "must be lowercase ASCII kebab-case",
+        ));
+    }
+    if command.description.trim().is_empty() {
+        return Err(ManifestError::new(
+            field("description"),
+            "description cannot be blank",
+        ));
+    }
+    if !prompt_ids.contains(command.prompt.as_str()) {
+        return Err(ManifestError::new(
+            field("prompt"),
+            "referenced prompt is not declared",
+        ));
+    }
+    if command.bindings.is_empty() {
+        return Err(ManifestError::new(
+            field("bindings"),
+            "at least one binding is required",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_bindings<'a>(
+    command: &'a CommandDeclaration,
+    command_index: usize,
+    agents: &HashMap<Agent, HashSet<Scope>>,
+    identities: &mut HashMap<(Agent, Scope, &'a str), (usize, usize)>,
+) -> Result<(), ManifestError> {
+    for (binding_index, binding) in command.bindings.iter().enumerate() {
+        let field =
+            |name: &str| format!("commands[{command_index}].bindings[{binding_index}].{name}");
+        super::validate_target(&field, binding.agent, binding.scope, agents)?;
+        let identity = (binding.agent, binding.scope, command.name.as_str());
+        if let Some((previous_command, previous_binding)) =
+            identities.insert(identity, (command_index, binding_index))
+        {
+            return Err(ManifestError::new(
+                field("agent"),
+                format!("duplicates commands[{previous_command}].bindings[{previous_binding}]"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.split('-').all(|segment| {
+            !segment.is_empty()
+                && segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        })
+}

--- a/tooling/arnes/src/prompts.rs
+++ b/tooling/arnes/src/prompts.rs
@@ -26,8 +26,15 @@ pub fn diagnose(
     }
 
     let prompts = manifest.prompts().collect::<Vec<_>>();
+    let selected_scopes = combinations
+        .iter()
+        .filter(|(agent, scope)| capability::registry(*agent, *scope).is_some())
+        .map(|(_, scope)| *scope)
+        .collect::<Vec<_>>();
+    let scopes = ProjectionTracker::relevant_scopes(roots, &selected_scopes);
     let mut diagnostics = Vec::new();
-    let mut topology = topology::Tracker::new(roots, manifest);
+    let mut topology =
+        (!scopes.is_empty()).then(|| ProjectionTracker::new_for_scopes(roots, manifest, &scopes));
     for (agent, scope) in combinations {
         if capability::registry(agent, scope).is_none() {
             diagnostics.push(unsupported_combination(Some(agent), Some(scope)));
@@ -40,6 +47,9 @@ pub fn diagnose(
                 .filter(|projection| projection.agent == agent && projection.scope == scope)
             {
                 projected = true;
+                let topology = topology
+                    .as_mut()
+                    .expect("supported prompt projections initialize topology");
                 if let Err(failure) = topology.validate(roots, *prompt, projection) {
                     diagnostics.push(broken(*prompt, projection, failure));
                 } else {

--- a/tooling/arnes/src/prompts.rs
+++ b/tooling/arnes/src/prompts.rs
@@ -57,23 +57,8 @@ fn diagnose_projection(
     prompt: Prompt<'_>,
     projection: PromptProjection<'_>,
 ) -> Diagnostic {
-    if projection.representation == PromptRepresentation::Symlink {
-        return broken(
-            prompt,
-            projection,
-            Failure::new(
-                State::Unsupported,
-                "symlink projections have no stable agent contract",
-                "symlink projection unsupported",
-            ),
-        );
-    }
-    let expected = match source::validate(roots, prompt) {
-        Ok(expected) => expected,
-        Err(failure) => return broken(prompt, projection, failure),
-    };
-    match projection::validate(roots, projection, &expected) {
-        Ok(()) => diagnostic(
+    match validate_projection(roots, prompt, projection) {
+        Ok(_) => diagnostic(
             prompt,
             projection,
             State::Healthy,
@@ -82,6 +67,22 @@ fn diagnose_projection(
         ),
         Err(failure) => broken(prompt, projection, failure),
     }
+}
+
+pub(crate) fn validate_projection(
+    roots: &Roots,
+    prompt: Prompt<'_>,
+    projection: PromptProjection<'_>,
+) -> Result<String, Failure> {
+    if projection.representation == PromptRepresentation::Symlink {
+        return Err(Failure::new(
+            State::Unsupported,
+            "symlink projections have no stable agent contract",
+            "symlink projection unsupported",
+        ));
+    }
+    let expected = source::validate(roots, prompt)?;
+    projection::validate(roots, projection, &expected)
 }
 
 fn unsupported_combination(agent: Option<Agent>, scope: Option<Scope>) -> Diagnostic {
@@ -136,14 +137,18 @@ fn subject(prompt: Prompt<'_>, projection: PromptProjection<'_>) -> String {
     )
 }
 
-struct Failure {
-    state: State,
-    message: String,
-    summary: String,
+pub(crate) struct Failure {
+    pub(crate) state: State,
+    pub(crate) message: String,
+    pub(crate) summary: String,
 }
 
 impl Failure {
-    fn new(state: State, message: impl Into<String>, summary: impl Into<String>) -> Self {
+    pub(crate) fn new(
+        state: State,
+        message: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Self {
         Self {
             state,
             message: message.into(),

--- a/tooling/arnes/src/prompts.rs
+++ b/tooling/arnes/src/prompts.rs
@@ -8,6 +8,8 @@ mod source;
 mod topology;
 mod variables;
 
+pub(crate) use topology::Tracker as ProjectionTracker;
+
 pub fn diagnose(
     roots: &Roots,
     manifest: &Manifest,

--- a/tooling/arnes/src/prompts/projection.rs
+++ b/tooling/arnes/src/prompts/projection.rs
@@ -11,7 +11,7 @@ pub fn validate(
     roots: &Roots,
     projection: PromptProjection<'_>,
     expected: &Expected,
-) -> Result<(), Failure> {
+) -> Result<String, Failure> {
     let destination = destination(roots, projection.scope, projection.destination);
     let boundary = match projection.scope {
         Scope::User => roots.home(),
@@ -24,7 +24,7 @@ pub fn validate(
         PromptRepresentation::Symlink => unreachable!(),
     };
     if actual == *expected {
-        Ok(())
+        Ok(actual)
     } else {
         Err(stale(projection))
     }

--- a/tooling/arnes/src/prompts/topology.rs
+++ b/tooling/arnes/src/prompts/topology.rs
@@ -1,31 +1,54 @@
 use super::Failure;
 use crate::Roots;
 use crate::diagnostic::State;
-use crate::files::paths::{canonical_within, destination, label, planned_within};
+use crate::files::paths::{
+    FileIdentity, canonical_within, destination, file_identity_within, label, planned_within,
+};
 use crate::manifest::{Manifest, Prompt, PromptProjection, PromptRepresentation, Scope};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
 pub struct Tracker {
-    sources: HashMap<PathBuf, String>,
-    destinations: HashMap<PathBuf, DestinationOwner>,
+    sources: HashMap<Identity, String>,
+    destinations: HashMap<Identity, DestinationOwner>,
 }
 
 impl Tracker {
     pub fn new(roots: &Roots, manifest: &Manifest) -> Self {
+        Self::new_for_scopes(roots, manifest, &[Scope::User, Scope::Project])
+    }
+
+    pub fn new_for_scopes(roots: &Roots, manifest: &Manifest, scopes: &[Scope]) -> Self {
         let mut tracker = Self {
             sources: HashMap::new(),
             destinations: HashMap::new(),
         };
-        for (scope, path) in manifest.resource_destinations() {
-            let destination = destination(roots, scope, path);
-            if let Some(identity) = planned_within(&destination, boundary(roots, scope)) {
-                tracker
-                    .destinations
-                    .insert(identity, DestinationOwner::resource(label(scope, path)));
-            }
+        for (scope, path) in manifest
+            .resource_destinations()
+            .filter(|(scope, _)| scopes.contains(scope))
+        {
+            tracker.seed_resource(roots, scope, path);
         }
         tracker
+    }
+
+    pub fn seed_projection_destination(
+        &mut self,
+        roots: &Roots,
+        prompt: Prompt<'_>,
+        projection: PromptProjection<'_>,
+    ) {
+        if projection.representation == PromptRepresentation::Symlink {
+            return;
+        }
+        let destination = destination(roots, projection.scope, projection.destination);
+        let owner =
+            DestinationOwner::prompt(prompt.id(), label(projection.scope, projection.destination));
+        for identity in planned_identities(&destination, boundary(roots, projection.scope)) {
+            self.destinations
+                .entry(identity)
+                .or_insert_with(|| owner.clone());
+        }
     }
 
     pub fn validate(
@@ -37,26 +60,52 @@ impl Tracker {
         if projection.representation == PromptRepresentation::Symlink {
             return Ok(());
         }
+        self.validate_source(roots, prompt)?;
+        self.validate_destination(roots, prompt, projection)
+    }
+
+    fn seed_resource(&mut self, roots: &Roots, scope: Scope, path: &std::path::Path) {
+        let destination = destination(roots, scope, path);
+        let owner = DestinationOwner::resource(label(scope, path));
+        for identity in planned_identities(&destination, boundary(roots, scope)) {
+            self.destinations
+                .entry(identity)
+                .or_insert_with(|| owner.clone());
+        }
+    }
+
+    fn validate_source(&mut self, roots: &Roots, prompt: Prompt<'_>) -> Result<(), Failure> {
         let source = roots.repository().join(prompt.source());
-        if let Some(identity) = canonical_within(&source, roots.repository()) {
-            if let Some(previous) = self.destinations.get(&identity)
+        let identities = canonical_identities(&source, roots.repository());
+        for identity in &identities {
+            if let Some(previous) = self.destinations.get(identity)
                 && previous.prompt.as_deref() != Some(prompt.id())
             {
                 return Err(ambiguous("source", prompt.id(), &previous.label));
             }
-            if let Some(previous) = self.sources.get(&identity) {
-                if previous != prompt.id() {
-                    return Err(ambiguous("source", prompt.id(), previous));
-                }
-            } else {
-                self.sources.insert(identity, prompt.id().to_owned());
+            if let Some(previous) = self.sources.get(identity)
+                && previous != prompt.id()
+            {
+                return Err(ambiguous("source", prompt.id(), previous));
             }
         }
+        for identity in identities {
+            self.sources.insert(identity, prompt.id().to_owned());
+        }
+        Ok(())
+    }
 
+    fn validate_destination(
+        &mut self,
+        roots: &Roots,
+        prompt: Prompt<'_>,
+        projection: PromptProjection<'_>,
+    ) -> Result<(), Failure> {
         let destination = destination(roots, projection.scope, projection.destination);
-        if let Some(identity) = planned_within(&destination, boundary(roots, projection.scope)) {
-            let current = label(projection.scope, projection.destination);
-            if let Some(previous) = self.sources.get(&identity) {
+        let identities = planned_identities(&destination, boundary(roots, projection.scope));
+        let current = label(projection.scope, projection.destination);
+        for identity in &identities {
+            if let Some(previous) = self.sources.get(identity) {
                 let direct = projection.scope == Scope::Project
                     && projection.representation == PromptRepresentation::File
                     && previous == prompt.id();
@@ -64,15 +113,47 @@ impl Tracker {
                     return Err(ambiguous("destination", &current, previous));
                 }
             }
-            let owner = DestinationOwner::prompt(prompt.id(), current.clone());
-            if let Some(previous) = self.destinations.insert(identity, owner) {
+            if let Some(previous) = self.destinations.get(identity) {
                 return Err(ambiguous("destination", &current, &previous.label));
             }
+        }
+        let owner = DestinationOwner::prompt(prompt.id(), current);
+        for identity in identities {
+            self.destinations.insert(identity, owner.clone());
         }
         Ok(())
     }
 }
 
+#[derive(Eq, Hash, PartialEq)]
+enum Identity {
+    Path(PathBuf),
+    File(FileIdentity),
+}
+
+fn canonical_identities(path: &std::path::Path, root: &std::path::Path) -> Vec<Identity> {
+    let Some(canonical) = canonical_within(path, root) else {
+        return Vec::new();
+    };
+    let mut identities = vec![Identity::Path(canonical)];
+    if let Some(identity) = file_identity_within(path, root) {
+        identities.push(Identity::File(identity));
+    }
+    identities
+}
+
+fn planned_identities(path: &std::path::Path, root: &std::path::Path) -> Vec<Identity> {
+    let Some(planned) = planned_within(path, root) else {
+        return Vec::new();
+    };
+    let mut identities = vec![Identity::Path(planned)];
+    if let Some(identity) = file_identity_within(path, root) {
+        identities.push(Identity::File(identity));
+    }
+    identities
+}
+
+#[derive(Clone)]
 struct DestinationOwner {
     prompt: Option<String>,
     label: String,

--- a/tooling/arnes/src/prompts/topology.rs
+++ b/tooling/arnes/src/prompts/topology.rs
@@ -5,7 +5,8 @@ use crate::files::paths::{
     FileIdentity, canonical_within, destination, file_identity_within, label, planned_within,
 };
 use crate::manifest::{Manifest, Prompt, PromptProjection, PromptRepresentation, Scope};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::path::PathBuf;
 
 pub struct Tracker {
@@ -14,10 +15,6 @@ pub struct Tracker {
 }
 
 impl Tracker {
-    pub fn new(roots: &Roots, manifest: &Manifest) -> Self {
-        Self::new_for_scopes(roots, manifest, &[Scope::User, Scope::Project])
-    }
-
     pub fn new_for_scopes(roots: &Roots, manifest: &Manifest, scopes: &[Scope]) -> Self {
         let mut tracker = Self {
             sources: HashMap::new(),
@@ -30,6 +27,21 @@ impl Tracker {
             tracker.seed_resource(roots, scope, path);
         }
         tracker
+    }
+
+    pub fn relevant_scopes(roots: &Roots, selected: &[Scope]) -> Vec<Scope> {
+        let mut scopes = selected.iter().copied().collect::<HashSet<_>>();
+        let shared = matches!(
+            (
+                fs::canonicalize(roots.home()).ok(),
+                fs::canonicalize(roots.repository()).ok()
+            ),
+            (Some(home), Some(repository)) if home == repository
+        );
+        if shared {
+            scopes.extend([Scope::User, Scope::Project]);
+        }
+        scopes.into_iter().collect()
     }
 
     pub fn seed_projection_destination(

--- a/tooling/arnes/tests/command_failures.rs
+++ b/tooling/arnes/tests/command_failures.rs
@@ -1,0 +1,239 @@
+#[path = "support/commands.rs"]
+pub mod command_support;
+#[path = "support/configured_commands.rs"]
+mod configured_command_support;
+pub mod support;
+
+use command_support::{CONTENTS, command, manifest, output_tuple, prompt, run};
+use configured_command_support::configured_fixture;
+use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use support::Fixture;
+
+const CLAUDE_PROJECT: &[&str] = &[
+    "doctor", "commands", "--agent", "claude", "--scope", "project", "--format", "json",
+];
+
+fn assert_state(fixture: &Fixture, code: i32, expected: &str) {
+    let (actual, stdout, stderr) = run(fixture, CLAUDE_PROJECT);
+    assert_eq!(actual, code, "{stdout}");
+    assert!(stdout.contains(expected), "missing {expected}: {stdout}");
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn missing_wrong_type_stale_and_symlink_destinations_are_drift() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.repository().join(".claude/commands/deploy.md")).unwrap();
+    assert_state(&fixture, 1, "is missing");
+
+    let fixture = configured_fixture();
+    let destination = fixture.repository().join(".claude/commands/deploy.md");
+    fs::remove_file(&destination).unwrap();
+    fs::create_dir(&destination).unwrap();
+    assert_state(&fixture, 1, "is not a regular file");
+
+    let fixture = configured_fixture();
+    fixture.write_repository(".claude/commands/deploy.md", "stale\n");
+    assert_state(&fixture, 1, "is stale");
+
+    let fixture = configured_fixture();
+    let destination = fixture.repository().join(".claude/commands/deploy.md");
+    fs::remove_file(&destination).unwrap();
+    symlink("../../harness/prompts/deploy.md", &destination).unwrap();
+    assert_state(&fixture, 1, "is a symlink");
+}
+
+#[test]
+fn unreadable_source_and_destination_are_errors() {
+    for relative in ["harness/prompts/deploy.md", ".claude/commands/deploy.md"] {
+        let fixture = configured_fixture();
+        let before = fixture.snapshot();
+        let path = fixture.repository().join(relative);
+        let permissions = fs::metadata(&path).unwrap().permissions();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        let output = fixture.command(CLAUDE_PROJECT);
+        fs::set_permissions(&path, permissions).unwrap();
+        assert_eq!(fixture.snapshot(), before);
+        let (code, stdout, stderr) = output_tuple(output);
+
+        assert_eq!(code, 2, "{stdout}");
+        assert!(stdout.contains("could not be read"));
+        assert!(stderr.is_empty());
+    }
+}
+
+#[test]
+fn projection_contract_failures_are_explicit() {
+    let fixture = Fixture::new();
+    let no_projection = prompt(
+        "deploy",
+        "cursor",
+        "project",
+        "file",
+        ".cursor/commands/deploy.md",
+    );
+    let commands = command(
+        "deploy",
+        "deploy",
+        "      - { agent: claude, scope: project }\n",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&no_projection, &commands));
+    assert_state(&fixture, 2, "has no projection for this binding");
+
+    let fixture = Fixture::new();
+    let incompatible = prompt(
+        "deploy",
+        "claude",
+        "project",
+        "file",
+        ".claude/commands/not-deploy.md",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&incompatible, &commands));
+    assert_state(&fixture, 2, "does not match .claude/commands/deploy.md");
+
+    let fixture = Fixture::new();
+    let symlinked = prompt(
+        "deploy",
+        "claude",
+        "project",
+        "symlink",
+        ".claude/commands/deploy.md",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&symlinked, &commands));
+    assert_state(
+        &fixture,
+        0,
+        "symlink projections have no stable agent contract",
+    );
+}
+
+#[test]
+fn source_include_and_variable_failures_are_transposed() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.repository().join("harness/prompts/deploy.md")).unwrap();
+    assert_state(&fixture, 2, "source harness/prompts/deploy.md is missing");
+
+    let fixture = Fixture::new();
+    let prompts = "  - id: deploy
+    source: { root: repository, path: harness/prompts/deploy.md }
+    includes: [missing.md]
+    variables: []
+    projections:
+      - agent: claude
+        scope: project
+        representation: file
+        destination: { root: repository, path: .claude/commands/deploy.md }
+";
+    let commands = command(
+        "deploy",
+        "deploy",
+        "      - { agent: claude, scope: project }\n",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(prompts, &commands));
+    fixture.write_repository("harness/prompts/deploy.md", "@missing.md\nDeploy\n");
+    fixture.write_repository(".claude/commands/deploy.md", "@missing.md\nDeploy\n");
+    assert_state(&fixture, 2, "include harness/prompts/missing.md is missing");
+
+    let fixture = configured_fixture();
+    let contents = format!("{CONTENTS}Deploy $undeclared\n");
+    fixture.write_repository("harness/prompts/deploy.md", &contents);
+    fixture.write_repository(".claude/commands/deploy.md", &contents);
+    assert_state(
+        &fixture,
+        2,
+        "variables undeclared are referenced but not declared",
+    );
+}
+
+#[test]
+fn frontmatter_and_description_mismatches_are_drift() {
+    for (contents, expected) in [
+        ("Deploy now\n", "frontmatter missing or malformed"),
+        (
+            "---\ndescription: Deploy safely\nDeploy now\n",
+            "frontmatter missing or malformed",
+        ),
+        (
+            "---\ndescription: [\n---\nDeploy now\n",
+            "frontmatter missing or malformed",
+        ),
+        (
+            "---\nother: value\n---\nDeploy now\n",
+            "description is missing",
+        ),
+        (
+            "---\ndescription: 42\n---\nDeploy now\n",
+            "description must be a string",
+        ),
+        (
+            "---\ndescription: Deploy unsafely\n---\nDeploy now\n",
+            "description differs from manifest",
+        ),
+    ] {
+        let fixture = configured_fixture();
+        fixture.write_repository("harness/prompts/deploy.md", contents);
+        fixture.write_repository(".claude/commands/deploy.md", contents);
+        assert_state(&fixture, 1, expected);
+    }
+}
+
+#[test]
+fn unrelated_frontmatter_keys_are_ignored() {
+    let fixture = configured_fixture();
+    let contents = "---\ndescription: Deploy safely\nallowed-tools: Bash\n---\nDeploy now\n";
+    fixture.write_repository("harness/prompts/deploy.md", contents);
+    fixture.write_repository(".claude/commands/deploy.md", contents);
+    assert_state(&fixture, 0, "binding is current");
+}
+
+#[test]
+fn the_highest_state_controls_the_exit_code() {
+    let fixture = Fixture::new();
+    let prompts = "  - id: cursor-command
+    source: { root: repository, path: harness/prompts/cursor-command.md }
+    includes: []
+    variables: []
+    projections: []
+  - id: drifting
+    source: { root: repository, path: harness/prompts/drifting.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: file
+        destination: { root: home, path: .claude/commands/drifting.md }
+  - id: broken
+    source: { root: repository, path: harness/prompts/broken.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: file
+        destination: { root: home, path: .claude/commands/broken.md }
+";
+    let commands = "  - name: cursor-command
+    description: Deploy safely
+    prompt: cursor-command
+    bindings: [{ agent: cursor, scope: user }]
+  - name: drifting
+    description: Deploy safely
+    prompt: drifting
+    bindings: [{ agent: claude, scope: user }]
+  - name: broken
+    description: Deploy safely
+    prompt: broken
+    bindings: [{ agent: claude, scope: user }]
+";
+    fixture.write_home(".arnes.yaml", &manifest(prompts, commands));
+    fixture.write_repository("harness/prompts/drifting.md", CONTENTS);
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "commands"]);
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("unsupported"));
+    assert!(stdout.contains("drift"));
+    assert!(stdout.contains("error"));
+    assert!(stderr.is_empty());
+}

--- a/tooling/arnes/tests/command_failures.rs
+++ b/tooling/arnes/tests/command_failures.rs
@@ -167,6 +167,10 @@ fn frontmatter_and_description_mismatches_are_drift() {
             "description must be a string",
         ),
         (
+            "---\ndescription: null\n---\nDeploy now\n",
+            "description must be a string",
+        ),
+        (
             "---\ndescription: Deploy unsafely\n---\nDeploy now\n",
             "description differs from manifest",
         ),

--- a/tooling/arnes/tests/command_topology.rs
+++ b/tooling/arnes/tests/command_topology.rs
@@ -75,6 +75,66 @@ fn command_destinations_cannot_alias_managed_resources() {
     assert_collision(&fixture, "aliases managed destination resource");
 }
 
+#[test]
+fn command_destinations_cannot_alias_unreferenced_prompt_projections() {
+    let fixture = Fixture::new();
+    let prompts = format!(
+        "{}{}",
+        prompt(
+            "deploy",
+            "claude",
+            "user",
+            "file",
+            ".claude/commands/deploy.md"
+        ),
+        prompt(
+            "other",
+            "claude",
+            "user",
+            "file",
+            ".claude/commands/alias/deploy.md"
+        )
+    );
+    let commands = command(
+        "deploy",
+        "deploy",
+        "      - { agent: claude, scope: user }\n",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+    fixture.write_repository("harness/prompts/deploy.md", CONTENTS);
+    fixture.write_repository("harness/prompts/other.md", CONTENTS);
+    fixture.write_home(".claude/commands/deploy.md", CONTENTS);
+    symlink(".", fixture.home().join(".claude/commands/alias")).unwrap();
+
+    assert_collision(&fixture, "aliases managed destination");
+}
+
+#[test]
+fn hardlinked_command_destinations_cannot_alias_each_other() {
+    let fixture = Fixture::new();
+    let prompts = format!(
+        "{}{}",
+        prompt("one", "claude", "user", "file", ".claude/commands/one.md"),
+        prompt("two", "claude", "user", "file", ".claude/commands/two.md")
+    );
+    let commands = format!(
+        "{}{}",
+        command("one", "one", "      - { agent: claude, scope: user }\n"),
+        command("two", "two", "      - { agent: claude, scope: user }\n")
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+    fixture.write_repository("harness/prompts/one.md", CONTENTS);
+    fixture.write_repository("harness/prompts/two.md", CONTENTS);
+    fixture.write_home(".claude/commands/one.md", CONTENTS);
+    fs::hard_link(
+        fixture.home().join(".claude/commands/one.md"),
+        fixture.home().join(".claude/commands/two.md"),
+    )
+    .unwrap();
+
+    assert_collision(&fixture, "aliases managed destination");
+}
+
 fn assert_collision(fixture: &Fixture, expected: &str) {
     let (code, stdout, stderr) = run(fixture, CLAUDE_USER);
     assert_eq!(code, 2, "{stdout}");

--- a/tooling/arnes/tests/command_topology.rs
+++ b/tooling/arnes/tests/command_topology.rs
@@ -1,0 +1,83 @@
+#[path = "support/commands.rs"]
+mod command_support;
+mod support;
+
+use command_support::{CONTENTS, command, manifest, prompt, run};
+use std::fs;
+use std::os::unix::fs::symlink;
+use support::Fixture;
+
+const CLAUDE_USER: &[&str] = &[
+    "doctor", "commands", "--agent", "claude", "--scope", "user", "--format", "json",
+];
+
+#[test]
+fn selected_command_destinations_cannot_alias_each_other() {
+    let fixture = Fixture::new();
+    let prompts = format!(
+        "{}{}",
+        prompt("one", "claude", "user", "file", ".claude/commands/one.md"),
+        prompt("two", "claude", "user", "file", ".claude/commands/two.md")
+    );
+    let commands = format!(
+        "{}{}",
+        command("one", "one", "      - { agent: claude, scope: user }\n"),
+        command("two", "two", "      - { agent: claude, scope: user }\n")
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+    for id in ["one", "two"] {
+        let source = fixture
+            .repository()
+            .join(format!("harness/prompts/{id}.md"));
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(source, CONTENTS).unwrap();
+    }
+    fixture.write_home(".claude/commands/shared.md", CONTENTS);
+    symlink("shared.md", fixture.home().join(".claude/commands/one.md")).unwrap();
+    symlink("shared.md", fixture.home().join(".claude/commands/two.md")).unwrap();
+
+    assert_collision(&fixture, "aliases managed destination");
+}
+
+#[test]
+fn command_destinations_cannot_alias_managed_resources() {
+    let fixture = Fixture::new();
+    let prompts = prompt(
+        "deploy",
+        "claude",
+        "user",
+        "file",
+        ".claude/commands/deploy.md",
+    );
+    let commands = command(
+        "deploy",
+        "deploy",
+        "      - { agent: claude, scope: user }\n",
+    );
+    let configured = manifest(&prompts, &commands).replace(
+        "resources: []",
+        "resources:\n  - id: managed-resource\n    kind: instructions\n    agent: claude\n    scope: user\n    source: { root: repository, path: harness/AGENTS.md }\n    destination: { root: home, path: .claude/commands/resource.md }",
+    );
+    fixture.write_home(".arnes.yaml", &configured);
+    fixture.write_repository("harness/prompts/deploy.md", CONTENTS);
+    fixture.write_home(".claude/commands/shared.md", CONTENTS);
+    symlink(
+        "shared.md",
+        fixture.home().join(".claude/commands/deploy.md"),
+    )
+    .unwrap();
+    symlink(
+        "shared.md",
+        fixture.home().join(".claude/commands/resource.md"),
+    )
+    .unwrap();
+
+    assert_collision(&fixture, "aliases managed destination resource");
+}
+
+fn assert_collision(fixture: &Fixture, expected: &str) {
+    let (code, stdout, stderr) = run(fixture, CLAUDE_USER);
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains(expected), "missing {expected}: {stdout}");
+    assert!(stderr.is_empty());
+}

--- a/tooling/arnes/tests/command_topology.rs
+++ b/tooling/arnes/tests/command_topology.rs
@@ -2,9 +2,10 @@
 mod command_support;
 mod support;
 
-use command_support::{CONTENTS, command, manifest, prompt, run};
+use command_support::{CONTENTS, command, manifest, output_tuple, prompt, run};
 use std::fs;
 use std::os::unix::fs::symlink;
+use std::process::Command;
 use support::Fixture;
 
 const CLAUDE_USER: &[&str] = &[
@@ -135,8 +136,83 @@ fn hardlinked_command_destinations_cannot_alias_each_other() {
     assert_collision(&fixture, "aliases managed destination");
 }
 
+#[test]
+fn shared_roots_cannot_hide_cross_scope_resource_collisions() {
+    let fixture = Fixture::new();
+    let prompts = prompt(
+        "deploy",
+        "claude",
+        "user",
+        "file",
+        ".claude/commands/deploy.md",
+    );
+    let commands = command(
+        "deploy",
+        "deploy",
+        "      - { agent: claude, scope: user }\n",
+    );
+    let configured = manifest(&prompts, &commands).replace(
+        "resources: []",
+        "resources:\n  - id: managed-resource\n    kind: instructions\n    agent: claude\n    scope: project\n    source: { root: repository, path: harness/AGENTS.md }\n    destination: { root: repository, path: .claude/commands/deploy.md }",
+    );
+    fixture.write_repository(".arnes.yaml", &configured);
+    fixture.write_repository("harness/prompts/deploy.md", CONTENTS);
+    fixture.write_repository(".claude/commands/deploy.md", CONTENTS);
+
+    assert_shared_root_collision(&fixture, "aliases managed destination resource");
+}
+
+#[test]
+fn shared_roots_cannot_hide_cross_scope_prompt_collisions() {
+    let fixture = Fixture::new();
+    let prompts = format!(
+        "{}{}",
+        prompt(
+            "deploy",
+            "claude",
+            "user",
+            "file",
+            ".claude/commands/deploy.md"
+        ),
+        prompt(
+            "other",
+            "claude",
+            "project",
+            "file",
+            ".claude/commands/deploy.md"
+        )
+    );
+    let commands = command(
+        "deploy",
+        "deploy",
+        "      - { agent: claude, scope: user }\n",
+    );
+    fixture.write_repository(".arnes.yaml", &manifest(&prompts, &commands));
+    fixture.write_repository("harness/prompts/deploy.md", CONTENTS);
+    fixture.write_repository("harness/prompts/other.md", CONTENTS);
+    fixture.write_repository(".claude/commands/deploy.md", CONTENTS);
+
+    assert_shared_root_collision(&fixture, "aliases managed destination");
+}
+
 fn assert_collision(fixture: &Fixture, expected: &str) {
     let (code, stdout, stderr) = run(fixture, CLAUDE_USER);
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains(expected), "missing {expected}: {stdout}");
+    assert!(stderr.is_empty());
+}
+
+fn assert_shared_root_collision(fixture: &Fixture, expected: &str) {
+    let before = fixture.snapshot();
+    let output = Command::new(env!("CARGO_BIN_EXE_arnes"))
+        .args(CLAUDE_USER)
+        .current_dir(fixture.repository())
+        .env_clear()
+        .env("HOME", fixture.repository())
+        .output()
+        .unwrap();
+    assert_eq!(fixture.snapshot(), before);
+    let (code, stdout, stderr) = output_tuple(output);
     assert_eq!(code, 2, "{stdout}");
     assert!(stdout.contains(expected), "missing {expected}: {stdout}");
     assert!(stderr.is_empty());

--- a/tooling/arnes/tests/commands.rs
+++ b/tooling/arnes/tests/commands.rs
@@ -1,0 +1,55 @@
+#[path = "support/commands.rs"]
+pub mod command_support;
+pub mod support;
+
+use command_support::{configured_fixture, output_tuple, run};
+use std::process::Command;
+
+#[test]
+fn claude_user_and_project_bindings_are_healthy() {
+    for scope in ["user", "project"] {
+        let fixture = configured_fixture();
+        let (code, stdout, stderr) = run(
+            &fixture,
+            &["doctor", "commands", "--agent", "claude", "--scope", scope],
+        );
+
+        assert_eq!(code, 0, "{stdout}");
+        assert!(stdout.contains(&format!("claude {scope} commands")));
+        assert!(stdout.contains("healthy     deploy · current"));
+        assert!(stderr.is_empty());
+    }
+}
+
+#[test]
+fn command_diagnostics_are_json_and_read_only() {
+    let fixture = configured_fixture();
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &[
+            "doctor", "commands", "--agent", "claude", "--scope", "project", "--format", "json",
+        ],
+    );
+    let diagnostics: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+
+    assert_eq!(code, 0);
+    assert_eq!(diagnostics[0]["resource"], "commands");
+    assert_eq!(diagnostics[0]["state"], "healthy");
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn doctor_commands_routes_root_errors_to_commands() {
+    let fixture = configured_fixture();
+    let output = Command::new(env!("CARGO_BIN_EXE_arnes"))
+        .args(["doctor", "commands"])
+        .current_dir(fixture.repository())
+        .env_clear()
+        .output()
+        .unwrap();
+    let (code, stdout, stderr) = output_tuple(output);
+
+    assert_eq!(code, 2);
+    assert!(stdout.starts_with("error commands:"));
+    assert!(stderr.is_empty());
+}

--- a/tooling/arnes/tests/commands.rs
+++ b/tooling/arnes/tests/commands.rs
@@ -219,3 +219,21 @@ fn unmanaged_and_plugin_neighbors_are_ignored() {
     assert!(!stdout.contains("opsx"));
     assert!(stderr.is_empty());
 }
+
+#[test]
+fn crlf_frontmatter_is_supported() {
+    let fixture = configured_fixture();
+    let contents = CONTENTS.replace('\n', "\r\n");
+    fixture.write_repository("harness/prompts/deploy.md", &contents);
+    fixture.write_repository(".claude/commands/deploy.md", &contents);
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &[
+            "doctor", "commands", "--agent", "claude", "--scope", "project",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("healthy     deploy · current"));
+    assert!(stderr.is_empty());
+}

--- a/tooling/arnes/tests/commands.rs
+++ b/tooling/arnes/tests/commands.rs
@@ -1,9 +1,13 @@
 #[path = "support/commands.rs"]
 pub mod command_support;
+#[path = "support/configured_commands.rs"]
+mod configured_command_support;
 pub mod support;
 
-use command_support::{configured_fixture, output_tuple, run};
+use command_support::{CONTENTS, command, manifest, output_tuple, prompt, run};
+use configured_command_support::configured_fixture;
 use std::process::Command;
+use support::Fixture;
 
 #[test]
 fn claude_user_and_project_bindings_are_healthy() {
@@ -51,5 +55,167 @@ fn doctor_commands_routes_root_errors_to_commands() {
 
     assert_eq!(code, 2);
     assert!(stdout.starts_with("error commands:"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn cursor_and_codex_are_unsupported_without_prompt_io() {
+    for (agent, scope) in [
+        ("cursor", "user"),
+        ("cursor", "project"),
+        ("codex", "user"),
+        ("codex", "project"),
+    ] {
+        let fixture = Fixture::new();
+        let prompts = prompt(
+            "deploy",
+            "claude",
+            "project",
+            "file",
+            ".claude/commands/deploy.md",
+        );
+        let bindings = format!("      - {{ agent: {agent}, scope: {scope} }}\n");
+        let commands = command("deploy", "deploy", &bindings);
+        fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+        let (code, stdout, stderr) = run(
+            &fixture,
+            &["doctor", "commands", "--agent", agent, "--scope", scope],
+        );
+
+        assert_eq!(code, 0, "{stdout}");
+        assert!(stdout.contains("capability · unsupported"));
+        assert!(!stdout.contains("source"));
+        assert!(stderr.is_empty());
+    }
+}
+
+#[test]
+fn filters_exclude_bindings_before_io() {
+    let fixture = Fixture::new();
+    let prompts = format!(
+        "{}{}",
+        prompt(
+            "missing",
+            "claude",
+            "user",
+            "file",
+            ".claude/commands/missing.md"
+        ),
+        prompt(
+            "selected",
+            "claude",
+            "project",
+            "file",
+            ".claude/commands/selected.md"
+        ),
+    );
+    let commands = format!(
+        "{}{}",
+        command(
+            "missing",
+            "missing",
+            "      - { agent: claude, scope: user }\n"
+        ),
+        command(
+            "selected",
+            "selected",
+            "      - { agent: claude, scope: project }\n"
+        ),
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+    fixture.write_repository("harness/prompts/selected.md", CONTENTS);
+    fixture.write_repository(".claude/commands/selected.md", CONTENTS);
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &[
+            "doctor", "commands", "--agent", "claude", "--scope", "project",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("selected · current"));
+    assert!(!stdout.contains("missing"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn an_empty_filtered_selection_is_unsupported() {
+    let fixture = configured_fixture();
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &[
+            "doctor", "commands", "--agent", "cursor", "--scope", "project",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("capability · unsupported"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn diagnostics_preserve_command_then_binding_order() {
+    let fixture = Fixture::new();
+    let prompts = format!(
+        "{}{}",
+        prompt("zeta", "claude", "user", "file", ".claude/commands/zeta.md"),
+        prompt(
+            "alpha",
+            "claude",
+            "user",
+            "file",
+            ".claude/commands/alpha.md"
+        ),
+    );
+    let bindings =
+        "      - { agent: claude, scope: user }\n      - { agent: cursor, scope: user }\n";
+    let commands = format!(
+        "{}{}",
+        command("zeta", "zeta", bindings),
+        command("alpha", "alpha", bindings),
+    );
+    fixture.write_home(".arnes.yaml", &manifest(&prompts, &commands));
+    for name in ["zeta", "alpha"] {
+        fixture.write_repository(format!("harness/prompts/{name}.md"), CONTENTS);
+        fixture.write_home(format!(".claude/commands/{name}.md"), CONTENTS);
+    }
+    let (_, human, _) = run(&fixture, &["doctor", "commands", "--scope", "user"]);
+    let positions = [
+        "zeta · current",
+        "capability · unsupported",
+        "alpha · current",
+    ]
+    .map(|needle| human.find(needle).unwrap());
+    assert!(positions[0] < positions[1] && positions[1] < positions[2]);
+    let (_, json, _) = run(
+        &fixture,
+        &["doctor", "commands", "--scope", "user", "--format", "json"],
+    );
+    let diagnostics: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+
+    assert!(diagnostics[0]["message"].as_str().unwrap().contains("zeta"));
+    assert_eq!(diagnostics[1]["state"], "unsupported");
+    assert!(
+        diagnostics[2]["message"]
+            .as_str()
+            .unwrap()
+            .contains("alpha")
+    );
+    assert_eq!(diagnostics[3]["state"], "unsupported");
+}
+
+#[test]
+fn unmanaged_and_plugin_neighbors_are_ignored() {
+    let fixture = configured_fixture();
+    fixture.write_home(".claude/commands/unmanaged.md", "ignored\n");
+    fixture.write_home(".claude/commands/opsx/plugin.md", "ignored\n");
+    let (code, stdout, stderr) = run(
+        &fixture,
+        &["doctor", "commands", "--agent", "claude", "--scope", "user"],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(!stdout.contains("unmanaged"));
+    assert!(!stdout.contains("opsx"));
     assert!(stderr.is_empty());
 }

--- a/tooling/arnes/tests/manifest_commands.rs
+++ b/tooling/arnes/tests/manifest_commands.rs
@@ -1,0 +1,230 @@
+use arnes::manifest::{self, Agent, Scope};
+
+fn input(commands: &str) -> String {
+    format!(
+        "version: 1
+agents:
+  - id: claude
+    scopes: [user, project]
+  - id: cursor
+    scopes: [project]
+  - id: codex
+    scopes: [user, project]
+prompts:
+  - id: deploy
+    source: {{ root: repository, path: harness/prompts/deploy.md }}
+    includes: []
+    variables: []
+    projections: []
+commands:{commands}
+resources: []
+"
+    )
+}
+
+fn error(commands: &str) -> String {
+    manifest::parse(&input(commands)).err().unwrap().to_string()
+}
+
+#[test]
+fn command_getters_preserve_command_and_binding_order() {
+    let manifest = manifest::parse(&input(
+        "
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings:
+      - { agent: claude, scope: user }
+      - { agent: cursor, scope: project }",
+    ))
+    .unwrap();
+    let commands = manifest.commands().collect::<Vec<_>>();
+
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].name(), "deploy");
+    assert_eq!(commands[0].description(), "Deploy safely");
+    assert_eq!(commands[0].prompt(), "deploy");
+    let bindings = commands[0].bindings().collect::<Vec<_>>();
+    assert_eq!(
+        (bindings[0].agent, bindings[0].scope),
+        (Agent::Claude, Scope::User)
+    );
+    assert_eq!(
+        (bindings[1].agent, bindings[1].scope),
+        (Agent::Cursor, Scope::Project)
+    );
+    assert_eq!(bindings[1].name(), "deploy");
+    assert_eq!(bindings[1].description(), "Deploy safely");
+    assert_eq!(bindings[1].prompt(), "deploy");
+}
+
+#[test]
+fn absent_commands_remain_compatible_with_manifest_v1() {
+    let manifest = manifest::parse(&input(" []")).unwrap();
+
+    assert_eq!(manifest.commands().count(), 0);
+}
+
+#[test]
+fn command_fields_are_normalized() {
+    for (commands, expected) in [
+        (
+            "
+  - name: ''
+    description: Deploy safely
+    prompt: deploy
+    bindings: [{ agent: claude, scope: user }]",
+            "commands[0].name: must be lowercase ASCII kebab-case",
+        ),
+        (
+            "
+  - name: Deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings: [{ agent: claude, scope: user }]",
+            "commands[0].name: must be lowercase ASCII kebab-case",
+        ),
+        (
+            "
+  - name: deploy_now
+    description: Deploy safely
+    prompt: deploy
+    bindings: [{ agent: claude, scope: user }]",
+            "commands[0].name: must be lowercase ASCII kebab-case",
+        ),
+        (
+            "
+  - name: deploy--now
+    description: Deploy safely
+    prompt: deploy
+    bindings: [{ agent: claude, scope: user }]",
+            "commands[0].name: must be lowercase ASCII kebab-case",
+        ),
+        (
+            "
+  - name: deploy
+    description: '  '
+    prompt: deploy
+    bindings: [{ agent: claude, scope: user }]",
+            "commands[0].description: description cannot be blank",
+        ),
+        (
+            "
+  - name: deploy
+    description: Deploy safely
+    prompt: missing
+    bindings: [{ agent: claude, scope: user }]",
+            "commands[0].prompt: referenced prompt is not declared",
+        ),
+        (
+            "
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings: []",
+            "commands[0].bindings: at least one binding is required",
+        ),
+        (
+            "
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings:
+      - { agent: claude, scope: user }
+      - { agent: claude, scope: user }",
+            "commands[0].bindings[1].agent: duplicates commands[0].bindings[0]",
+        ),
+        (
+            "
+  - name: deploy
+    description: One
+    prompt: deploy
+    bindings: [{ agent: claude, scope: user }]
+  - name: deploy
+    description: Two
+    prompt: deploy
+    bindings: [{ agent: claude, scope: user }]",
+            "commands[1].bindings[0].agent: duplicates commands[0].bindings[0]",
+        ),
+    ] {
+        assert_eq!(error(commands), expected);
+    }
+}
+
+#[test]
+fn command_targets_must_be_declared() {
+    let command = "
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings: [{ agent: cursor, scope: project }]";
+    let without_cursor = input(command).replace(
+        "  - id: cursor
+    scopes: [project]
+",
+        "",
+    );
+
+    assert_eq!(
+        manifest::parse(&without_cursor).err().unwrap().to_string(),
+        "commands[0].bindings[0].agent: agent is not declared"
+    );
+    let wrong_scope = command.replace("scope: project", "scope: user");
+    assert_eq!(
+        error(&wrong_scope),
+        "commands[0].bindings[0].scope: scope is not declared for this agent"
+    );
+}
+
+#[test]
+fn the_same_name_is_allowed_across_agents_and_scopes() {
+    manifest::parse(&input(
+        "
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings:
+      - { agent: claude, scope: user }
+      - { agent: claude, scope: project }
+      - { agent: cursor, scope: project }",
+    ))
+    .unwrap();
+}
+
+#[test]
+fn legacy_command_resources_are_rejected() {
+    let error = manifest::parse(&input(" []").replace(
+        "resources: []",
+        "resources:
+  - id: deploy
+    kind: commands
+    agent: claude
+    scope: project
+    source: { root: repository, path: prompt.md }
+    destination: { root: repository, path: .claude/commands/deploy.md }",
+    ))
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        error.to_string(),
+        "resources[0].kind: commands must use normalized top-level declarations"
+    );
+}
+
+#[test]
+fn unknown_command_and_binding_fields_are_rejected() {
+    let command = "
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    extra: value
+    bindings: [{ agent: claude, scope: user }]";
+    assert!(error(command).contains("unknown field `extra`"));
+    let binding = "
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings: [{ agent: claude, scope: user, extra: value }]";
+    assert!(error(binding).contains("unknown field `extra`"));
+}

--- a/tooling/arnes/tests/prompt_topology.rs
+++ b/tooling/arnes/tests/prompt_topology.rs
@@ -11,6 +11,10 @@ const CLAUDE_PROJECT: &[&str] = &[
     "doctor", "prompts", "--agent", "claude", "--scope", "project", "--format", "json",
 ];
 
+const CLAUDE_USER: &[&str] = &[
+    "doctor", "prompts", "--agent", "claude", "--scope", "user", "--format", "json",
+];
+
 #[test]
 fn prompt_destinations_cannot_alias_other_managed_resources() {
     let fixture = Fixture::new();
@@ -83,6 +87,39 @@ fn resolved_source_destination_aliases_only_allow_direct_project_files() {
         }
         assert!(stderr.is_empty());
     }
+}
+
+#[test]
+fn filtered_scopes_ignore_hardlinked_resources_in_distinct_roots() {
+    let fixture = Fixture::new();
+    let prompt = "  - id: deploy
+    source: { root: repository, path: harness/prompts/deploy.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: rendered
+        destination: { root: home, path: .claude/commands/deploy.md }
+";
+    let configured = manifest(prompt).replace(
+        "resources: []",
+        "resources:\n  - id: managed-resource\n    kind: instructions\n    agent: claude\n    scope: project\n    source: { root: repository, path: harness/AGENTS.md }\n    destination: { root: repository, path: .claude/resource.md }",
+    );
+    fixture.write_home(".arnes.yaml", &configured);
+    fixture.write_repository("harness/prompts/deploy.md", "same\n");
+    fixture.write_repository(".claude/resource.md", "same\n");
+    fs::create_dir_all(fixture.home().join(".claude/commands")).unwrap();
+    fs::hard_link(
+        fixture.repository().join(".claude/resource.md"),
+        fixture.home().join(".claude/commands/deploy.md"),
+    )
+    .unwrap();
+
+    let (code, stdout, stderr) = run(&fixture, CLAUDE_USER);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("\"state\": \"healthy\""));
+    assert!(stderr.is_empty());
 }
 
 fn assert_collision(fixture: &Fixture, expected: &str) {

--- a/tooling/arnes/tests/support/commands.rs
+++ b/tooling/arnes/tests/support/commands.rs
@@ -1,0 +1,88 @@
+use crate::support::Fixture;
+use std::process::Output;
+
+pub const DESCRIPTION: &str = "Deploy safely";
+pub const CONTENTS: &str = "---\ndescription: Deploy safely\n---\nDeploy now\n";
+
+pub fn manifest(prompts: &str, commands: &str) -> String {
+    format!(
+        "version: 1
+agents:
+  - id: claude
+    scopes: [user, project]
+  - id: cursor
+    scopes: [user, project]
+  - id: codex
+    scopes: [user, project]
+prompts:
+{prompts}commands:
+{commands}resources: []
+"
+    )
+}
+
+pub fn prompt(
+    id: &str,
+    agent: &str,
+    scope: &str,
+    representation: &str,
+    destination: &str,
+) -> String {
+    let root = if scope == "user" {
+        "home"
+    } else {
+        "repository"
+    };
+    format!(
+        "  - id: {id}\n    source: {{ root: repository, path: harness/prompts/{id}.md }}\n    includes: []\n    variables: []\n    projections:\n      - agent: {agent}\n        scope: {scope}\n        representation: {representation}\n        destination: {{ root: {root}, path: {destination} }}\n"
+    )
+}
+
+pub fn command(name: &str, prompt: &str, bindings: &str) -> String {
+    format!(
+        "  - name: {name}\n    description: {DESCRIPTION}\n    prompt: {prompt}\n    bindings:\n{bindings}"
+    )
+}
+
+pub fn configured_fixture() -> Fixture {
+    let fixture = Fixture::new();
+    let prompts = "  - id: deploy
+    source: { root: repository, path: harness/prompts/deploy.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: rendered
+        destination: { root: home, path: .claude/commands/deploy.md }
+      - agent: claude
+        scope: project
+        representation: file
+        destination: { root: repository, path: .claude/commands/deploy.md }
+";
+    let commands = command(
+        "deploy",
+        "deploy",
+        "      - { agent: claude, scope: user }\n      - { agent: claude, scope: project }\n",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(prompts, &commands));
+    fixture.write_repository("harness/prompts/deploy.md", CONTENTS);
+    fixture.write_home(".claude/commands/deploy.md", CONTENTS);
+    fixture.write_repository(".claude/commands/deploy.md", CONTENTS);
+    fixture
+}
+
+pub fn run(fixture: &Fixture, args: &[&str]) -> (i32, String, String) {
+    let before = fixture.snapshot();
+    let output = fixture.command(args);
+    assert_eq!(fixture.snapshot(), before);
+    output_tuple(output)
+}
+
+pub fn output_tuple(output: Output) -> (i32, String, String) {
+    (
+        output.status.code().unwrap(),
+        String::from_utf8(output.stdout).unwrap(),
+        String::from_utf8(output.stderr).unwrap(),
+    )
+}

--- a/tooling/arnes/tests/support/commands.rs
+++ b/tooling/arnes/tests/support/commands.rs
@@ -44,34 +44,6 @@ pub fn command(name: &str, prompt: &str, bindings: &str) -> String {
     )
 }
 
-pub fn configured_fixture() -> Fixture {
-    let fixture = Fixture::new();
-    let prompts = "  - id: deploy
-    source: { root: repository, path: harness/prompts/deploy.md }
-    includes: []
-    variables: []
-    projections:
-      - agent: claude
-        scope: user
-        representation: rendered
-        destination: { root: home, path: .claude/commands/deploy.md }
-      - agent: claude
-        scope: project
-        representation: file
-        destination: { root: repository, path: .claude/commands/deploy.md }
-";
-    let commands = command(
-        "deploy",
-        "deploy",
-        "      - { agent: claude, scope: user }\n      - { agent: claude, scope: project }\n",
-    );
-    fixture.write_home(".arnes.yaml", &manifest(prompts, &commands));
-    fixture.write_repository("harness/prompts/deploy.md", CONTENTS);
-    fixture.write_home(".claude/commands/deploy.md", CONTENTS);
-    fixture.write_repository(".claude/commands/deploy.md", CONTENTS);
-    fixture
-}
-
 pub fn run(fixture: &Fixture, args: &[&str]) -> (i32, String, String) {
     let before = fixture.snapshot();
     let output = fixture.command(args);

--- a/tooling/arnes/tests/support/configured_commands.rs
+++ b/tooling/arnes/tests/support/configured_commands.rs
@@ -1,0 +1,30 @@
+use crate::command_support::{CONTENTS, command, manifest};
+use crate::support::Fixture;
+
+pub fn configured_fixture() -> Fixture {
+    let fixture = Fixture::new();
+    let prompts = "  - id: deploy
+    source: { root: repository, path: harness/prompts/deploy.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: rendered
+        destination: { root: home, path: .claude/commands/deploy.md }
+      - agent: claude
+        scope: project
+        representation: file
+        destination: { root: repository, path: .claude/commands/deploy.md }
+";
+    let commands = command(
+        "deploy",
+        "deploy",
+        "      - { agent: claude, scope: user }\n      - { agent: claude, scope: project }\n",
+    );
+    fixture.write_home(".arnes.yaml", &manifest(prompts, &commands));
+    fixture.write_repository("harness/prompts/deploy.md", CONTENTS);
+    fixture.write_home(".claude/commands/deploy.md", CONTENTS);
+    fixture.write_repository(".claude/commands/deploy.md", CONTENTS);
+    fixture
+}


### PR DESCRIPTION
## Summary

- add normalized logical `commands[]` declarations with shared metadata and multi-agent bindings
- implement read-only `arnes doctor commands` validation for Claude user/project bindings while reporting Cursor and Codex as unsupported
- reuse prompt projection validation and harden topology checks for symlinks, hardlinks, resources, unreferenced projections, and shared roots

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 253 tests on macOS Darwin arm64
- [ ] Ubuntu workflow (hosted CI)

Closes #110