### PR TITLE
feat(arnes): make doctor diagnostics human-readable

### DIFF
--- a/docs/arnes-capacites-externes.md
+++ b/docs/arnes-capacites-externes.md
@@ -19,8 +19,11 @@ Une autorisation permet une capacité, elle ne la rend pas obligatoire. Son abse
 aucun drift. La propriété reste `external`, même pour une capacité autorisée. Les diagnostics
 conservent le schéma partagé `resource/state/message` et exposent dans le message l'origine, le
 conteneur, la version, l'exposition, la topologie, la politique et la limite d'observation runtime.
-La sortie humaine regroupe et abrège ces dimensions ; `--format json` conserve le diagnostic
-exhaustif, notamment les chemins sains omis de la vue humaine.
+La sortie humaine affiche le nombre de diagnostics `healthy`, masque leur détail et inventorie les
+problèmes ainsi que les limites `unsupported`. Pour les skills, elle regroupe cet inventaire par
+agent et place les agents en défaut en premier. `-v` ou `--verbose` rétablit le détail des
+diagnostics `healthy` pour tous les doctors. `--format json` reste exhaustif et conserve l'ordre
+canonique ; il ne se combine pas avec `--verbose`.
 
 ## Codex
 

--- a/docs/superpowers/plans/2026-08-18-arnes-human-diagnostics.md
+++ b/docs/superpowers/plans/2026-08-18-arnes-human-diagnostics.md
@@ -1,0 +1,1452 @@
+# Arnes Human Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendre toutes les sorties humaines de `arnes doctor` concises par défaut, exhaustives avec `-v`, et regrouper `doctor skills` par agent sans modifier les diagnostics canoniques.
+
+**Architecture:** La collecte continue de produire un `Report` ordonné servant au JSON et aux exit codes. Un renderer humain séparé reçoit un contexte et une verbosité, travaille sur des références aux diagnostics, puis utilise des métadonnées humaines structurées pour les sections et détails skills sans parser `message`.
+
+**Tech Stack:** Rust 2024, Clap 4.5, Serde, tests d’intégration Cargo, fixtures texte.
+
+---
+
+## Structure des fichiers
+
+**Créer :**
+
+- `tooling/arnes/src/diagnostic/human.rs` — projection humaine, compteurs, filtres et tri stable ;
+- `tooling/arnes/tests/human_cli.rs` — contrat `-v`, aide et refus du couple verbose/JSON ;
+- `tooling/arnes/tests/human_skills.rs` — snapshots multi-agent normal et verbose ;
+- `tooling/arnes/tests/fixtures/diagnostic/report-verbose.txt` — vue générique exhaustive ;
+- `tooling/arnes/tests/fixtures/skills/report.txt` — vue skills normale exacte ;
+- `tooling/arnes/tests/fixtures/skills/report-verbose.txt` — vue skills verbose exacte.
+
+**Modifier :**
+
+- `tooling/arnes/src/main.rs` — parse, validation et contexte de rendu ;
+- `tooling/arnes/src/diagnostic.rs` — modèle canonique inchangé, métadonnées humaines et délégation ;
+- `tooling/arnes/src/skills.rs` — attachement centralisé des sections agent/scope ;
+- `tooling/arnes/src/skills/projection.rs` — détails structurés des écarts de projection ;
+- `tooling/arnes/tests/diagnostic.rs` et `tests/fixtures/diagnostic/report.txt` — contrat générique ;
+- les tests d’intégration qui inspectent des lignes saines — demander `-v` lorsque leur objet exige l’inventaire ;
+- `docs/arnes-capacites-externes.md` — documenter vue normale, verbose et JSON.
+
+`diagnostic.rs`, `main.rs` et chaque fonction de production restent sous les seuils de 250 et 50
+lignes. Les nouveaux tests ne sont pas ajoutés à `tests/cli.rs` ou `tests/commands.rs`, déjà proches
+de 250 lignes. Le plan lui-même dépasse ce seuil parce qu'il est une checklist séquentielle
+exécutable ; le fractionner rendrait les signatures et checkpoints interdépendants ambigus.
+
+### Task 1: Établir le contrat CLI de verbosité
+
+**Files:**
+
+- Create: `tooling/arnes/tests/human_cli.rs`
+- Modify: `tooling/arnes/src/main.rs:20-77`
+
+- [ ] **Step 1: Écrire les tests CLI rouges**
+
+Créer `tooling/arnes/tests/human_cli.rs` avec le contrat de parsing et la validation avant `HOME` :
+
+```rust
+use std::process::{Command, Output};
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_arnes"))
+        .args(args)
+        .env_clear()
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn doctor_help_lists_verbose_options() {
+    let output = run(&["doctor", "--help"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout.contains("-v, --verbose"), "{stdout}");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn verbose_json_is_rejected_before_home_is_read() {
+    for args in [
+        vec!["doctor", "skills", "-v", "--format", "json"],
+        vec!["doctor", "--verbose", "skills", "--format=json"],
+        vec!["doctor", "--format", "json", "skills", "-v"],
+    ] {
+        let output = run(&args);
+
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+        assert!(output.stdout.is_empty(), "{args:?}");
+        assert_eq!(
+            String::from_utf8(output.stderr).unwrap(),
+            "--verbose cannot be used with --format json\n",
+            "{args:?}"
+        );
+    }
+}
+
+#[test]
+fn duplicate_format_is_rejected_by_clap() {
+    let output = run(&[
+        "doctor", "skills", "--format", "human", "--format", "json",
+    ]);
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(stderr.contains("cannot be used multiple times"), "{stderr}");
+}
+```
+
+- [ ] **Step 2: Exécuter le test ciblé et constater le rouge**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test human_cli
+```
+
+Expected: FAIL ; l'aide ne contient pas `-v, --verbose` et les invocations sont refusées par Clap
+comme arguments inconnus.
+
+- [ ] **Step 3: Ajouter l'option typée et le guard format/verbosité**
+
+Dans `tooling/arnes/src/main.rs`, compléter les dérivations et `Command::Doctor`, puis valider les
+valeurs typées avant `diagnose` :
+
+```rust
+#[derive(Subcommand)]
+enum Command {
+    Doctor {
+        #[arg(value_enum)]
+        resource: Option<Resource>,
+        #[arg(long, value_enum)]
+        agent: Option<Agent>,
+        #[arg(long, value_enum, default_value = "user")]
+        scope: Option<Scope>,
+        #[arg(long, value_enum, default_value_t)]
+        format: Format,
+        #[arg(short, long)]
+        verbose: bool,
+    },
+}
+
+#[derive(Clone, Copy, Default, Eq, PartialEq, ValueEnum)]
+enum Format {
+    #[default]
+    Human,
+    Json,
+}
+
+fn validate_render_options(format: Format, verbose: bool) -> Result<(), &'static str> {
+    if verbose && format == Format::Json {
+        return Err("--verbose cannot be used with --format json");
+    }
+    Ok(())
+}
+```
+
+Conserver `#[default]` sur `Format::Human`. Après la destructuration de `Command::Doctor`, insérer
+avant la première ligne qui appelle `diagnose` :
+
+```rust
+if let Err(error) = validate_render_options(format, verbose) {
+    eprintln!("{error}");
+    return ExitCode::from(2);
+}
+```
+
+Ne pas passer `verbose` à `diagnose` et ne modifier ni `Report::json()` ni `Report::exit_code()`.
+
+- [ ] **Step 4: Exécuter le test CLI ciblé et constater le vert**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test human_cli
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Vérifier les bypasses du guard**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test human_cli verbose_json_is_rejected_before_home_is_read
+```
+
+Expected: PASS pour forme courte, forme longue, `--format=json` et ordre inversé. Le sink protégé est
+le couple typé `(Format, bool)`, jamais la chaîne argv.
+
+- [ ] **Step 6: Committer le contrat CLI**
+
+```bash
+git add tooling/arnes/src/main.rs tooling/arnes/tests/human_cli.rs
+git commit -m "feat(arnes): add doctor verbosity contract" -m "Validate the parsed format and verbosity pair before diagnostics. Covered bypass forms: short and long flags, format equals syntax, and reversed argument order."
+```
+
+### Task 2: Extraire le renderer humain générique
+
+**Files:**
+
+- Create: `tooling/arnes/src/diagnostic/human.rs`
+- Create: `tooling/arnes/tests/fixtures/diagnostic/report-verbose.txt`
+- Modify: `tooling/arnes/src/diagnostic.rs:1-127`
+- Modify: `tooling/arnes/src/main.rs:35-77`
+- Modify: `tooling/arnes/tests/diagnostic.rs:1-91`
+- Modify: `tooling/arnes/tests/fixtures/diagnostic/report.txt`
+
+- [ ] **Step 1: Remplacer les tests de rendu générique par les contrats normal et verbose**
+
+Dans `tooling/arnes/tests/diagnostic.rs`, importer les options et le contexte puis remplacer le test
+humain exact par ces tests :
+
+```rust
+use arnes::diagnostic::{Diagnostic, HumanContext, HumanOptions, Report, State};
+
+fn context() -> HumanContext {
+    HumanContext::new("Diagnostics")
+}
+
+#[test]
+fn normal_human_output_hides_healthy_details() {
+    assert_eq!(
+        format!("{}\n", report().human(&context(), HumanOptions::normal())),
+        include_str!("fixtures/diagnostic/report.txt")
+    );
+}
+
+#[test]
+fn verbose_human_output_includes_healthy_details() {
+    assert_eq!(
+        format!("{}\n", report().human(&context(), HumanOptions::verbose())),
+        include_str!("fixtures/diagnostic/report-verbose.txt")
+    );
+}
+
+#[test]
+fn empty_human_report_does_not_claim_health() {
+    let report = Report::new(Vec::new());
+
+    assert_eq!(
+        report.human(&context(), HumanOptions::normal()),
+        "No diagnostics"
+    );
+}
+
+#[test]
+fn report_without_healthy_diagnostics_displays_zero() {
+    let report = Report::new(vec![Diagnostic::new(
+        "skills",
+        State::Unsupported,
+        "inventory unavailable",
+    )]);
+
+    assert!(
+        report
+            .human(&context(), HumanOptions::normal())
+            .starts_with("Diagnostics\n✓ 0 healthy\n")
+    );
+}
+```
+
+Conserver sans modification les tests JSON, ordre canonique, échappement et exit codes. Adapter le
+test des groupes pour appeler `HumanOptions::verbose()` afin qu'il continue de vérifier les deux
+lignes.
+
+- [ ] **Step 2: Écrire les deux fixtures exactes**
+
+Remplacer `tooling/arnes/tests/fixtures/diagnostic/report.txt` par :
+
+```text
+Diagnostics
+✓ 1 healthy
+! 1 unsupported (non-blocking)
+
+unsupported rules: cursor does not expose native user rules
+drift skills: destination is missing
+error config: settings.json could not be read
+```
+
+Créer `tooling/arnes/tests/fixtures/diagnostic/report-verbose.txt` :
+
+```text
+Diagnostics
+✓ 1 healthy
+! 1 unsupported (non-blocking)
+
+healthy manifest: manifest is valid
+unsupported rules: cursor does not expose native user rules
+drift skills: destination is missing
+error config: settings.json could not be read
+```
+
+- [ ] **Step 3: Exécuter les tests de diagnostic et constater le rouge de compilation**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test diagnostic
+```
+
+Expected: FAIL ; `HumanContext`, `HumanOptions` et la nouvelle signature de `Report::human` n'existent
+pas.
+
+- [ ] **Step 4: Définir l'API humaine sans modifier le modèle sérialisé**
+
+Dans `tooling/arnes/src/diagnostic.rs`, ajouter `mod human;`, réexporter les options, puis déléguer :
+
+```rust
+mod human;
+
+pub use human::{HumanContext, HumanOptions};
+
+impl Report {
+    pub fn human(&self, context: &HumanContext, options: HumanOptions) -> String {
+        human::render(&self.diagnostics, context, options)
+    }
+}
+```
+
+Supprimer uniquement l'ancien corps de `Report::human`. Ne toucher ni aux trois champs publics de
+`Diagnostic`, ni à `#[serde(skip)]`, ni à `Report::json`, ni à `Report::exit_code`.
+
+- [ ] **Step 5: Implémenter le renderer plat minimal**
+
+Créer `tooling/arnes/src/diagnostic/human.rs` avec des fonctions courtes et sans dépendance :
+
+```rust
+use super::{Diagnostic, State};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SectionCount {
+    singular: &'static str,
+    plural: &'static str,
+    empty: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HumanContext {
+    parts: Vec<String>,
+    section_count: Option<SectionCount>,
+}
+
+impl HumanContext {
+    pub fn new(heading: impl Into<String>) -> Self {
+        Self {
+            parts: vec![heading.into()],
+            section_count: None,
+        }
+    }
+
+    pub fn with_qualifier(mut self, qualifier: impl Into<String>) -> Self {
+        self.parts.push(qualifier.into());
+        self
+    }
+
+    pub fn with_section_count(
+        mut self,
+        singular: &'static str,
+        plural: &'static str,
+        empty: &'static str,
+    ) -> Self {
+        self.section_count = Some(SectionCount {
+            singular,
+            plural,
+            empty,
+        });
+        self
+    }
+
+    pub(super) fn heading(&self, count: Option<usize>) -> String {
+        let mut parts = self.parts.clone();
+        if let Some(labels) = &self.section_count {
+            parts.push(match count {
+                Some(1) => format!("1 {}", labels.singular),
+                Some(count) => format!("{count} {}", labels.plural),
+                None => labels.empty.to_owned(),
+            });
+        }
+        parts.join(" · ")
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HumanOptions {
+    verbose: bool,
+}
+
+impl HumanOptions {
+    pub fn normal() -> Self {
+        Self { verbose: false }
+    }
+
+    pub fn verbose() -> Self {
+        Self { verbose: true }
+    }
+
+    pub fn includes_healthy(self) -> bool {
+        self.verbose
+    }
+}
+
+pub(super) fn render(
+    diagnostics: &[Diagnostic],
+    context: &HumanContext,
+    options: HumanOptions,
+) -> String {
+    if diagnostics.is_empty() {
+        return "No diagnostics".to_owned();
+    }
+    let mut lines = vec![
+        context.heading(None),
+        format!("✓ {} healthy", state_count(diagnostics, State::Healthy)),
+    ];
+    let unsupported = state_count(diagnostics, State::Unsupported);
+    if unsupported > 0 {
+        lines.push(format!("! {unsupported} unsupported (non-blocking)"));
+    }
+    lines.push(String::new());
+    lines.extend(render_flat(diagnostics, options));
+    trim_trailing_empty(&mut lines);
+    lines.join("\n")
+}
+
+fn state_count(diagnostics: &[Diagnostic], state: State) -> usize {
+    diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.state == state)
+        .count()
+}
+
+fn render_flat(diagnostics: &[Diagnostic], options: HumanOptions) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut group = None;
+    for diagnostic in diagnostics
+        .iter()
+        .filter(|diagnostic| options.includes_healthy() || diagnostic.state != State::Healthy)
+    {
+        if let Some(human) = diagnostic.human() {
+            if group != Some(human.group()) {
+                if !lines.is_empty() {
+                    lines.push(String::new());
+                }
+                lines.push(human.group().to_owned());
+                group = Some(human.group());
+            }
+            lines.push(format!("  {:11} {}", diagnostic.state, human.summary()));
+        } else {
+            group = None;
+            lines.push(diagnostic.to_string());
+        }
+    }
+    lines
+}
+
+fn trim_trailing_empty(lines: &mut Vec<String>) {
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+}
+```
+
+Ajouter sur `HumanDiagnostic` des accesseurs privés de crate `group()` et `summary()`, et sur
+`Diagnostic` l'accesseur `pub(super) fn human(&self) -> Option<&HumanDiagnostic>`. Garder
+`human_field` pour l'échappement des sorties plates.
+
+- [ ] **Step 6: Relier `main` au contexte et à la verbosité**
+
+Dériver `Copy, Eq, PartialEq` sur `Resource`, ajouter son libellé, puis construire un contexte sans
+parser de diagnostic :
+
+```rust
+impl Resource {
+    fn heading(self) -> &'static str {
+        match self {
+            Self::Manifest => "Manifest",
+            Self::Config => "Config",
+            Self::Instructions => "Instructions",
+            Self::Skills => "Skills",
+            Self::Prompts => "Prompts",
+            Self::Commands => "Commands",
+            Self::Rules => "Rules",
+            Self::Hooks => "Hooks",
+            Self::Mcp => "MCP",
+            Self::Statusline => "Statusline",
+        }
+    }
+}
+
+fn human_context(
+    resource: Option<Resource>,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> HumanContext {
+    let resource = resource.unwrap_or(Resource::Manifest);
+    let mut context = HumanContext::new(resource.heading());
+    if resource != Resource::Manifest {
+        if let Some(scope) = scope {
+            context = context.with_qualifier(format!("{scope} scope"));
+        }
+        if let Some(agent) = agent {
+            context = context.with_qualifier(format!("{agent} agent"));
+        } else if resource == Resource::Skills {
+            context = context.with_section_count("agent", "agents", "all agents");
+        }
+    }
+    context
+}
+```
+
+Remplacer le choix de format par :
+
+```rust
+let output = match format {
+    Format::Human => report.human(
+        &human_context(resource, agent, scope),
+        if verbose {
+            HumanOptions::verbose()
+        } else {
+            HumanOptions::normal()
+        },
+    ),
+    Format::Json => report.json().expect("diagnostics are JSON serializable"),
+};
+```
+
+Passer `resource` copiable à `diagnose` sans changer sa signature ni le moment de collecte.
+
+- [ ] **Step 7: Exécuter les tests génériques ciblés**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test diagnostic --test human_cli
+```
+
+Expected: PASS ; le JSON exact de `report.json` reste identique à `report.json` existant.
+
+- [ ] **Step 8: Committer le renderer générique**
+
+```bash
+git add tooling/arnes/src/main.rs tooling/arnes/src/diagnostic.rs tooling/arnes/src/diagnostic/human.rs tooling/arnes/tests/diagnostic.rs tooling/arnes/tests/fixtures/diagnostic/report.txt tooling/arnes/tests/fixtures/diagnostic/report-verbose.txt
+git commit -m "feat(arnes): summarize healthy diagnostics"
+```
+
+### Task 3: Structurer la vue humaine skills par agent
+
+**Files:**
+
+- Create: `tooling/arnes/tests/human_skills.rs`
+- Create: `tooling/arnes/tests/fixtures/skills/report.txt`
+- Create: `tooling/arnes/tests/fixtures/skills/report-verbose.txt`
+- Modify: `tooling/arnes/src/diagnostic.rs`
+- Modify: `tooling/arnes/src/diagnostic/human.rs`
+- Modify: `tooling/arnes/src/skills.rs:12-55`
+- Modify: `tooling/arnes/src/skills/projection.rs:10-166`
+- Modify: `tooling/arnes/src/main.rs`
+
+- [ ] **Step 1: Écrire le test exact multi-agent normal et verbose**
+
+Créer `tooling/arnes/tests/human_skills.rs` avec un rapport entièrement déterministe :
+
+```rust
+use arnes::diagnostic::{
+    Diagnostic, HumanContext, HumanDetail, HumanOptions, HumanSection, Report, State,
+};
+
+fn section(key: &str, label: &str) -> HumanSection {
+    HumanSection::new(key, label)
+}
+
+fn diagnostic(
+    section: HumanSection,
+    state: State,
+    message: &str,
+    summary: &str,
+) -> Diagnostic {
+    Diagnostic::new("skills", state, message)
+        .with_human_summary(summary)
+        .with_human_section(section)
+}
+
+fn report() -> Report {
+    let claude = section("claude:user", "CLAUDE");
+    let cursor = section("cursor:user", "CURSOR");
+    let codex = section("codex:user", "CODEX");
+    Report::new(vec![
+        diagnostic(claude.clone(), State::Healthy, "handoff current", "handoff"),
+        diagnostic(
+            claude,
+            State::Unsupported,
+            "system skills inventory is unsupported",
+            "system skills inventory",
+        ),
+        diagnostic(
+            cursor.clone(),
+            State::Healthy,
+            "merge-verdict current",
+            "merge-verdict",
+        ),
+        diagnostic(
+            cursor.clone(),
+            State::Unsupported,
+            "extension skill exposure unavailable",
+            "extension skill exposure",
+        ),
+        diagnostic(
+            cursor,
+            State::Drift,
+            "destination is missing",
+            "enforcement-code",
+        )
+        .with_human_details([
+            HumanDetail::new("expected", "managed skill present"),
+            HumanDetail::new("actual", "destination missing"),
+            HumanDetail::new("path", "~/.cursor/skills/enforcement-code"),
+        ]),
+        diagnostic(
+            codex,
+            State::Unsupported,
+            "browser plugin version unavailable",
+            "browser plugin version/cache",
+        ),
+    ])
+}
+
+fn context() -> HumanContext {
+    HumanContext::new("Skills")
+        .with_qualifier("user scope")
+        .with_section_count("agent", "agents", "all agents")
+}
+
+#[test]
+fn normal_skills_output_matches_the_exact_fixture() {
+    assert_eq!(
+        format!("{}\n", report().human(&context(), HumanOptions::normal())),
+        include_str!("fixtures/skills/report.txt")
+    );
+}
+
+#[test]
+fn verbose_skills_output_matches_the_exact_fixture() {
+    assert_eq!(
+        format!("{}\n", report().human(&context(), HumanOptions::verbose())),
+        include_str!("fixtures/skills/report-verbose.txt")
+    );
+}
+```
+
+Créer `tooling/arnes/tests/fixtures/skills/report.txt` avec ce contenu exact :
+
+```text
+Skills · user scope · 3 agents
+✓ 2 healthy
+! 3 unsupported (non-blocking)
+
+CURSOR
+  1 issue · 1 unsupported · 1 healthy
+
+  DRIFT enforcement-code
+    expected  managed skill present
+    actual    destination missing
+    path      ~/.cursor/skills/enforcement-code
+  UNSUPPORTED extension skill exposure
+
+CLAUDE
+  1 unsupported · 1 healthy
+
+  UNSUPPORTED system skills inventory
+
+CODEX
+  1 unsupported · 0 healthy
+
+  UNSUPPORTED browser plugin version/cache
+```
+
+Créer `tooling/arnes/tests/fixtures/skills/report-verbose.txt` avec ce contenu exact :
+
+```text
+Skills · user scope · 3 agents
+✓ 2 healthy
+! 3 unsupported (non-blocking)
+
+CURSOR
+  1 issue · 1 unsupported · 1 healthy
+
+  DRIFT enforcement-code
+    expected  managed skill present
+    actual    destination missing
+    path      ~/.cursor/skills/enforcement-code
+  UNSUPPORTED extension skill exposure
+  HEALTHY merge-verdict
+
+CLAUDE
+  1 unsupported · 1 healthy
+
+  UNSUPPORTED system skills inventory
+  HEALTHY handoff
+
+CODEX
+  1 unsupported · 0 healthy
+
+  UNSUPPORTED browser plugin version/cache
+```
+
+- [ ] **Step 2: Écrire les assertions unitaires de tri stable et de section saine masquée**
+
+Dans `tooling/arnes/tests/diagnostic.rs`, ajouter un helper et deux tests :
+
+```rust
+fn section(key: &str, label: &str) -> HumanSection {
+    HumanSection::new(key, label)
+}
+
+#[test]
+fn structured_sections_sort_by_severity_without_mutating_report_order() {
+    let report = Report::new(vec![
+        Diagnostic::new("skills", State::Unsupported, "claude limitation")
+            .with_human_section(section("claude:user", "CLAUDE")),
+        Diagnostic::new("skills", State::Healthy, "cursor current")
+            .with_human_section(section("cursor:user", "CURSOR")),
+        Diagnostic::new("skills", State::Drift, "cursor missing")
+            .with_human_section(section("cursor:user", "CURSOR")),
+    ]);
+
+    let output = report.human(&context(), HumanOptions::normal());
+
+    assert!(output.find("CURSOR").unwrap() < output.find("CLAUDE").unwrap());
+    assert!(!output.contains("cursor current"));
+    assert_eq!(
+        report
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str())
+            .collect::<Vec<_>>(),
+        ["claude limitation", "cursor current", "cursor missing"]
+    );
+}
+
+#[test]
+fn verbose_places_healthy_diagnostics_after_other_states() {
+    let report = Report::new(vec![
+        Diagnostic::new("skills", State::Healthy, "current")
+            .with_human_section(section("cursor:user", "CURSOR")),
+        Diagnostic::new("skills", State::Unsupported, "inventory unavailable")
+            .with_human_section(section("cursor:user", "CURSOR")),
+    ]);
+
+    let output = report.human(&context(), HumanOptions::verbose());
+
+    assert!(output.find("inventory unavailable").unwrap() < output.find("current").unwrap());
+}
+
+#[test]
+fn healthy_only_section_is_hidden_until_verbose() {
+    let report = Report::new(vec![
+        Diagnostic::new("skills", State::Healthy, "claude current")
+            .with_human_section(section("claude:user", "CLAUDE")),
+    ]);
+
+    assert!(!report
+        .human(&context(), HumanOptions::normal())
+        .contains("CLAUDE"));
+    assert!(report
+        .human(&context(), HumanOptions::verbose())
+        .contains("CLAUDE"));
+}
+```
+
+Ajouter `HumanSection` à l'import du test.
+
+- [ ] **Step 3: Exécuter les tests ciblés et constater le rouge**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test diagnostic --test human_skills
+```
+
+Expected: FAIL ; `HumanSection` et les snapshots skills n'existent pas, et le renderer ne regroupe
+pas les agents.
+
+- [ ] **Step 4: Ajouter les métadonnées humaines structurées**
+
+Dans `tooling/arnes/src/diagnostic.rs`, conserver `resource`, `state`, `message` et Serde tels quels,
+puis étendre uniquement les champs ignorés par Serde :
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HumanSection {
+    key: String,
+    label: String,
+}
+
+impl HumanSection {
+    pub fn new(key: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            label: label.into(),
+        }
+    }
+
+    pub(super) fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub(super) fn label(&self) -> &str {
+        &self.label
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HumanDetail {
+    label: String,
+    value: String,
+}
+
+impl HumanDetail {
+    pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+        }
+    }
+}
+```
+
+Ajouter `#[serde(skip)] section: Option<HumanSection>` à `Diagnostic` et
+`details: Vec<HumanDetail>` à `HumanDiagnostic`. Conserver `group: String` et la signature publique
+existante de `with_human`, puis ajouter :
+
+```rust
+pub fn with_human_section(mut self, section: HumanSection) -> Self {
+    self.section = Some(section);
+    self
+}
+
+pub fn with_human_summary(mut self, summary: impl Into<String>) -> Self {
+    let details = self
+        .human
+        .take()
+        .map(|human| human.details)
+        .unwrap_or_default();
+    self.human = Some(HumanDiagnostic {
+        group: String::new(),
+        summary: summary.into(),
+        details,
+    });
+    self
+}
+
+pub fn with_human_details(
+    mut self,
+    details: impl IntoIterator<Item = HumanDetail>,
+) -> Self {
+    self.human
+        .as_mut()
+        .expect("human details require a human summary")
+        .details = details.into_iter().collect();
+    self
+}
+
+pub(super) fn section(&self) -> Option<&HumanSection> {
+    self.section.as_ref()
+}
+```
+
+Initialiser `section: None` et les détails vides dans les constructeurs. Ajouter sur `HumanDetail`
+les accesseurs `pub(super) fn label(&self) -> &str` et `value(&self) -> &str`; les autres accesseurs
+utilisés par `human.rs` restent non publics hors crate. Dans le renderer structuré, un `group` vide
+n'affiche aucun sous-en-tête.
+
+- [ ] **Step 5: Implémenter le regroupement et le tri sur des références**
+
+Dans `tooling/arnes/src/diagnostic/human.rs`, faire choisir `render` entre fallback plat et sections
+uniquement lorsque tous les diagnostics portent une section. Le chemin structuré appelle
+`context.heading(Some(sections.len()))`; le fallback appelle `context.heading(None)`. Les deux
+partagent le total sain et l'unique ligne globale `unsupported (non-blocking)`. Étendre l'import à
+`use super::{Diagnostic, HumanDiagnostic, State};`, puis ajouter ces unités :
+
+```rust
+struct Section<'a> {
+    key: &'a str,
+    label: &'a str,
+    first_index: usize,
+    diagnostics: Vec<(usize, &'a Diagnostic)>,
+}
+
+fn state_rank(state: State) -> u8 {
+    match state {
+        State::Error => 3,
+        State::Drift => 2,
+        State::Unsupported => 1,
+        State::Healthy => 0,
+    }
+}
+
+fn collect_sections(diagnostics: &[Diagnostic]) -> Vec<Section<'_>> {
+    let mut sections = Vec::<Section<'_>>::new();
+    for (index, diagnostic) in diagnostics.iter().enumerate() {
+        let section = diagnostic.section().expect("structured report has sections");
+        if let Some(existing) = sections.iter_mut().find(|item| item.key == section.key()) {
+            existing.diagnostics.push((index, diagnostic));
+        } else {
+            sections.push(Section {
+                key: section.key(),
+                label: section.label(),
+                first_index: index,
+                diagnostics: vec![(index, diagnostic)],
+            });
+        }
+    }
+    sections.sort_by_key(|section| {
+        (
+            std::cmp::Reverse(
+                section
+                    .diagnostics
+                    .iter()
+                    .map(|(_, diagnostic)| state_rank(diagnostic.state))
+                    .max()
+                    .unwrap_or(0),
+            ),
+            section.first_index,
+        )
+    });
+    sections
+}
+
+fn ordered_diagnostics<'a>(section: &Section<'a>) -> Vec<&'a Diagnostic> {
+    let mut diagnostics = section.diagnostics.clone();
+    diagnostics.sort_by_key(|(index, diagnostic)| {
+        (std::cmp::Reverse(state_rank(diagnostic.state)), *index)
+    });
+    diagnostics
+        .into_iter()
+        .map(|(_, diagnostic)| diagnostic)
+        .collect()
+}
+```
+
+Remplacer l'orchestration de `render` par ces fonctions ; `issues` vaut `error + drift` :
+
+```rust
+#[derive(Default)]
+struct Counts {
+    issues: usize,
+    unsupported: usize,
+    healthy: usize,
+}
+
+pub(super) fn render(
+    diagnostics: &[Diagnostic],
+    context: &HumanContext,
+    options: HumanOptions,
+) -> String {
+    if diagnostics.is_empty() {
+        return "No diagnostics".to_owned();
+    }
+    let structured = diagnostics.iter().all(|diagnostic| diagnostic.section().is_some());
+    let sections = structured.then(|| collect_sections(diagnostics));
+    let mut lines = summary_lines(context, diagnostics, sections.as_deref());
+    let body = match &sections {
+        Some(sections) => render_sections(sections, options),
+        None => render_flat(diagnostics, options),
+    };
+    if !body.is_empty() {
+        lines.push(String::new());
+        lines.extend(body);
+    }
+    lines.join("\n")
+}
+
+fn summary_lines(
+    context: &HumanContext,
+    diagnostics: &[Diagnostic],
+    sections: Option<&[Section<'_>]>,
+) -> Vec<String> {
+    let mut lines = vec![
+        context.heading(sections.map(|sections| sections.len())),
+        format!("✓ {} healthy", state_count(diagnostics, State::Healthy)),
+    ];
+    let unsupported = state_count(diagnostics, State::Unsupported);
+    if unsupported > 0 {
+        lines.push(format!("! {unsupported} unsupported (non-blocking)"));
+    }
+    lines
+}
+
+fn render_sections(sections: &[Section<'_>], options: HumanOptions) -> Vec<String> {
+    let mut lines = Vec::new();
+    for section in sections {
+        let visible = ordered_diagnostics(section)
+            .into_iter()
+            .filter(|diagnostic| {
+                options.includes_healthy() || diagnostic.state != State::Healthy
+            })
+            .collect::<Vec<_>>();
+        if visible.is_empty() {
+            continue;
+        }
+        if !lines.is_empty() {
+            lines.push(String::new());
+        }
+        lines.push(section.label.to_owned());
+        lines.push(render_section_counts(&section.diagnostics));
+        lines.push(String::new());
+        lines.extend(render_section_diagnostics(&visible));
+    }
+    lines
+}
+
+fn render_section_counts(diagnostics: &[(usize, &Diagnostic)]) -> String {
+    let counts = diagnostics.iter().fold(Counts::default(), |mut counts, (_, diagnostic)| {
+        match diagnostic.state {
+            State::Error | State::Drift => counts.issues += 1,
+            State::Unsupported => counts.unsupported += 1,
+            State::Healthy => counts.healthy += 1,
+        }
+        counts
+    });
+    let mut parts = Vec::new();
+    if counts.issues > 0 {
+        parts.push(plural(counts.issues, "issue", "issues"));
+    }
+    if counts.unsupported > 0 {
+        parts.push(format!("{} unsupported", counts.unsupported));
+    }
+    parts.push(format!("{} healthy", counts.healthy));
+    format!("  {}", parts.join(" · "))
+}
+
+fn plural(count: usize, singular: &str, plural: &str) -> String {
+    format!("{count} {}", if count == 1 { singular } else { plural })
+}
+
+fn render_section_diagnostics(diagnostics: &[&Diagnostic]) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut group = None;
+    for diagnostic in diagnostics {
+        let human = diagnostic.human();
+        let next_group = human.map(HumanDiagnostic::group).filter(|group| !group.is_empty());
+        if next_group != group {
+            if let Some(next_group) = next_group {
+                lines.push(format!("  {next_group}"));
+            }
+            group = next_group;
+        }
+        let indent = if group.is_some() { 4 } else { 2 };
+        lines.extend(render_structured_diagnostic(diagnostic, indent));
+    }
+    lines
+}
+
+fn render_structured_diagnostic(diagnostic: &Diagnostic, indent: usize) -> Vec<String> {
+    let human = diagnostic.human();
+    let summary = human
+        .map(HumanDiagnostic::summary)
+        .unwrap_or(&diagnostic.message);
+    let mut lines = vec![format!(
+        "{}{} {}",
+        " ".repeat(indent),
+        diagnostic.state.to_string().to_uppercase(),
+        super::human_field(summary),
+    )];
+    if let Some(human) = human {
+        lines.extend(human.details().iter().map(|detail| {
+            format!(
+                "{}{:9} {}",
+                " ".repeat(indent + 2),
+                detail.label(),
+                super::human_field(detail.value()),
+            )
+        }));
+    }
+    lines
+}
+```
+
+Rendre `human_field` `pub(super)` dans `diagnostic.rs`. Ajouter sur `HumanDiagnostic` les accesseurs
+`group()`, `summary()` et `details()`. Supprimer `trim_trailing_empty`, devenu inutilisé après cette
+orchestration. Le renderer ne doit muter ni réordonner `Report::diagnostics`.
+
+- [ ] **Step 6: Attacher chaque diagnostic skills à sa section au point d'orchestration**
+
+Dans `tooling/arnes/src/skills.rs`, ajouter ces helpers :
+
+```rust
+fn human_section(agent: Agent, scope: Scope) -> HumanSection {
+    HumanSection::new(
+        format!("{agent}:{scope}"),
+        agent.to_string().to_uppercase(),
+    )
+}
+
+fn section_diagnostics(
+    diagnostics: Vec<Diagnostic>,
+    agent: Agent,
+    scope: Scope,
+) -> Vec<Diagnostic> {
+    let section = human_section(agent, scope);
+    diagnostics
+        .into_iter()
+        .map(|diagnostic| diagnostic.with_human_section(section.clone()))
+        .collect()
+}
+```
+
+Dans la boucle de `diagnose`, envelopper le résultat de chaque `diagnose_one` avec
+`section_diagnostics`. Pour la branche `combinations.is_empty()`, attacher une section uniquement
+lorsque `agent` et `scope` sont tous deux présents ; sinon conserver le fallback non sectionné. Ne
+modifier aucun producteur externe ni l'ordre du vecteur.
+
+- [ ] **Step 7: Produire les détails `expected / actual / path` sans parser le message**
+
+Dans `tooling/arnes/src/skills/projection.rs`, introduire une vue humaine passée à
+`expected_link` :
+
+```rust
+struct ProjectionHuman {
+    summary: String,
+    path: String,
+}
+
+impl ProjectionHuman {
+    fn missing_destination(&self, diagnostic: Diagnostic) -> Diagnostic {
+        diagnostic
+            .with_human_summary(&self.summary)
+            .with_human_details([
+                HumanDetail::new("expected", "managed skill present"),
+                HumanDetail::new("actual", "destination missing"),
+                HumanDetail::new("path", &self.path),
+            ])
+    }
+}
+```
+
+Dans `leaf`, construire puis passer cette vue à `expected_link` :
+
+```rust
+let human = ProjectionHuman {
+    summary: name.to_owned(),
+    path: label(resource.scope, &installed),
+};
+```
+
+Dans la branche `ErrorKind::NotFound`, construire d'abord le `Diagnostic` canonique avec `broken`,
+puis retourner `human.missing_destination(diagnostic)`. Dans `root`, passer cette vue :
+
+```rust
+let human = ProjectionHuman {
+    summary: "managed skills projection".to_owned(),
+    path: label(resource.scope, resource.destination),
+};
+```
+
+Les autres erreurs conservent leur message humain de fallback tant qu'aucun détail structuré fidèle
+n'est disponible ; aucun `split`, regex ou extraction de texte n'est autorisé.
+
+- [ ] **Step 8: Ajouter la preuve E2E que `skills::diagnose` attache les sections**
+
+Compléter `tooling/arnes/tests/human_skills.rs` avec la fixture isolée :
+
+```rust
+#[path = "support/skills.rs"]
+mod skill_support;
+mod support;
+
+use skill_support::{configured_fixture, run};
+
+#[test]
+fn skills_doctor_attaches_agent_sections_without_reading_real_home() {
+    let fixture = configured_fixture();
+    std::fs::remove_file(fixture.home().join(".cursor/skills/alpha")).unwrap();
+
+    let (code, normal, stderr) = run(&fixture, &["doctor", "skills"]);
+    let (_, verbose, verbose_stderr) = run(&fixture, &["doctor", "skills", "-v"]);
+
+    assert_eq!(code, 1, "{normal}");
+    assert!(normal.find("CURSOR").unwrap() < normal.find("CLAUDE").unwrap());
+    assert!(!normal.contains("HEALTHY"));
+    assert!(verbose.contains("HEALTHY"));
+    assert!(stderr.is_empty());
+    assert!(verbose_stderr.is_empty());
+}
+```
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test human_skills --test diagnostic
+```
+
+Expected: PASS, avec snapshots exacts déterministes et fixture E2E confinée au `HOME` temporaire.
+
+- [ ] **Step 9: Prouver que JSON et ordre canonique n'ont pas changé**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test diagnostic json_output_matches_the_exact_fixture
+cargo test --manifest-path tooling/arnes/Cargo.toml --test diagnostic report_preserves_diagnostic_order
+```
+
+Expected: PASS pour les deux oracles historiques, sans modification de `report.json`.
+
+- [ ] **Step 10: Committer la vue skills structurée**
+
+```bash
+git add tooling/arnes/src/diagnostic.rs tooling/arnes/src/diagnostic/human.rs tooling/arnes/src/skills.rs tooling/arnes/src/skills/projection.rs tooling/arnes/src/main.rs tooling/arnes/tests/diagnostic.rs tooling/arnes/tests/human_skills.rs tooling/arnes/tests/fixtures/skills/report.txt tooling/arnes/tests/fixtures/skills/report-verbose.txt
+git commit -m "feat(arnes): group skill diagnostics by agent"
+```
+
+### Task 4: Migrer les contrats humains existants et la documentation
+
+**Files:**
+
+- Modify: `tooling/arnes/tests/skills.rs`
+- Modify: `tooling/arnes/tests/skill_adversarial.rs`
+- Modify: `tooling/arnes/tests/skill_failures.rs`
+- Modify: `tooling/arnes/tests/external_managed_skills.rs`
+- Modify: `tooling/arnes/tests/external_system_skills.rs`
+- Modify: `tooling/arnes/tests/external_cursor_plugins.rs`
+- Modify: `tooling/arnes/tests/external_claude_plugins.rs`
+- Modify: `tooling/arnes/tests/external_codex_plugins.rs`
+- Modify: `tooling/arnes/tests/external_boundary_failures.rs`
+- Modify: `tooling/arnes/tests/config.rs`
+- Modify: `tooling/arnes/tests/instructions.rs`
+- Modify: `tooling/arnes/tests/instruction_adversarial.rs`
+- Modify: `tooling/arnes/tests/instruction_failures.rs`
+- Modify: `tooling/arnes/tests/prompts.rs`
+- Modify: `tooling/arnes/tests/commands.rs`
+- Modify: `tooling/arnes/tests/cli.rs`
+- Modify: `docs/arnes-capacites-externes.md:18-23`
+
+- [ ] **Step 1: Inventorier les assertions humaines affectées**
+
+Run:
+
+```bash
+rg -n 'healthy|\.human\(|doctor.*(skills|config|instructions|prompts|commands)' tooling/arnes/tests -g '*.rs'
+```
+
+Expected: chaque assertion de détail sain est classée soit « inventaire » et doit appeler `-v`, soit
+« résumé normal » et doit vérifier compteurs/absence de lignes saines. Ne modifier aucun test JSON.
+
+- [ ] **Step 2: Passer en verbose les tests dont l'objet est l'inventaire sain**
+
+Appliquer la transformation explicite suivante aux tableaux argv concernés :
+
+```rust
+let (code, stdout, stderr) = run(&fixture, &["doctor", "skills", "-v"]);
+```
+
+Pour une commande avec filtres, ajouter `"-v"` sans déplacer les valeurs existantes :
+
+```rust
+let (code, stdout, stderr) = run(
+    &fixture,
+    &[
+        "doctor", "commands", "--agent", "claude", "--scope", scope, "-v",
+    ],
+);
+```
+
+Conserver la vue normale pour les tests qui valident `drift`, `error` ou `unsupported`. Mettre à jour
+leurs égalités exactes avec l'en-tête et `✓ N healthy`, sans relâcher une égalité en simple
+`contains` lorsque l'ordre fait partie du contrat.
+
+- [ ] **Step 3: Ajouter le comportement générique hors skills au test CLI**
+
+Dans `tooling/arnes/tests/human_cli.rs`, ajouter un manifeste sain et vérifier les deux vues :
+
+```rust
+mod support;
+
+use support::Fixture;
+
+#[test]
+fn verbose_is_generic_across_doctor_resources() {
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        "version: 1\nagents: []\nresources: []\n",
+    );
+
+    let normal = fixture.command(["doctor", "manifest"]);
+    let verbose_after = fixture.command(["doctor", "manifest", "--verbose"]);
+    let verbose_before = fixture.command(["doctor", "-v", "manifest"]);
+    let verbose_after_stdout = String::from_utf8(verbose_after.stdout).unwrap();
+    let verbose_before_stdout = String::from_utf8(verbose_before.stdout).unwrap();
+
+    assert_eq!(String::from_utf8(normal.stdout).unwrap(), "Manifest\n✓ 1 healthy\n");
+    assert_eq!(
+        verbose_after_stdout,
+        "Manifest\n✓ 1 healthy\n\nhealthy manifest: manifest is valid\n"
+    );
+    assert_eq!(verbose_before_stdout, verbose_after_stdout);
+}
+```
+
+Fusionner l'unique déclaration `mod support;` en tête de fichier ; ne pas la dupliquer.
+
+Dans `tooling/arnes/tests/commands.rs`, ajouter la preuve hors skills avec la fixture déjà importée :
+
+```rust
+#[test]
+fn command_healthy_details_require_verbose() {
+    let fixture = configured_fixture();
+    let (_, normal, _) = run(
+        &fixture,
+        &["doctor", "commands", "--agent", "claude", "--scope", "user"],
+    );
+    let (_, verbose, _) = run(
+        &fixture,
+        &[
+            "doctor", "commands", "--agent", "claude", "--scope", "user", "-v",
+        ],
+    );
+
+    assert!(normal.contains("✓"));
+    assert!(!normal.contains("healthy     deploy"));
+    assert!(verbose.contains("healthy     deploy"));
+}
+```
+
+- [ ] **Step 4: Documenter le contrat utilisateur**
+
+Dans `docs/arnes-capacites-externes.md`, remplacer le paragraphe sur les formats par :
+
+```markdown
+Les diagnostics conservent le schéma partagé `resource/state/message`. La sortie humaine affiche le
+nombre de diagnostics `healthy`, masque leur détail par défaut et inventorie tous les états
+`error`, `drift` et `unsupported`. `-v, --verbose` réinsère les détails sains ; `--format json` reste
+exhaustif et ne se combine pas avec `--verbose`.
+```
+
+- [ ] **Step 5: Exécuter les suites historiquement affectées**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test cli --test config --test instructions --test prompts --test commands --test skills --test skill_adversarial --test skill_failures
+```
+
+Expected: PASS.
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --test external_managed_skills --test external_system_skills --test external_claude_plugins --test external_cursor_plugins --test external_codex_plugins --test external_boundary_failures
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Vérifier les tailles après migration**
+
+Run:
+
+```bash
+wc -l tooling/arnes/src/main.rs tooling/arnes/src/diagnostic.rs tooling/arnes/src/diagnostic/human.rs tooling/arnes/tests/human_cli.rs tooling/arnes/tests/human_skills.rs tooling/arnes/tests/cli.rs tooling/arnes/tests/commands.rs tooling/arnes/tests/config.rs
+```
+
+Expected: aucun nouveau fichier de production au-dessus de 250 lignes et aucune fonction de
+production au-dessus de 50 lignes. `tests/config.rs` peut rester au-dessus de 250 uniquement parce
+que les changements y sont mécaniques et que cette dette préexistante n'est pas copiée ailleurs ;
+la signaler dans la livraison.
+
+- [ ] **Step 7: Committer la migration des contrats**
+
+```bash
+git add tooling/arnes/tests docs/arnes-capacites-externes.md
+git commit -m "test(arnes): adopt concise doctor output"
+```
+
+### Task 5: Vérifier l'implémentation complète
+
+**Files:**
+
+- Verify: `tooling/arnes/src/**/*.rs`
+- Verify: `tooling/arnes/tests/**/*.rs`
+- Verify: `docs/arnes-capacites-externes.md`
+
+- [ ] **Step 1: Formater puis vérifier le format Rust**
+
+Run:
+
+```bash
+cargo fmt --manifest-path tooling/arnes/Cargo.toml
+cargo fmt --manifest-path tooling/arnes/Cargo.toml --check
+```
+
+Expected: les deux commandes terminent avec l'exit code `0`.
+
+- [ ] **Step 2: Exécuter Clippy sur toutes les cibles**
+
+Run:
+
+```bash
+cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings
+```
+
+Expected: exit code `0`, aucun warning.
+
+- [ ] **Step 3: Exécuter toute la suite Arnes**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml
+```
+
+Expected: exit code `0`, zéro test échoué.
+
+- [ ] **Step 4: Vérifier le scénario réel sur macOS sans mutation**
+
+Run depuis le checkout canonique :
+
+```bash
+cargo run --manifest-path tooling/arnes/Cargo.toml -- doctor skills
+cargo run --manifest-path tooling/arnes/Cargo.toml -- doctor skills -v
+```
+
+Expected: la première sortie montre le total sain, le drift Cursor puis tous les `unsupported` sans
+détails sains ; la seconde ajoute chaque ligne saine dans sa section. Les deux conservent l'exit
+code `1` tant que `~/.cursor/skills/enforcement-code` manque. Comparer un snapshot du dépôt et de
+`HOME` avant/après avec le helper d'intégration plutôt que revendiquer la lecture seule sur simple
+observation manuelle.
+
+- [ ] **Step 5: Vérifier le diff, les commentaires et les extensions couvertes**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat
+git diff -- tooling/arnes docs/arnes-capacites-externes.md
+```
+
+Expected: aucun whitespace invalide, aucun changement hors périmètre. Lister dans la livraison tous
+les commentaires ajoutés et le fait externe qu'ils enregistrent ; la liste attendue est vide. Les
+barrières Rust couvrent `.rs`, mais aucune barrière automatisée ne couvre `.md` : ne pas qualifier la
+documentation de « green » sur la seule base de Cargo.
+
+- [ ] **Step 6: Vérifier Ubuntu en CI avant toute affirmation de portabilité**
+
+Après push de la branche, attendre le workflow `.github/workflows/test-arnes.yml` et relever son nom,
+son run et son résultat. Expected: job Ubuntu exit `0`. Sans ce run, livrer uniquement la preuve
+macOS locale et déclarer Ubuntu non exercé.
+
+- [ ] **Step 7: Committer uniquement les éventuels changements de formatage**
+
+Si `cargo fmt` a modifié des fichiers après Task 4 :
+
+```bash
+git add tooling/arnes
+git commit -m "style(arnes): format human diagnostics"
+```
+
+Sinon, ne créer aucun commit vide.

--- a/docs/superpowers/specs/2026-08-18-arnes-human-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-18-arnes-human-diagnostics-design.md
@@ -1,0 +1,248 @@
+# Lisibilité des diagnostics humains Arnes — Design
+
+**Date** : 2026-08-18 · **Statut** : approuvé
+
+## Objectif
+
+Rendre la sortie humaine de `arnes doctor` immédiatement exploitable sans modifier ce qu'Arnes
+observe. La vue par défaut indique combien de diagnostics sont sains, masque leur inventaire, puis
+affiche tous les diagnostics `error`, `drift` et `unsupported`. L'option globale `-v, --verbose`
+réinsère les diagnostics `healthy` dans cette même vue.
+
+Pour `doctor skills`, les diagnostics sont présentés par agent. L'agent qui porte l'état le plus
+grave apparaît en premier afin que la configuration effectivement incorrecte ne soit plus noyée
+par les capacités saines ou non observables.
+
+## Non-objectifs
+
+- modifier collecte, états, exit codes, schéma JSON ou ordre canonique des diagnostics ;
+- réparer une ressource, suggérer une commande ou coupler Arnes à une procédure externe ;
+- déduire une structure humaine en parsant `resource` ou `message` ;
+- ajouter couleurs, détection TTY ou dépendance, ni adopter les ressources externes.
+
+## Interface CLI
+
+`-v, --verbose` est une option de `doctor`, disponible pour toutes les ressources :
+
+```text
+arnes doctor [RESOURCE] [--agent AGENT] [--scope SCOPE] [--format FORMAT] [-v|--verbose]
+```
+
+Le raccourci `-v` est libre ; `-V` reste réservé à la version par Clap. L'option ne change que le
+rendu humain, jamais `diagnose` ni le calcul de l'exit code.
+
+Le JSON est déjà exhaustif. Toute combinaison de `-v` ou `--verbose` avec `--format json` est donc
+refusée avant la collecte avec l'erreur suivante sur stderr et l'exit code `2` :
+
+```text
+--verbose cannot be used with --format json
+```
+
+La validation porte sur les valeurs typées produites par Clap, indépendamment de l'ordre des
+arguments ou de la forme `--format=json`. Une option inconnue, une valeur de format inconnue ou un
+argument dupliqué conserve le contrat d'erreur de Clap.
+
+## Sortie humaine commune
+
+Un rapport non vide commence par un en-tête de contexte puis un total `healthy`. Le contexte reprend
+la ressource, le scope et le filtre agent réellement demandés, sans prétendre qu'un autre scope ou
+agent a été audité ; tous les nouveaux libellés et messages de la CLI restent en anglais :
+
+```text
+Skills · user scope · 3 agents
+✓ 50 healthy
+```
+
+La vue normale suit ces règles :
+
+1. compter tous les diagnostics sans en changer l'ordre canonique ;
+2. afficher le total `healthy` même lorsqu'il vaut zéro ;
+3. masquer uniquement les lignes `healthy` ;
+4. afficher intégralement `error`, `drift` et `unsupported` ;
+5. qualifier `unsupported` de non bloquant sans le présenter comme une configuration cassée.
+
+La vue verbose applique les mêmes en-têtes, compteurs, groupes et ordre de présentation, puis ajoute
+les lignes `healthy` à la fin de leur section. Elle ne recalcule aucun diagnostic.
+
+Un rapport vide affiche `No diagnostics`. Il ne doit jamais afficher un symbole vert ou laisser
+entendre que l'absence de diagnostic prouve un état sain.
+
+Pour les ressources sans regroupement structuré, les diagnostics visibles conservent leur ordre de
+production. Le masquage des lignes saines s'applique néanmoins à toutes les ressources de
+`doctor`, y compris `manifest`, `config`, `instructions`, `prompts` et `commands`.
+
+## Vue `doctor skills`
+
+Chaque agent forme une section avec les compteurs de ses états. Les sections sont classées selon
+leur état maximal, dans l'ordre `error`, `drift`, `unsupported`, `healthy`; les égalités conservent
+l'ordre de découverte. Dans une section, les diagnostics suivent ce même ordre de sévérité et
+restent stables à sévérité égale. Ce tri est une projection humaine uniquement.
+
+Vue normale représentative :
+
+```text
+$ arnes doctor skills
+
+Skills · user scope · 3 agents
+✓ 50 healthy
+
+CURSOR
+  1 issue · 3 unsupported · 16 healthy
+
+  DRIFT enforcement-code
+    expected  managed skill present
+    actual    destination missing
+    path      ~/.cursor/skills/enforcement-code
+
+  UNSUPPORTED system skills inventory
+  UNSUPPORTED marketplace plugin activation
+  UNSUPPORTED extension skill exposure
+
+CLAUDE
+  1 unsupported · 25 healthy
+
+  UNSUPPORTED system skills inventory
+
+CODEX
+  12 unsupported · 9 healthy
+
+  UNSUPPORTED browser plugin version/cache
+  UNSUPPORTED documents plugin version/cache
+  ...
+```
+
+Vue verbose représentative :
+
+```text
+$ arnes doctor skills -v
+
+Skills · user scope · 3 agents
+✓ 50 healthy
+
+CURSOR
+  1 issue · 3 unsupported · 16 healthy
+
+  DRIFT enforcement-code
+    expected  managed skill present
+    actual    destination missing
+    path      ~/.cursor/skills/enforcement-code
+
+  UNSUPPORTED system skills inventory
+  UNSUPPORTED marketplace plugin activation
+  UNSUPPORTED extension skill exposure
+
+  HEALTHY merge-verdict · managed skill
+  HEALTHY superpowers · enabled plugin
+  HEALTHY brainstorming · enabled skill
+  ...
+```
+
+Les ellipses appartiennent uniquement à cette spécification : la commande affiche chaque diagnostic
+`unsupported`, et `-v` affiche chaque diagnostic `healthy`.
+
+## Architecture de rendu
+
+`Diagnostic` reste la donnée canonique utilisée pour le JSON et l'exit code. La présentation humaine
+devient une projection distincte recevant des options de rendu, dont la verbosité, et un contexte
+d'en-tête fourni par la CLI. Elle travaille sur des références aux diagnostics existants et ne
+réordonne jamais le vecteur stocké dans `Report`.
+
+La métadonnée humaine existante est enrichie par une section structurée optionnelle. Une section
+porte une clé stable et un libellé ; elle ne se déduit jamais du texte affiché. Les producteurs de
+diagnostics skills renseignent la section agent/scope pour les ressources gérées, système et plugin.
+Les groupes plus fins, comme un plugin, restent des métadonnées de présentation imbriquées et non
+des fragments à extraire du message.
+
+Le renderer suit deux chemins :
+
+- avec sections structurées, il calcule les compteurs et l'ordre de présentation des sections sur
+  des références indexées vers les diagnostics ;
+- sans section structurée, il conserve les groupes et l'ordre humain existants tout en appliquant
+  le total et le filtre `healthy`.
+
+Les champs de présentation restent exclus de Serde. `Report::json()` conserve donc exactement
+`resource`, `state` et `message`, dans l'ordre de collecte. `main` valide d'abord la combinaison
+format/verbosité, appelle ensuite `diagnose`, puis choisit le renderer ; aucune branche de rendu ne
+peut modifier l'exit code déjà dérivé du rapport.
+
+## Erreurs et cas limites
+
+- `-v --format json` échoue avant tout chargement du manifeste ou accès à `HOME` ;
+- un rapport sans diagnostic dit `No diagnostics`, sans faux vert ;
+- un rapport sans diagnostic sain affiche `✓ 0 healthy` puis ses autres états ;
+- un rapport entièrement sain affiche son total seul en mode normal et son inventaire en verbose ;
+- un agent entièrement sain reste compté globalement, disparaît de l'inventaire normal et réapparaît
+  avec sa section en verbose ;
+- `unsupported` reste exit `0` en l'absence d'un état plus grave et reste toujours inventorié ;
+- une erreur de sortie, dont un pipe fermé, conserve le traitement I/O et l'exit code `2` actuels ;
+- les chemins humains continuent d'utiliser `~` lorsque le producteur connaît `HOME`, sans modifier
+  le chemin absolu conservé dans le diagnostic canonique.
+
+## Analyse des classes d'échec
+
+1. Atomicité et ordering : non applicable, aucune écriture ni décision transactionnelle.
+2. Retry idempotence : non applicable, aucune mutation ni retry.
+3. Invariant without a constraint : non applicable, aucune donnée persistée.
+4. Authorization as a side effect : non applicable, aucune autorisation.
+5. Tenant scope : non applicable, aucun tenant ni identifiant client.
+6. Error contract : tient parce que la combinaison verbose/JSON, son stderr et son exit code sont
+   documentés et testés au niveau CLI.
+7. Deferred functionality : non applicable, la remédiation est explicitement hors contrat et aucun
+   contrôle métier ou réglementaire n'est différé.
+8. Parsing versus assertion : tient parce que Clap produit un booléen et un enum typés, puis la
+   validation refuse le couple canonique `(verbose, json)` sans valeur permissive par défaut.
+9. Upstream control as a trust boundary : non applicable, le rendu ne fait confiance à aucun
+   allowlist upstream pour valider une ressource.
+10. Claim stronger than mechanism : tient parce qu'un rapport vide ne prétend pas être sain et que
+    `unsupported` est décrit comme une limite d'observation non bloquante.
+
+## Tests
+
+Les tests unitaires du renderer couvrent :
+
+- les totaux de chaque état et le total `healthy` nul ou non nul ;
+- le masquage strict des lignes saines en mode normal ;
+- leur insertion à la fin de chaque section en verbose ;
+- l'ordre des sections par sévérité maximale et sa stabilité à égalité ;
+- l'ordre des diagnostics par sévérité dans une section et sa stabilité à égalité ;
+- le fallback sans section structurée ;
+- un rapport vide sans affirmation de santé ;
+- l'échappement des retours chariot et sauts de ligne existant.
+
+Les tests d'intégration CLI couvrent :
+
+- `-v` et `--verbose`, avant ou après la ressource ;
+- la sortie normale et verbose de `doctor skills` avec plusieurs agents et états ;
+- une ressource entièrement saine dans les deux modes ;
+- le comportement générique sur au moins une ressource autre que `skills`, dont `commands` ;
+- le JSON byte-for-byte inchangé sans `-v` ;
+- le refus de `-v --format json`, `--format=json --verbose` et de l'ordre inverse, avec stdout vide,
+  stderr documenté, exit code `2` et aucun accès à `HOME` ;
+- les exit codes inchangés pour `healthy`, `unsupported`, `drift` et `error` ;
+- l'absence de mutation de `HOME` et du dépôt via les snapshots avant/après existants.
+
+Les fixtures de sortie plate historiques sont remplacées ou complétées par des fixtures qui rendent
+le contrat normal et verbose intentionnel. Les tests ne doivent pas se limiter à des fragments si
+l'ordre, les groupes ou les compteurs font partie du contrat.
+
+## Vérification
+
+Depuis `tooling/arnes`, l'implémentation devra exécuter les barrières couvrant les fichiers Rust :
+
+```text
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Ces résultats vaudront pour macOS dans le checkout canonique. Le workflow Arnes devra exercer Ubuntu
+avant toute affirmation de portabilité ; une réussite locale ne sera pas présentée comme une preuve
+Linux ou CI.
+
+## Livraison
+
+Aucun ADR n'est requis : le changement porte sur une option CLI et une projection humaine sans
+modifier le modèle canonique, la propriété des ressources ou une décision structurelle en vigueur.
+Le changement fonctionnel reste distinct de tout nettoyage adjacent. Aucun commentaire de code
+n'est attendu ; si un fait externe impose exceptionnellement un commentaire, il devra être listé
+dans la livraison avec sa source.

--- a/tooling/arnes/src/diagnostic.rs
+++ b/tooling/arnes/src/diagnostic.rs
@@ -1,6 +1,10 @@
 use serde::Serialize;
 use std::fmt::{self, Display};
 
+mod human;
+
+pub use human::{HumanContext, HumanOptions};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum State {
@@ -31,9 +35,19 @@ pub struct Diagnostic {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-struct HumanDiagnostic {
+pub(super) struct HumanDiagnostic {
     group: String,
     summary: String,
+}
+
+impl HumanDiagnostic {
+    pub(super) fn group(&self) -> &str {
+        &self.group
+    }
+
+    pub(super) fn summary(&self) -> &str {
+        &self.summary
+    }
 }
 
 impl Diagnostic {
@@ -53,6 +67,10 @@ impl Diagnostic {
         });
         self
     }
+
+    pub(super) fn human(&self) -> Option<&HumanDiagnostic> {
+        self.human.as_ref()
+    }
 }
 
 impl Display for Diagnostic {
@@ -67,7 +85,7 @@ impl Display for Diagnostic {
     }
 }
 
-fn human_field(value: &str) -> String {
+pub(super) fn human_field(value: &str) -> String {
     value.replace('\r', "\\r").replace('\n', "\\n")
 }
 
@@ -97,29 +115,8 @@ impl Report {
             .unwrap_or(0)
     }
 
-    pub fn human(&self) -> String {
-        let mut lines = Vec::new();
-        let mut group = None;
-        for diagnostic in &self.diagnostics {
-            if let Some(human) = &diagnostic.human {
-                if group != Some(human.group.as_str()) {
-                    if !lines.is_empty() {
-                        lines.push(String::new());
-                    }
-                    lines.push(human.group.clone());
-                    group = Some(&human.group);
-                }
-                lines.push(format!(
-                    "  {:11} {}",
-                    diagnostic.state.to_string(),
-                    human.summary
-                ));
-            } else {
-                group = None;
-                lines.push(diagnostic.to_string());
-            }
-        }
-        lines.join("\n")
+    pub fn human(&self, context: &HumanContext, options: HumanOptions) -> String {
+        human::render(&self.diagnostics, context, options)
     }
 
     pub fn json(&self) -> Result<String, serde_json::Error> {

--- a/tooling/arnes/src/diagnostic.rs
+++ b/tooling/arnes/src/diagnostic.rs
@@ -31,13 +31,62 @@ pub struct Diagnostic {
     pub state: State,
     pub message: String,
     #[serde(skip)]
-    human: Option<HumanDiagnostic>,
+    human: Option<Box<HumanDiagnostic>>,
+    #[serde(skip)]
+    section: Option<Box<HumanSection>>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
 pub(super) struct HumanDiagnostic {
     group: String,
     summary: String,
+    details: Vec<HumanDetail>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HumanDetail {
+    label: String,
+    value: String,
+}
+
+impl HumanDetail {
+    pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+        }
+    }
+
+    pub(super) fn label(&self) -> &str {
+        &self.label
+    }
+
+    pub(super) fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HumanSection {
+    key: String,
+    label: String,
+}
+
+impl HumanSection {
+    pub fn new(key: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            label: label.into(),
+        }
+    }
+
+    pub(super) fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub(super) fn label(&self) -> &str {
+        &self.label
+    }
 }
 
 impl HumanDiagnostic {
@@ -48,6 +97,10 @@ impl HumanDiagnostic {
     pub(super) fn summary(&self) -> &str {
         &self.summary
     }
+
+    pub(super) fn details(&self) -> &[HumanDetail] {
+        &self.details
+    }
 }
 
 impl Diagnostic {
@@ -57,19 +110,57 @@ impl Diagnostic {
             state,
             message: message.into(),
             human: None,
+            section: None,
         }
     }
 
     pub fn with_human(mut self, group: impl Into<String>, summary: impl Into<String>) -> Self {
-        self.human = Some(HumanDiagnostic {
+        self.human = Some(Box::new(HumanDiagnostic {
             group: group.into(),
             summary: summary.into(),
+            details: Vec::new(),
+        }));
+        self
+    }
+
+    pub fn with_human_summary(mut self, summary: impl Into<String>) -> Self {
+        let summary = summary.into();
+        match &mut self.human {
+            Some(human) => human.summary = summary,
+            None => {
+                self.human = Some(Box::new(HumanDiagnostic {
+                    group: String::new(),
+                    summary,
+                    details: Vec::new(),
+                }));
+            }
+        }
+        self
+    }
+
+    pub fn with_human_details(mut self, details: impl IntoIterator<Item = HumanDetail>) -> Self {
+        let human = self.human.get_or_insert_with(|| {
+            Box::new(HumanDiagnostic {
+                group: String::new(),
+                summary: self.message.clone(),
+                details: Vec::new(),
+            })
         });
+        human.details = details.into_iter().collect();
+        self
+    }
+
+    pub fn with_human_section(mut self, section: HumanSection) -> Self {
+        self.section = Some(Box::new(section));
         self
     }
 
     pub(super) fn human(&self) -> Option<&HumanDiagnostic> {
-        self.human.as_ref()
+        self.human.as_deref()
+    }
+
+    pub(super) fn section(&self) -> Option<&HumanSection> {
+        self.section.as_deref()
     }
 }
 

--- a/tooling/arnes/src/diagnostic/human.rs
+++ b/tooling/arnes/src/diagnostic/human.rs
@@ -1,0 +1,136 @@
+use super::{Diagnostic, State, human_field};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SectionCount {
+    singular: &'static str,
+    plural: &'static str,
+    empty: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HumanContext {
+    parts: Vec<String>,
+    section_count: Option<SectionCount>,
+}
+
+impl HumanContext {
+    pub fn new(heading: impl Into<String>) -> Self {
+        Self {
+            parts: vec![heading.into()],
+            section_count: None,
+        }
+    }
+
+    pub fn with_qualifier(mut self, qualifier: impl Into<String>) -> Self {
+        self.parts.push(qualifier.into());
+        self
+    }
+
+    pub fn with_section_count(
+        mut self,
+        singular: &'static str,
+        plural: &'static str,
+        empty: &'static str,
+    ) -> Self {
+        self.section_count = Some(SectionCount {
+            singular,
+            plural,
+            empty,
+        });
+        self
+    }
+
+    pub(super) fn heading(&self, count: Option<usize>) -> String {
+        let mut parts = self.parts.clone();
+        if let Some(labels) = &self.section_count {
+            parts.push(match count {
+                Some(1) => format!("1 {}", labels.singular),
+                Some(count) => format!("{count} {}", labels.plural),
+                None => labels.empty.to_owned(),
+            });
+        }
+        parts.join(" · ")
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HumanOptions {
+    verbose: bool,
+}
+
+impl HumanOptions {
+    pub fn normal() -> Self {
+        Self { verbose: false }
+    }
+
+    pub fn verbose() -> Self {
+        Self { verbose: true }
+    }
+
+    pub fn includes_healthy(self) -> bool {
+        self.verbose
+    }
+}
+
+pub(super) fn render(
+    diagnostics: &[Diagnostic],
+    context: &HumanContext,
+    options: HumanOptions,
+) -> String {
+    if diagnostics.is_empty() {
+        return "No diagnostics".to_owned();
+    }
+    let mut lines = vec![
+        context.heading(None),
+        format!("✓ {} healthy", state_count(diagnostics, State::Healthy)),
+    ];
+    let unsupported = state_count(diagnostics, State::Unsupported);
+    if unsupported > 0 {
+        lines.push(format!("! {unsupported} unsupported (non-blocking)"));
+    }
+    lines.push(String::new());
+    lines.extend(render_flat(diagnostics, options));
+    trim_trailing_empty(&mut lines);
+    lines.join("\n")
+}
+
+fn state_count(diagnostics: &[Diagnostic], state: State) -> usize {
+    diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.state == state)
+        .count()
+}
+
+fn render_flat(diagnostics: &[Diagnostic], options: HumanOptions) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut group = None;
+    for diagnostic in diagnostics
+        .iter()
+        .filter(|diagnostic| options.includes_healthy() || diagnostic.state != State::Healthy)
+    {
+        if let Some(human) = diagnostic.human() {
+            if group != Some(human.group()) {
+                if !lines.is_empty() {
+                    lines.push(String::new());
+                }
+                lines.push(human_field(human.group()));
+                group = Some(human.group());
+            }
+            lines.push(format!(
+                "  {:11} {}",
+                diagnostic.state.to_string(),
+                human_field(human.summary())
+            ));
+        } else {
+            group = None;
+            lines.push(diagnostic.to_string());
+        }
+    }
+    lines
+}
+
+fn trim_trailing_empty(lines: &mut Vec<String>) {
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+}

--- a/tooling/arnes/src/diagnostic/human.rs
+++ b/tooling/arnes/src/diagnostic/human.rs
@@ -1,5 +1,7 @@
 use super::{Diagnostic, State, human_field};
 
+mod sections;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct SectionCount {
     singular: &'static str,
@@ -80,8 +82,17 @@ pub(super) fn render(
     if diagnostics.is_empty() {
         return "No diagnostics".to_owned();
     }
+    let structured = diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.section().is_some());
+    let (section_count, body) = if structured {
+        let (count, lines) = sections::render(diagnostics, options);
+        (Some(count), lines)
+    } else {
+        (None, render_flat(diagnostics, options))
+    };
     let mut lines = vec![
-        context.heading(None),
+        context.heading(section_count),
         format!("✓ {} healthy", state_count(diagnostics, State::Healthy)),
     ];
     let unsupported = state_count(diagnostics, State::Unsupported);
@@ -89,7 +100,7 @@ pub(super) fn render(
         lines.push(format!("! {unsupported} unsupported (non-blocking)"));
     }
     lines.push(String::new());
-    lines.extend(render_flat(diagnostics, options));
+    lines.extend(body);
     trim_trailing_empty(&mut lines);
     lines.join("\n")
 }

--- a/tooling/arnes/src/diagnostic/human/sections.rs
+++ b/tooling/arnes/src/diagnostic/human/sections.rs
@@ -1,0 +1,151 @@
+use super::{HumanOptions, human_field};
+use crate::diagnostic::{Diagnostic, State};
+
+struct Section<'a> {
+    key: &'a str,
+    label: &'a str,
+    position: usize,
+    diagnostics: Vec<(usize, &'a Diagnostic)>,
+}
+
+pub(super) fn render(diagnostics: &[Diagnostic], options: HumanOptions) -> (usize, Vec<String>) {
+    let mut sections = collect(diagnostics);
+    let count = sections.len();
+    sections.sort_by(|left, right| {
+        section_rank(right)
+            .cmp(&section_rank(left))
+            .then(left.position.cmp(&right.position))
+    });
+    let mut lines = Vec::new();
+    for section in sections {
+        render_section(&mut lines, section, options);
+    }
+    (count, lines)
+}
+
+fn collect(diagnostics: &[Diagnostic]) -> Vec<Section<'_>> {
+    let mut sections: Vec<Section<'_>> = Vec::new();
+    for (index, diagnostic) in diagnostics.iter().enumerate() {
+        let metadata = diagnostic.section().expect("structured diagnostic section");
+        match sections
+            .iter_mut()
+            .find(|section| section.key == metadata.key())
+        {
+            Some(section) => section.diagnostics.push((index, diagnostic)),
+            None => sections.push(Section {
+                key: metadata.key(),
+                label: metadata.label(),
+                position: index,
+                diagnostics: vec![(index, diagnostic)],
+            }),
+        }
+    }
+    sections
+}
+
+fn render_section(lines: &mut Vec<String>, mut section: Section<'_>, options: HumanOptions) {
+    if !options.includes_healthy()
+        && section
+            .diagnostics
+            .iter()
+            .all(|(_, diagnostic)| diagnostic.state == State::Healthy)
+    {
+        return;
+    }
+    if !lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines.push(human_field(section.label));
+    lines.push(format!("  {}", counts(&section.diagnostics)));
+    lines.push(String::new());
+    section.diagnostics.sort_by(|left, right| {
+        state_rank(right.1.state)
+            .cmp(&state_rank(left.1.state))
+            .then(left.0.cmp(&right.0))
+    });
+    render_diagnostics(lines, &section.diagnostics, options);
+}
+
+fn render_diagnostics(
+    lines: &mut Vec<String>,
+    diagnostics: &[(usize, &Diagnostic)],
+    options: HumanOptions,
+) {
+    let mut group = None;
+    for (_, diagnostic) in diagnostics
+        .iter()
+        .filter(|(_, diagnostic)| options.includes_healthy() || diagnostic.state != State::Healthy)
+    {
+        let human = diagnostic.human();
+        let next_group = human
+            .map(|metadata| metadata.group())
+            .filter(|group| !group.is_empty());
+        if next_group != group {
+            if let Some(label) = next_group {
+                lines.push(format!("  {}", human_field(label)));
+            }
+            group = next_group;
+        }
+        let indent = if group.is_some() { "    " } else { "  " };
+        let summary = human.map_or(diagnostic.message.as_str(), |metadata| metadata.summary());
+        lines.push(format!(
+            "{indent}{} {}",
+            diagnostic.state.to_string().to_uppercase(),
+            human_field(summary)
+        ));
+        if let Some(metadata) = human {
+            for detail in metadata.details() {
+                lines.push(format!(
+                    "{indent}  {:9} {}",
+                    human_field(detail.label()),
+                    human_field(detail.value())
+                ));
+            }
+        }
+    }
+}
+
+fn counts(diagnostics: &[(usize, &Diagnostic)]) -> String {
+    let issues = count(diagnostics, |state| {
+        matches!(state, State::Error | State::Drift)
+    });
+    let unsupported = count(diagnostics, |state| state == State::Unsupported);
+    let healthy = count(diagnostics, |state| state == State::Healthy);
+    let mut parts = Vec::new();
+    if issues > 0 {
+        parts.push(format!(
+            "{issues} {}",
+            if issues == 1 { "issue" } else { "issues" }
+        ));
+    }
+    if unsupported > 0 {
+        parts.push(format!("{unsupported} unsupported"));
+    }
+    parts.push(format!("{healthy} healthy"));
+    parts.join(" · ")
+}
+
+fn count(diagnostics: &[(usize, &Diagnostic)], predicate: impl Fn(State) -> bool) -> usize {
+    diagnostics
+        .iter()
+        .filter(|(_, diagnostic)| predicate(diagnostic.state))
+        .count()
+}
+
+fn section_rank(section: &Section<'_>) -> u8 {
+    section
+        .diagnostics
+        .iter()
+        .map(|(_, diagnostic)| state_rank(diagnostic.state))
+        .max()
+        .unwrap_or(0)
+}
+
+fn state_rank(state: State) -> u8 {
+    match state {
+        State::Error => 3,
+        State::Drift => 2,
+        State::Unsupported => 1,
+        State::Healthy => 0,
+    }
+}

--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -29,6 +29,8 @@ enum Command {
         scope: Option<Scope>,
         #[arg(long, value_enum, default_value_t)]
         format: Format,
+        #[arg(short, long)]
+        verbose: bool,
     },
 }
 
@@ -46,7 +48,7 @@ enum Resource {
     Statusline,
 }
 
-#[derive(Clone, Default, ValueEnum)]
+#[derive(Clone, Copy, Default, Eq, PartialEq, ValueEnum)]
 enum Format {
     #[default]
     Human,
@@ -61,7 +63,13 @@ fn main() -> ExitCode {
         agent,
         scope,
         format,
+        verbose,
     } = command;
+
+    if let Err(error) = validate_render_options(format, verbose) {
+        eprintln!("{error}");
+        return ExitCode::from(2);
+    }
 
     let diagnostics = diagnose(resource, agent, scope);
     let report = Report::new(diagnostics);
@@ -75,6 +83,13 @@ fn main() -> ExitCode {
         return ExitCode::from(2);
     }
     ExitCode::from(report.exit_code())
+}
+
+fn validate_render_options(format: Format, verbose: bool) -> Result<(), &'static str> {
+    if verbose && format == Format::Json {
+        return Err("--verbose cannot be used with --format json");
+    }
+    Ok(())
 }
 
 fn diagnose(

--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -5,7 +5,7 @@ use std::process::ExitCode;
 use arnes::Roots;
 use arnes::commands;
 use arnes::config;
-use arnes::diagnostic::{Diagnostic, Report, State};
+use arnes::diagnostic::{Diagnostic, HumanContext, HumanOptions, Report, State};
 use arnes::instructions;
 use arnes::manifest::{self, Agent, Scope};
 use arnes::prompts;
@@ -34,7 +34,7 @@ enum Command {
     },
 }
 
-#[derive(Clone, ValueEnum)]
+#[derive(Clone, Copy, Eq, PartialEq, ValueEnum)]
 enum Resource {
     Manifest,
     Config,
@@ -74,7 +74,14 @@ fn main() -> ExitCode {
     let diagnostics = diagnose(resource, agent, scope);
     let report = Report::new(diagnostics);
     let output = match format {
-        Format::Human => report.human(),
+        Format::Human => report.human(
+            &human_context(resource, agent, scope),
+            if verbose {
+                HumanOptions::verbose()
+            } else {
+                HumanOptions::normal()
+            },
+        ),
         Format::Json => report.json().expect("diagnostics are JSON serializable"),
     };
 
@@ -90,6 +97,43 @@ fn validate_render_options(format: Format, verbose: bool) -> Result<(), &'static
         return Err("--verbose cannot be used with --format json");
     }
     Ok(())
+}
+
+impl Resource {
+    fn heading(self) -> &'static str {
+        match self {
+            Self::Manifest => "Manifest",
+            Self::Config => "Config",
+            Self::Instructions => "Instructions",
+            Self::Skills => "Skills",
+            Self::Prompts => "Prompts",
+            Self::Commands => "Commands",
+            Self::Rules => "Rules",
+            Self::Hooks => "Hooks",
+            Self::Mcp => "MCP",
+            Self::Statusline => "Statusline",
+        }
+    }
+}
+
+fn human_context(
+    resource: Option<Resource>,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> HumanContext {
+    let resource = resource.unwrap_or(Resource::Manifest);
+    let mut context = HumanContext::new(resource.heading());
+    if resource != Resource::Manifest {
+        if let Some(scope) = scope {
+            context = context.with_qualifier(format!("{scope} scope"));
+        }
+        if let Some(agent) = agent {
+            context = context.with_qualifier(format!("{agent} agent"));
+        } else if resource == Resource::Skills {
+            context = context.with_section_count("agent", "agents", "all agents");
+        }
+    }
+    context
 }
 
 fn diagnose(

--- a/tooling/arnes/src/skills.rs
+++ b/tooling/arnes/src/skills.rs
@@ -1,5 +1,5 @@
 use crate::Roots;
-use crate::diagnostic::{Diagnostic, State};
+use crate::diagnostic::{Diagnostic, HumanSection, State};
 use crate::manifest::{Agent, Manifest, Scope, SkillLayout, SkillProjection};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -21,12 +21,24 @@ pub fn diagnose(
         .filter(|(_, candidate)| scope.is_none_or(|scope| scope == *candidate))
         .collect::<Vec<_>>();
     if combinations.is_empty() {
-        return vec![unsupported(agent, scope)];
+        let diagnostic = unsupported(agent, scope);
+        return vec![match (agent, scope) {
+            (Some(agent), Some(scope)) => diagnostic.with_human_section(section(agent, scope)),
+            _ => diagnostic,
+        }];
     }
     combinations
         .into_iter()
-        .flat_map(|(agent, scope)| diagnose_one(roots, manifest, agent, scope))
+        .flat_map(|(agent, scope)| {
+            diagnose_one(roots, manifest, agent, scope)
+                .into_iter()
+                .map(move |diagnostic| diagnostic.with_human_section(section(agent, scope)))
+        })
         .collect()
+}
+
+fn section(agent: Agent, scope: Scope) -> HumanSection {
+    HumanSection::new(format!("{agent}:{scope}"), agent.to_string().to_uppercase())
 }
 
 fn diagnose_one(roots: &Roots, manifest: &Manifest, agent: Agent, scope: Scope) -> Vec<Diagnostic> {

--- a/tooling/arnes/src/skills/projection.rs
+++ b/tooling/arnes/src/skills/projection.rs
@@ -30,7 +30,7 @@ pub fn leaf(roots: &Roots, resource: &SkillProjection<'_>, name: &str) -> Diagno
     {
         Ok(()) => Diagnostic::new("skills", State::Healthy, format!("{subject} is current"))
             .with_human_summary(name),
-        Err(diagnostic) => diagnostic.with_human_summary(name),
+        Err(diagnostic) => diagnostic,
     }
 }
 
@@ -88,7 +88,7 @@ fn root_skill(
     match result {
         Ok(()) => Diagnostic::new("skills", State::Healthy, format!("{subject} is current"))
             .with_human_summary(name.display().to_string()),
-        Err(diagnostic) => diagnostic.with_human_summary(name.display().to_string()),
+        Err(diagnostic) => diagnostic,
     }
 }
 

--- a/tooling/arnes/src/skills/projection.rs
+++ b/tooling/arnes/src/skills/projection.rs
@@ -1,6 +1,6 @@
 use super::references;
 use crate::Roots;
-use crate::diagnostic::{Diagnostic, State};
+use crate::diagnostic::{Diagnostic, HumanDetail, State};
 use crate::files::paths::{ancestor_within, canonical_within, destination, label};
 use crate::manifest::{Scope, SkillProjection};
 use std::fs;
@@ -17,11 +17,20 @@ pub fn leaf(roots: &Roots, resource: &SkillProjection<'_>, name: &str) -> Diagno
     );
     let source = roots.repository().join(resource.source).join(name);
     let destination = destination(roots, resource.scope, &installed);
-    match expected_link(roots, resource.scope, &source, &destination, &subject)
-        .and_then(|_| references::validate(&destination, &subject))
+    let human = ProjectionHuman::new(name, label(resource.scope, &installed));
+    match expected_link(
+        roots,
+        resource.scope,
+        &source,
+        &destination,
+        &subject,
+        &human,
+    )
+    .and_then(|_| references::validate(&destination, &subject))
     {
-        Ok(()) => Diagnostic::new("skills", State::Healthy, format!("{subject} is current")),
-        Err(diagnostic) => diagnostic,
+        Ok(()) => Diagnostic::new("skills", State::Healthy, format!("{subject} is current"))
+            .with_human_summary(name),
+        Err(diagnostic) => diagnostic.with_human_summary(name),
     }
 }
 
@@ -38,7 +47,18 @@ pub fn root(
         resource.scope,
         label(resource.scope, resource.destination)
     );
-    expected_link(roots, resource.scope, &source, &destination, &subject)?;
+    let human = ProjectionHuman::new(
+        "managed skills projection",
+        label(resource.scope, resource.destination),
+    );
+    expected_link(
+        roots,
+        resource.scope,
+        &source,
+        &destination,
+        &subject,
+        &human,
+    )?;
     Ok(skills
         .iter()
         .map(|name| root_skill(roots, resource, &source, &destination, Path::new(name)))
@@ -66,8 +86,33 @@ fn root_skill(
         .and_then(|expected| same_target(&installed, &expected, &subject))
         .and_then(|_| references::validate(&installed, &subject));
     match result {
-        Ok(()) => Diagnostic::new("skills", State::Healthy, format!("{subject} is current")),
-        Err(diagnostic) => diagnostic,
+        Ok(()) => Diagnostic::new("skills", State::Healthy, format!("{subject} is current"))
+            .with_human_summary(name.display().to_string()),
+        Err(diagnostic) => diagnostic.with_human_summary(name.display().to_string()),
+    }
+}
+
+struct ProjectionHuman {
+    summary: String,
+    path: String,
+}
+
+impl ProjectionHuman {
+    fn new(summary: impl Into<String>, path: impl Into<String>) -> Self {
+        Self {
+            summary: summary.into(),
+            path: path.into(),
+        }
+    }
+
+    fn missing_destination(&self, diagnostic: Diagnostic) -> Diagnostic {
+        diagnostic
+            .with_human_summary(&self.summary)
+            .with_human_details([
+                HumanDetail::new("expected", "managed skill present"),
+                HumanDetail::new("actual", "destination missing"),
+                HumanDetail::new("path", &self.path),
+            ])
     }
 }
 
@@ -77,6 +122,7 @@ fn expected_link(
     source: &Path,
     destination: &Path,
     subject: &str,
+    human: &ProjectionHuman,
 ) -> Result<(), Diagnostic> {
     let expected = source_directory(source, roots.repository(), subject)?;
     let boundary = match scope {
@@ -94,11 +140,11 @@ fn expected_link(
         ));
     }
     let metadata = fs::symlink_metadata(destination).map_err(|error| match error.kind() {
-        ErrorKind::NotFound => broken(
+        ErrorKind::NotFound => human.missing_destination(broken(
             subject,
             State::Drift,
             format!("destination {} is missing", destination.display()),
-        ),
+        )),
         _ => broken(
             subject,
             State::Error,

--- a/tooling/arnes/tests/cli.rs
+++ b/tooling/arnes/tests/cli.rs
@@ -76,7 +76,7 @@ fn doctor_accepts_shared_options_without_reading_the_environment() {
     assert_eq!(output.status.code(), Some(0));
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
-        "unsupported skills: codex project skill projection is not declared or supported\n\ncodex project unsupported capabilities\n  unsupported system skills inventory is unsupported\nunsupported skills: external codex project plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=project plugin activation has no documented filesystem registry\n"
+        "Skills · project scope · codex agent\n✓ 0 healthy\n! 3 unsupported (non-blocking)\n\nCODEX\n  3 unsupported · 0 healthy\n\n  UNSUPPORTED codex project skill projection is not declared or supported\n  codex project unsupported capabilities\n    UNSUPPORTED system skills inventory is unsupported\n  UNSUPPORTED external codex project plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=project plugin activation has no documented filesystem registry\n"
     );
     assert!(output.stderr.is_empty());
 }
@@ -99,12 +99,12 @@ fn json_doctor_emits_the_manifest_diagnostic() {
 fn manifest_doctor_loads_from_the_injected_home() {
     let fixture = Fixture::new();
     fixture.write_home(".arnes.yaml", &manifest("valid.yaml"));
-    let output = fixture.command(["doctor", "manifest"]);
+    let output = fixture.command(["doctor", "manifest", "-v"]);
 
     assert_eq!(output.status.code(), Some(0));
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
-        "healthy manifest: manifest is valid\n"
+        "Manifest\n✓ 1 healthy\n\nhealthy manifest: manifest is valid\n"
     );
     assert!(output.stderr.is_empty());
 }
@@ -118,7 +118,7 @@ fn manifest_doctor_reports_invalid_manifests() {
     assert_eq!(output.status.code(), Some(2));
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
-        "error manifest: version: unsupported version 2; expected 1\n"
+        "Manifest\n✓ 0 healthy\n\nerror manifest: version: unsupported version 2; expected 1\n"
     );
     assert!(output.stderr.is_empty());
 }
@@ -166,7 +166,7 @@ fn manifest_doctor_requires_home_without_reading_the_environment() {
     assert_eq!(output.status.code(), Some(2));
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
-        "error manifest: HOME: environment variable is required\n"
+        "Manifest\n✓ 0 healthy\n\nerror manifest: HOME: environment variable is required\n"
     );
     assert!(output.stderr.is_empty());
 }
@@ -178,7 +178,7 @@ fn skills_doctor_requires_injected_home_without_fallback() {
     assert_eq!(output.status.code(), Some(2));
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
-        "error skills: HOME: environment variable is required\n"
+        "Skills · user scope · all agents\n✓ 0 healthy\n\nerror skills: HOME: environment variable is required\n"
     );
     assert!(output.stderr.is_empty());
 }
@@ -197,7 +197,7 @@ fn manifest_doctor_rejects_home_paths_relative_to_the_repository() {
         assert_eq!(output.status.code(), Some(2));
         assert_eq!(
             String::from_utf8(output.stdout).unwrap(),
-            format!("error manifest: {message}\n")
+            format!("Manifest\n✓ 0 healthy\n\nerror manifest: {message}\n")
         );
         assert!(output.stderr.is_empty());
     }

--- a/tooling/arnes/tests/commands.rs
+++ b/tooling/arnes/tests/commands.rs
@@ -15,7 +15,9 @@ fn claude_user_and_project_bindings_are_healthy() {
         let fixture = configured_fixture();
         let (code, stdout, stderr) = run(
             &fixture,
-            &["doctor", "commands", "--agent", "claude", "--scope", scope],
+            &[
+                "doctor", "commands", "--agent", "claude", "--scope", scope, "-v",
+            ],
         );
 
         assert_eq!(code, 0, "{stdout}");
@@ -54,7 +56,7 @@ fn doctor_commands_routes_root_errors_to_commands() {
     let (code, stdout, stderr) = output_tuple(output);
 
     assert_eq!(code, 2);
-    assert!(stdout.starts_with("error commands:"));
+    assert!(stdout.contains("error commands:"));
     assert!(stderr.is_empty());
 }
 
@@ -128,7 +130,7 @@ fn filters_exclude_bindings_before_io() {
     let (code, stdout, stderr) = run(
         &fixture,
         &[
-            "doctor", "commands", "--agent", "claude", "--scope", "project",
+            "doctor", "commands", "--agent", "claude", "--scope", "project", "-v",
         ],
     );
 
@@ -179,7 +181,7 @@ fn diagnostics_preserve_command_then_binding_order() {
         fixture.write_repository(format!("harness/prompts/{name}.md"), CONTENTS);
         fixture.write_home(format!(".claude/commands/{name}.md"), CONTENTS);
     }
-    let (_, human, _) = run(&fixture, &["doctor", "commands", "--scope", "user"]);
+    let (_, human, _) = run(&fixture, &["doctor", "commands", "--scope", "user", "-v"]);
     let positions = [
         "zeta · current",
         "capability · unsupported",
@@ -229,7 +231,7 @@ fn crlf_frontmatter_is_supported() {
     let (code, stdout, stderr) = run(
         &fixture,
         &[
-            "doctor", "commands", "--agent", "claude", "--scope", "project",
+            "doctor", "commands", "--agent", "claude", "--scope", "project", "-v",
         ],
     );
 

--- a/tooling/arnes/tests/config.rs
+++ b/tooling/arnes/tests/config.rs
@@ -48,10 +48,10 @@ fn run(fixture: &Fixture, args: &[&str]) -> (i32, String, String) {
 #[test]
 fn user_scope_is_default_and_accepts_unknown_keys() {
     let fixture = configured_fixture();
-    let (code, stdout, stderr) = run(&fixture, &["doctor", "config"]);
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "config", "-v"]);
 
     assert_eq!(code, 0);
-    assert_eq!(stdout.lines().count(), 3);
+    assert_eq!(stdout.matches("healthy config:").count(), 3);
     assert!(stderr.is_empty());
     for expected in [
         "healthy config: claude user",
@@ -69,27 +69,29 @@ fn agent_and_scope_filters_isolate_selected_configurations() {
 
     for (args, expected_lines, expected) in [
         (
-            vec!["doctor", "config", "--agent", "codex", "--scope", "user"],
+            vec![
+                "doctor", "config", "--agent", "codex", "--scope", "user", "-v",
+            ],
             1,
             "healthy config: codex user",
         ),
         (
-            vec!["doctor", "config", "--agent", "claude"],
+            vec!["doctor", "config", "--agent", "claude", "-v"],
             1,
             "healthy config: claude user",
         ),
     ] {
         let (code, stdout, stderr) = run(&fixture, &args);
         assert_eq!(code, 0);
-        assert_eq!(stdout.lines().count(), expected_lines);
+        assert_eq!(stdout.matches("healthy config:").count(), expected_lines);
         assert!(stdout.contains(expected), "{stdout}");
         assert!(!stdout.contains("cursor"), "{stdout}");
         assert!(stderr.is_empty());
     }
 
-    let (code, stdout, _) = run(&fixture, &["doctor", "config", "--scope", "project"]);
+    let (code, stdout, _) = run(&fixture, &["doctor", "config", "--scope", "project", "-v"]);
     assert_eq!(code, 2);
-    assert_eq!(stdout.lines().count(), 3);
+    assert_eq!(stdout.matches(" config:").count(), 3);
     assert!(stdout.contains("error config: cursor project"));
     assert!(!stdout.contains("cursor user"));
 }
@@ -212,7 +214,7 @@ fn undeclared_filtered_combinations_are_unsupported() {
     assert_eq!(code, 0);
     assert_eq!(
         stdout,
-        "unsupported config: codex project configuration is not declared in the manifest\n"
+        "Config · project scope · codex agent\n✓ 0 healthy\n! 1 unsupported (non-blocking)\n\nunsupported config: codex project configuration is not declared in the manifest\n"
     );
     assert!(stderr.is_empty());
 }
@@ -230,7 +232,7 @@ fn empty_manifests_are_explicitly_unsupported() {
         assert_eq!(code, 0);
         assert_eq!(
             stdout,
-            "unsupported config: user configuration scope is not declared in the manifest\n"
+            "Config · user scope\n✓ 0 healthy\n! 1 unsupported (non-blocking)\n\nunsupported config: user configuration scope is not declared in the manifest\n"
         );
         assert!(stderr.is_empty());
     }
@@ -244,7 +246,7 @@ fn manifest_failures_fail_closed_as_config_errors() {
     assert_eq!(code, 2);
     assert_eq!(
         stdout,
-        "error config: manifest: .arnes.yaml was not found\n"
+        "Config · user scope\n✓ 0 healthy\n\nerror config: manifest: .arnes.yaml was not found\n"
     );
     assert!(stderr.is_empty());
 }

--- a/tooling/arnes/tests/diagnostic.rs
+++ b/tooling/arnes/tests/diagnostic.rs
@@ -1,4 +1,4 @@
-use arnes::diagnostic::{Diagnostic, Report, State};
+use arnes::diagnostic::{Diagnostic, HumanContext, HumanOptions, Report, State};
 
 fn report() -> Report {
     Report::new(vec![
@@ -13,11 +13,51 @@ fn report() -> Report {
     ])
 }
 
+fn context() -> HumanContext {
+    HumanContext::new("Diagnostics")
+}
+
 #[test]
-fn human_output_matches_the_exact_fixture() {
+fn normal_human_output_hides_healthy_details() {
     assert_eq!(
-        format!("{}\n", report().human()),
+        format!("{}\n", report().human(&context(), HumanOptions::normal())),
         include_str!("fixtures/diagnostic/report.txt")
+    );
+}
+
+#[test]
+fn verbose_human_output_includes_healthy_details() {
+    assert_eq!(
+        format!(
+            "{}\n",
+            report().human(&context(), HumanOptions::verbose())
+        ),
+        include_str!("fixtures/diagnostic/report-verbose.txt")
+    );
+}
+
+#[test]
+fn empty_human_report_does_not_claim_health() {
+    let report = Report::new(Vec::new());
+
+    assert_eq!(
+        report.human(&context(), HumanOptions::normal()),
+        "No diagnostics"
+    );
+}
+
+#[test]
+fn report_without_healthy_diagnostics_displays_zero() {
+    let report = Report::new(vec![Diagnostic::new(
+        "skills",
+        State::Unsupported,
+        "inventory unavailable",
+    )]);
+
+    assert!(
+        report
+            .human(&context(), HumanOptions::normal())
+            .starts_with("Diagnostics\n✓ 0 healthy\n")
     );
 }
 
@@ -82,8 +122,8 @@ fn human_groups_compact_diagnostics_without_changing_json() {
     ]);
 
     assert_eq!(
-        report.human(),
-        "claude user external skills\n  healthy     ponytail · allowed\n  drift       ponytail-audit · unexpected"
+        report.human(&context(), HumanOptions::verbose()),
+        "Diagnostics\n✓ 1 healthy\n\nclaude user external skills\n  healthy     ponytail · allowed\n  drift       ponytail-audit · unexpected"
     );
     let json = report.json().unwrap();
     assert!(json.contains("verbose first"));

--- a/tooling/arnes/tests/diagnostic.rs
+++ b/tooling/arnes/tests/diagnostic.rs
@@ -1,4 +1,4 @@
-use arnes::diagnostic::{Diagnostic, HumanContext, HumanOptions, Report, State};
+use arnes::diagnostic::{Diagnostic, HumanContext, HumanOptions, HumanSection, Report, State};
 
 fn report() -> Report {
     Report::new(vec![
@@ -17,6 +17,10 @@ fn context() -> HumanContext {
     HumanContext::new("Diagnostics")
 }
 
+fn section(key: &str, label: &str) -> HumanSection {
+    HumanSection::new(key, label)
+}
+
 #[test]
 fn normal_human_output_hides_healthy_details() {
     assert_eq!(
@@ -28,10 +32,7 @@ fn normal_human_output_hides_healthy_details() {
 #[test]
 fn verbose_human_output_includes_healthy_details() {
     assert_eq!(
-        format!(
-            "{}\n",
-            report().human(&context(), HumanOptions::verbose())
-        ),
+        format!("{}\n", report().human(&context(), HumanOptions::verbose())),
         include_str!("fixtures/diagnostic/report-verbose.txt")
     );
 }
@@ -128,4 +129,62 @@ fn human_groups_compact_diagnostics_without_changing_json() {
     let json = report.json().unwrap();
     assert!(json.contains("verbose first"));
     assert!(!json.contains("ponytail · allowed"));
+}
+
+#[test]
+fn structured_sections_sort_by_severity_without_mutating_report_order() {
+    let report = Report::new(vec![
+        Diagnostic::new("skills", State::Unsupported, "claude limitation")
+            .with_human_section(section("claude:user", "CLAUDE")),
+        Diagnostic::new("skills", State::Healthy, "cursor current")
+            .with_human_section(section("cursor:user", "CURSOR")),
+        Diagnostic::new("skills", State::Drift, "cursor missing")
+            .with_human_section(section("cursor:user", "CURSOR")),
+    ]);
+
+    let output = report.human(&context(), HumanOptions::normal());
+
+    assert!(output.find("CURSOR").unwrap() < output.find("CLAUDE").unwrap());
+    assert!(!output.contains("cursor current"));
+    assert_eq!(
+        report
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str())
+            .collect::<Vec<_>>(),
+        ["claude limitation", "cursor current", "cursor missing"]
+    );
+}
+
+#[test]
+fn verbose_places_healthy_diagnostics_after_other_states() {
+    let report = Report::new(vec![
+        Diagnostic::new("skills", State::Healthy, "current")
+            .with_human_section(section("cursor:user", "CURSOR")),
+        Diagnostic::new("skills", State::Unsupported, "inventory unavailable")
+            .with_human_section(section("cursor:user", "CURSOR")),
+    ]);
+
+    let output = report.human(&context(), HumanOptions::verbose());
+
+    assert!(output.find("inventory unavailable").unwrap() < output.find("current").unwrap());
+}
+
+#[test]
+fn healthy_only_section_is_hidden_until_verbose() {
+    let report = Report::new(vec![
+        Diagnostic::new("skills", State::Healthy, "claude current")
+            .with_human_section(section("claude:user", "CLAUDE")),
+    ]);
+
+    assert!(
+        !report
+            .human(&context(), HumanOptions::normal())
+            .contains("CLAUDE")
+    );
+    assert!(
+        report
+            .human(&context(), HumanOptions::verbose())
+            .contains("CLAUDE")
+    );
 }

--- a/tooling/arnes/tests/external_claude_plugins.rs
+++ b/tooling/arnes/tests/external_claude_plugins.rs
@@ -70,7 +70,9 @@ fn active_allowlisted_plugin_and_skill_are_external_and_healthy() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "claude", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");
@@ -97,7 +99,7 @@ fn active_unexpected_plugin_reports_plugin_and_skill_policy_drift() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert_eq!(stdout.matches("  drift       ").count(), 2);
+    assert_eq!(stdout.matches("    DRIFT ").count(), 2);
     assert!(stdout.contains("plugin demo@marketplace"));
     assert!(stdout.contains("skill hello"));
     assert!(stdout.contains("· unexpected"));
@@ -116,7 +118,9 @@ fn plugin_allowlist_does_not_allow_new_skills_implicitly() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "claude", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 1, "{stdout}");
@@ -128,8 +132,8 @@ fn plugin_allowlist_does_not_allow_new_skills_implicitly() {
         .lines()
         .find(|line| line.contains("skill future-capability"))
         .unwrap();
-    assert!(plugin.trim_start().starts_with("healthy"));
-    assert!(skill.trim_start().starts_with("drift"));
+    assert!(plugin.trim_start().starts_with("HEALTHY"));
+    assert!(skill.trim_start().starts_with("DRIFT"));
 }
 
 #[test]
@@ -145,7 +149,9 @@ fn disabled_plugin_is_visible_without_being_reported_as_active() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "claude", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");

--- a/tooling/arnes/tests/external_codex_plugins.rs
+++ b/tooling/arnes/tests/external_codex_plugins.rs
@@ -39,7 +39,7 @@ fn codex_plugin_policy_uses_config_but_never_guesses_active_cache_version() {
 
     assert_eq!(code, 1, "{stdout}");
     assert!(stdout.contains("codex user plugin demo@marketplace@?"));
-    assert!(stdout.contains("drift       plugin · enabled · unknown · unexpected"));
+    assert!(stdout.contains("DRIFT plugin · enabled · unknown · unexpected"));
     assert!(stdout.contains("· enabled · unknown · unexpected"));
     assert!(stdout.contains("active cache version cannot be selected reliably"));
     assert!(!stdout.contains("orphan"));
@@ -60,7 +60,7 @@ fn allowed_or_disabled_codex_plugin_does_not_create_false_policy_drift() {
     );
     assert_eq!(code, 0, "{stdout}");
     assert!(stdout.contains("codex user plugin demo@marketplace@?"));
-    assert!(stdout.contains("unsupported plugin · enabled · unknown · allowed"));
+    assert!(stdout.contains("UNSUPPORTED plugin · enabled · unknown · allowed"));
     assert!(stdout.contains("· enabled · unknown · allowed"));
 
     fixture.write_home(".arnes.yaml", &manifest(false));
@@ -74,5 +74,5 @@ fn allowed_or_disabled_codex_plugin_does_not_create_false_policy_drift() {
     );
     assert_eq!(code, 0, "{stdout}");
     assert!(stdout.contains("· disabled · unknown · unexpected"));
-    assert!(!stdout.contains("drift       plugin"));
+    assert!(!stdout.contains("DRIFT plugin"));
 }

--- a/tooling/arnes/tests/external_cursor_plugins.rs
+++ b/tooling/arnes/tests/external_cursor_plugins.rs
@@ -52,7 +52,9 @@ fn active_allowlisted_cursor_plugin_and_skill_are_healthy() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "cursor", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");
@@ -73,7 +75,7 @@ fn active_unexpected_cursor_plugin_reports_plugin_and_skill() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert_eq!(stdout.matches("  drift       ").count(), 2);
+    assert_eq!(stdout.matches("    DRIFT ").count(), 2);
     assert!(stdout.contains("plugin cursor-demo"));
     assert!(stdout.contains("skill hello"));
 }
@@ -91,11 +93,13 @@ fn managed_system_and_plugin_slug_collisions_remain_distinct() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "cursor", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("managed cursor user skill alpha"));
+    assert!(stdout.contains("HEALTHY alpha"));
     assert!(stdout.contains("cursor user system skills"));
     assert!(stdout.contains("alpha · enabled · healthy · allowed"));
     assert!(stdout.contains("skill alpha · enabled · healthy · allowed"));

--- a/tooling/arnes/tests/external_managed_skills.rs
+++ b/tooling/arnes/tests/external_managed_skills.rs
@@ -29,7 +29,9 @@ fn allowed_external_managed_skill_is_healthy_and_not_adopted() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "codex", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");

--- a/tooling/arnes/tests/external_system_skills.rs
+++ b/tooling/arnes/tests/external_system_skills.rs
@@ -32,7 +32,9 @@ fn codex_system_skills_report_policy_without_claiming_runtime_activation() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "codex", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 1, "{stdout}");
@@ -57,7 +59,9 @@ fn disabled_system_skill_is_visible_but_not_active_or_drift() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "codex", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");
@@ -71,7 +75,9 @@ fn absent_roots_and_allowed_skills_do_not_drift() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "codex", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");
@@ -86,7 +92,9 @@ fn undeclared_system_mechanism_is_explicitly_unsupported() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "codex", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");
@@ -105,7 +113,9 @@ fn external_inventory_runs_without_a_managed_projection() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "codex", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");

--- a/tooling/arnes/tests/fixtures/diagnostic/report-verbose.txt
+++ b/tooling/arnes/tests/fixtures/diagnostic/report-verbose.txt
@@ -2,6 +2,7 @@ Diagnostics
 ✓ 1 healthy
 ! 1 unsupported (non-blocking)
 
+healthy manifest: manifest is valid
 unsupported rules: cursor does not expose native user rules
 drift skills: destination is missing
 error config: settings.json could not be read

--- a/tooling/arnes/tests/fixtures/skills/report-verbose.txt
+++ b/tooling/arnes/tests/fixtures/skills/report-verbose.txt
@@ -1,0 +1,24 @@
+Skills · user scope · 3 agents
+✓ 2 healthy
+! 3 unsupported (non-blocking)
+
+CURSOR
+  1 issue · 1 unsupported · 1 healthy
+
+  DRIFT enforcement-code
+    expected  managed skill present
+    actual    destination missing
+    path      ~/.cursor/skills/enforcement-code
+  UNSUPPORTED extension skill exposure
+  HEALTHY merge-verdict
+
+CLAUDE
+  1 unsupported · 1 healthy
+
+  UNSUPPORTED system skills inventory
+  HEALTHY handoff
+
+CODEX
+  1 unsupported · 0 healthy
+
+  UNSUPPORTED browser plugin version/cache

--- a/tooling/arnes/tests/fixtures/skills/report.txt
+++ b/tooling/arnes/tests/fixtures/skills/report.txt
@@ -1,0 +1,22 @@
+Skills · user scope · 3 agents
+✓ 2 healthy
+! 3 unsupported (non-blocking)
+
+CURSOR
+  1 issue · 1 unsupported · 1 healthy
+
+  DRIFT enforcement-code
+    expected  managed skill present
+    actual    destination missing
+    path      ~/.cursor/skills/enforcement-code
+  UNSUPPORTED extension skill exposure
+
+CLAUDE
+  1 unsupported · 1 healthy
+
+  UNSUPPORTED system skills inventory
+
+CODEX
+  1 unsupported · 0 healthy
+
+  UNSUPPORTED browser plugin version/cache

--- a/tooling/arnes/tests/human_cli.rs
+++ b/tooling/arnes/tests/human_cli.rs
@@ -39,9 +39,7 @@ fn verbose_json_is_rejected_before_home_is_read() {
 
 #[test]
 fn duplicate_format_is_rejected_by_clap() {
-    let output = run(&[
-        "doctor", "skills", "--format", "human", "--format", "json",
-    ]);
+    let output = run(&["doctor", "skills", "--format", "human", "--format", "json"]);
     let stderr = String::from_utf8(output.stderr).unwrap();
 
     assert_eq!(output.status.code(), Some(2));

--- a/tooling/arnes/tests/human_cli.rs
+++ b/tooling/arnes/tests/human_cli.rs
@@ -1,4 +1,7 @@
+mod support;
+
 use std::process::{Command, Output};
+use support::Fixture;
 
 fn run(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_arnes"))
@@ -45,4 +48,31 @@ fn duplicate_format_is_rejected_by_clap() {
     assert_eq!(output.status.code(), Some(2));
     assert!(output.stdout.is_empty());
     assert!(stderr.contains("cannot be used multiple times"), "{stderr}");
+}
+
+#[test]
+fn verbose_restores_healthy_details_before_or_after_the_resource() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", "version: 1\nagents: []\nresources: []\n");
+    assert!(fixture.home().is_dir());
+    assert!(fixture.repository().is_dir());
+    let before = fixture.snapshot();
+
+    let normal = fixture.command(["doctor", "manifest"]);
+    let verbose_before = fixture.command(["doctor", "-v", "manifest"]);
+    let verbose_after = fixture.command(["doctor", "manifest", "--verbose"]);
+
+    assert_eq!(
+        String::from_utf8(normal.stdout).unwrap(),
+        "Manifest\n✓ 1 healthy\n"
+    );
+    for output in [verbose_before, verbose_after] {
+        assert_eq!(output.status.code(), Some(0));
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            "Manifest\n✓ 1 healthy\n\nhealthy manifest: manifest is valid\n"
+        );
+        assert!(output.stderr.is_empty());
+    }
+    assert_eq!(fixture.snapshot(), before);
 }

--- a/tooling/arnes/tests/human_cli.rs
+++ b/tooling/arnes/tests/human_cli.rs
@@ -1,0 +1,50 @@
+use std::process::{Command, Output};
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_arnes"))
+        .args(args)
+        .env_clear()
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn doctor_help_lists_verbose_options() {
+    let output = run(&["doctor", "--help"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout.contains("-v, --verbose"), "{stdout}");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn verbose_json_is_rejected_before_home_is_read() {
+    for args in [
+        vec!["doctor", "skills", "-v", "--format", "json"],
+        vec!["doctor", "--verbose", "skills", "--format=json"],
+        vec!["doctor", "--format", "json", "skills", "-v"],
+    ] {
+        let output = run(&args);
+
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+        assert!(output.stdout.is_empty(), "{args:?}");
+        assert_eq!(
+            String::from_utf8(output.stderr).unwrap(),
+            "--verbose cannot be used with --format json\n",
+            "{args:?}"
+        );
+    }
+}
+
+#[test]
+fn duplicate_format_is_rejected_by_clap() {
+    let output = run(&[
+        "doctor", "skills", "--format", "human", "--format", "json",
+    ]);
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(stderr.contains("cannot be used multiple times"), "{stderr}");
+}

--- a/tooling/arnes/tests/human_commands.rs
+++ b/tooling/arnes/tests/human_commands.rs
@@ -1,0 +1,53 @@
+mod support;
+
+use support::Fixture;
+
+fn fixture() -> Fixture {
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        "version: 1
+agents:
+  - id: claude
+    scopes: [user]
+prompts:
+  - id: deploy
+    source: { root: repository, path: deploy.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: rendered
+        destination: { root: home, path: .claude/commands/deploy.md }
+commands:
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings:
+      - { agent: claude, scope: user }
+resources: []
+",
+    );
+    let contents = "---\ndescription: Deploy safely\n---\nDeploy now\n";
+    fixture.write_repository("deploy.md", contents);
+    fixture.write_home(".claude/commands/deploy.md", contents);
+    fixture
+}
+
+#[test]
+fn commands_hide_healthy_details_until_verbose() {
+    let fixture = fixture();
+    assert!(fixture.home().is_dir());
+    assert!(fixture.repository().is_dir());
+    let before = fixture.snapshot();
+    let normal = fixture.command(["doctor", "commands", "--agent", "claude"]);
+    let verbose = fixture.command(["doctor", "commands", "--agent", "claude", "-v"]);
+    let normal = String::from_utf8(normal.stdout).unwrap();
+    let verbose = String::from_utf8(verbose.stdout).unwrap();
+
+    assert!(normal.starts_with("Commands · user scope · claude agent\n✓ 1 healthy\n"));
+    assert!(!normal.contains("deploy · current"));
+    assert!(verbose.contains("healthy     deploy · current"));
+    assert_eq!(fixture.snapshot(), before);
+}

--- a/tooling/arnes/tests/human_skills.rs
+++ b/tooling/arnes/tests/human_skills.rs
@@ -1,0 +1,102 @@
+#[path = "support/skills.rs"]
+mod skill_support;
+mod support;
+
+use arnes::diagnostic::{
+    Diagnostic, HumanContext, HumanDetail, HumanOptions, HumanSection, Report, State,
+};
+use skill_support::{configured_fixture, run};
+
+fn section(key: &str, label: &str) -> HumanSection {
+    HumanSection::new(key, label)
+}
+
+fn diagnostic(section: HumanSection, state: State, message: &str, summary: &str) -> Diagnostic {
+    Diagnostic::new("skills", state, message)
+        .with_human_summary(summary)
+        .with_human_section(section)
+}
+
+fn report() -> Report {
+    let claude = section("claude:user", "CLAUDE");
+    let cursor = section("cursor:user", "CURSOR");
+    let codex = section("codex:user", "CODEX");
+    Report::new(vec![
+        diagnostic(claude.clone(), State::Healthy, "handoff current", "handoff"),
+        diagnostic(
+            claude,
+            State::Unsupported,
+            "system skills inventory is unsupported",
+            "system skills inventory",
+        ),
+        diagnostic(
+            cursor.clone(),
+            State::Healthy,
+            "merge-verdict current",
+            "merge-verdict",
+        ),
+        diagnostic(
+            cursor.clone(),
+            State::Unsupported,
+            "extension skill exposure unavailable",
+            "extension skill exposure",
+        ),
+        diagnostic(
+            cursor,
+            State::Drift,
+            "destination is missing",
+            "enforcement-code",
+        )
+        .with_human_details([
+            HumanDetail::new("expected", "managed skill present"),
+            HumanDetail::new("actual", "destination missing"),
+            HumanDetail::new("path", "~/.cursor/skills/enforcement-code"),
+        ]),
+        diagnostic(
+            codex,
+            State::Unsupported,
+            "browser plugin version unavailable",
+            "browser plugin version/cache",
+        ),
+    ])
+}
+
+fn context() -> HumanContext {
+    HumanContext::new("Skills")
+        .with_qualifier("user scope")
+        .with_section_count("agent", "agents", "all agents")
+}
+
+#[test]
+fn normal_skills_output_matches_the_exact_fixture() {
+    assert_eq!(
+        format!("{}\n", report().human(&context(), HumanOptions::normal())),
+        include_str!("fixtures/skills/report.txt")
+    );
+}
+
+#[test]
+fn verbose_skills_output_matches_the_exact_fixture() {
+    assert_eq!(
+        format!("{}\n", report().human(&context(), HumanOptions::verbose())),
+        include_str!("fixtures/skills/report-verbose.txt")
+    );
+}
+
+#[test]
+fn skills_doctor_attaches_agent_sections_without_reading_real_home() {
+    let fixture = configured_fixture();
+    std::fs::remove_file(fixture.home().join(".claude/skills/alpha")).unwrap();
+    skill_support::link_home_relative(&fixture, ".agents/skills/alpha", ".claude/skills/alpha");
+    std::fs::remove_file(fixture.home().join(".cursor/skills/alpha")).unwrap();
+
+    let (code, normal, stderr) = run(&fixture, &["doctor", "skills"]);
+    let (_, verbose, verbose_stderr) = run(&fixture, &["doctor", "skills", "-v"]);
+
+    assert_eq!(code, 1, "{normal}");
+    assert!(normal.find("CURSOR").unwrap() < normal.find("CLAUDE").unwrap());
+    assert!(!normal.contains("HEALTHY"));
+    assert!(verbose.contains("HEALTHY"));
+    assert!(stderr.is_empty());
+    assert!(verbose_stderr.is_empty());
+}

--- a/tooling/arnes/tests/instruction_adversarial.rs
+++ b/tooling/arnes/tests/instruction_adversarial.rs
@@ -32,6 +32,7 @@ fn relative_symlinks_to_expected_sources_are_healthy() {
             "claude",
             "--scope",
             "user",
+            "-v",
         ],
     );
 
@@ -66,6 +67,7 @@ fn source_and_include_symlinks_within_the_repository_are_healthy() {
                 "claude",
                 "--scope",
                 "user",
+                "-v",
             ],
         );
 
@@ -90,6 +92,7 @@ fn dangling_source_includes_fail_closed() {
             "codex",
             "--scope",
             "user",
+            "-v",
         ],
     );
 
@@ -194,6 +197,7 @@ fn markdown_code_does_not_create_includes() {
             "claude",
             "--scope",
             "user",
+            "-v",
         ],
     );
 

--- a/tooling/arnes/tests/instruction_failures.rs
+++ b/tooling/arnes/tests/instruction_failures.rs
@@ -18,6 +18,7 @@ fn missing_sources_fail_closed_and_missing_destinations_drift() {
             "claude",
             "--scope",
             "user",
+            "-v",
         ],
     );
     assert_eq!(code, 2);
@@ -139,6 +140,7 @@ fn includes_resolve_from_the_effective_destination() {
             "claude",
             "--scope",
             "user",
+            "-v",
         ],
     );
 
@@ -195,7 +197,7 @@ fn manifest_failures_fail_closed_as_instruction_errors() {
     assert_eq!(code, 2);
     assert_eq!(
         stdout,
-        "error instructions: manifest: .arnes.yaml was not found\n"
+        "Instructions · user scope\n✓ 0 healthy\n\nerror instructions: manifest: .arnes.yaml was not found\n"
     );
     assert!(stderr.is_empty());
 }

--- a/tooling/arnes/tests/instructions.rs
+++ b/tooling/arnes/tests/instructions.rs
@@ -9,10 +9,9 @@ use support::Fixture;
 #[test]
 fn user_scope_is_default_for_supported_and_unsupported_projections() {
     let fixture = configured_fixture();
-    let (code, stdout, stderr) = run(&fixture, &["doctor", "instructions"]);
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "instructions", "-v"]);
 
     assert_eq!(code, 0);
-    assert_eq!(stdout.lines().count(), 5);
     assert_eq!(stdout.matches("healthy instructions:").count(), 4);
     assert_eq!(stdout.matches("unsupported instructions:").count(), 1);
     for expected in [
@@ -41,10 +40,11 @@ fn agent_and_scope_filters_isolate_projections() {
             "claude",
             "--scope",
             "user",
+            "-v",
         ],
     );
     assert_eq!(code, 0);
-    assert_eq!(stdout.lines().count(), 3);
+    assert_eq!(stdout.matches("healthy instructions:").count(), 3);
     assert!(!stdout.contains("codex"));
 
     let (code, stdout, _) = run(&fixture, &["doctor", "instructions", "--agent", "cursor"]);
@@ -63,7 +63,7 @@ fn agent_and_scope_filters_isolate_projections() {
         ],
     );
     assert_eq!(code, 0);
-    assert_eq!(stdout.lines().count(), 1);
+    assert_eq!(stdout.matches("unsupported instructions:").count(), 1);
     assert!(stdout.contains("unsupported instructions: codex project"));
 }
 
@@ -79,7 +79,7 @@ fn undeclared_filtered_combinations_are_unsupported() {
     assert_eq!(code, 0);
     assert_eq!(
         stdout,
-        "unsupported instructions: codex user instruction projection is not declared or supported\n"
+        "Instructions · user scope · codex agent\n✓ 0 healthy\n! 1 unsupported (non-blocking)\n\nunsupported instructions: codex user instruction projection is not declared or supported\n"
     );
     assert!(stderr.is_empty());
 }
@@ -142,5 +142,5 @@ fn doctor_without_resource_does_not_aggregate_instructions_yet() {
     let (code, stdout, _) = run(&fixture, &["doctor"]);
 
     assert_eq!(code, 0);
-    assert_eq!(stdout, "healthy manifest: manifest is valid\n");
+    assert_eq!(stdout, "Manifest\n✓ 1 healthy\n");
 }

--- a/tooling/arnes/tests/prompts.rs
+++ b/tooling/arnes/tests/prompts.rs
@@ -12,7 +12,9 @@ fn direct_project_files_are_healthy_for_claude_and_cursor() {
         let fixture = configured_fixture();
         let (code, stdout, stderr) = run(
             &fixture,
-            &["doctor", "prompts", "--agent", agent, "--scope", "project"],
+            &[
+                "doctor", "prompts", "--agent", agent, "--scope", "project", "-v",
+            ],
         );
 
         assert_eq!(code, 0, "{stdout}");
@@ -33,7 +35,7 @@ fn prompt_content_does_not_validate_command_names_or_metadata() {
     let (code, stdout, stderr) = run(
         &fixture,
         &[
-            "doctor", "prompts", "--agent", "claude", "--scope", "project",
+            "doctor", "prompts", "--agent", "claude", "--scope", "project", "-v",
         ],
     );
 
@@ -47,7 +49,9 @@ fn rendered_user_file_resolves_nested_includes_and_declared_variables() {
     let fixture = configured_fixture();
     let (code, stdout, stderr) = run(
         &fixture,
-        &["doctor", "prompts", "--agent", "claude", "--scope", "user"],
+        &[
+            "doctor", "prompts", "--agent", "claude", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");
@@ -83,7 +87,7 @@ fn supported_combinations_without_managed_projections_are_explicitly_unsupported
     let (code, stdout, stderr) = run(
         &fixture,
         &[
-            "doctor", "prompts", "--agent", "claude", "--scope", "project",
+            "doctor", "prompts", "--agent", "claude", "--scope", "project", "-v",
         ],
     );
 
@@ -103,7 +107,7 @@ fn symlink_representation_is_unsupported_without_inspecting_its_source() {
     let (code, stdout, _) = run(
         &fixture,
         &[
-            "doctor", "prompts", "--agent", "claude", "--scope", "project",
+            "doctor", "prompts", "--agent", "claude", "--scope", "project", "-v",
         ],
     );
 
@@ -127,7 +131,7 @@ fn filters_prevent_io_for_unselected_prompt_projections() {
     let (code, stdout, _) = run(
         &fixture,
         &[
-            "doctor", "prompts", "--agent", "claude", "--scope", "project",
+            "doctor", "prompts", "--agent", "claude", "--scope", "project", "-v",
         ],
     );
 
@@ -153,7 +157,7 @@ fn human_and_json_preserve_manifest_prompt_order() {
     let (_, human, _) = run(
         &fixture,
         &[
-            "doctor", "prompts", "--agent", "claude", "--scope", "project",
+            "doctor", "prompts", "--agent", "claude", "--scope", "project", "-v",
         ],
     );
     let (_, json, _) = run(
@@ -198,6 +202,6 @@ fn doctor_without_resource_still_reports_only_the_manifest() {
     let (code, stdout, stderr) = run(&fixture, &["doctor"]);
 
     assert_eq!(code, 0);
-    assert_eq!(stdout, "healthy manifest: manifest is valid\n");
+    assert_eq!(stdout, "Manifest\n✓ 1 healthy\n");
     assert!(stderr.is_empty());
 }

--- a/tooling/arnes/tests/skill_adversarial.rs
+++ b/tooling/arnes/tests/skill_adversarial.rs
@@ -15,11 +15,13 @@ fn relative_symlinks_to_declared_sources_are_managed() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "claude", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "claude", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("healthy skills: managed claude user skill alpha"));
+    assert!(stdout.contains("HEALTHY alpha"));
 }
 
 #[test]
@@ -32,7 +34,9 @@ fn source_components_cannot_escape_the_repository() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "cursor", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 2);
@@ -108,12 +112,14 @@ fn undeclared_aliases_of_managed_sources_remain_unmanaged() {
 
     let (code, stdout, _) = run(
         &fixture,
-        &["doctor", "skills", "--agent", "cursor", "--scope", "user"],
+        &[
+            "doctor", "skills", "--agent", "cursor", "--scope", "user", "-v",
+        ],
     );
 
     assert_eq!(code, 1, "{stdout}");
     assert!(stdout.contains("plugin-owned · managed · enabled · healthy · unexpected"));
-    assert_eq!(stdout.matches("managed cursor user skill alpha").count(), 1);
+    assert_eq!(stdout.matches("HEALTHY alpha").count(), 1);
 }
 
 #[test]

--- a/tooling/arnes/tests/skill_failures.rs
+++ b/tooling/arnes/tests/skill_failures.rs
@@ -15,8 +15,8 @@ fn missing_skills_and_projection_destinations_are_broken() {
         &["doctor", "skills", "--agent", "claude", "--scope", "user"],
     );
     assert_eq!(code, 1);
-    assert!(stdout.contains("broken managed claude user skill alpha"));
-    assert!(stdout.contains("is missing"));
+    assert!(stdout.contains("DRIFT alpha"));
+    assert!(stdout.contains("actual    destination missing"));
 
     let fixture = configured_fixture();
     fs::remove_file(fixture.repository().join(".claude/skills")).unwrap();
@@ -27,8 +27,8 @@ fn missing_skills_and_projection_destinations_are_broken() {
         ],
     );
     assert_eq!(code, 1);
-    assert!(stdout.contains("broken managed claude project skills projection"));
-    assert!(stdout.contains("is missing"));
+    assert!(stdout.contains("DRIFT managed skills projection"));
+    assert!(stdout.contains("actual    destination missing"));
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn manifest_failures_fail_closed_as_skill_errors() {
     assert_eq!(code, 2);
     assert_eq!(
         stdout,
-        "error skills: version: unsupported version 2; expected 1\n"
+        "Skills · user scope · all agents\n✓ 0 healthy\n\nerror skills: version: unsupported version 2; expected 1\n"
     );
     assert!(stderr.is_empty());
 }

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -8,16 +8,12 @@ use support::Fixture;
 #[test]
 fn user_scope_is_default_for_declared_skills() {
     let fixture = configured_fixture();
-    let (code, stdout, stderr) = run(&fixture, &["doctor", "skills"]);
+    let (code, stdout, stderr) = run(&fixture, &["doctor", "skills", "-v"]);
 
     assert_eq!(code, 0, "{stdout}");
-    assert_eq!(stdout.matches("healthy skills: managed").count(), 3);
+    assert_eq!(stdout.matches("  HEALTHY alpha").count(), 3);
     assert!(!stdout.contains(" project "));
-    for expected in [
-        "managed claude user skill alpha",
-        "managed cursor user skill alpha",
-        "managed codex user skill alpha",
-    ] {
+    for expected in ["CLAUDE", "CURSOR", "CODEX"] {
         assert!(stdout.contains(expected), "missing {expected}: {stdout}");
     }
     assert!(stderr.is_empty());
@@ -29,7 +25,7 @@ fn agent_and_scope_filters_isolate_skill_projections() {
     let (code, stdout, _) = run(
         &fixture,
         &[
-            "doctor", "skills", "--agent", "cursor", "--scope", "project",
+            "doctor", "skills", "--agent", "cursor", "--scope", "project", "-v",
         ],
     );
 
@@ -37,31 +33,23 @@ fn agent_and_scope_filters_isolate_skill_projections() {
     assert_eq!(
         stdout
             .lines()
-            .filter(|line| line.starts_with("healthy skills: managed cursor project"))
+            .filter(|line| line.trim_start().starts_with("HEALTHY alpha"))
             .count(),
         1
     );
     assert_eq!(
         stdout
             .lines()
-            .filter(|line| line.contains("drift       beta · managed"))
+            .filter(|line| line.contains("DRIFT beta · managed"))
             .count(),
         1
     );
-    assert!(stdout.lines().filter(|line| !line.is_empty()).all(|line| {
-        line.contains("cursor project")
-            || line.contains("beta · managed")
-            || line.starts_with("  unsupported")
-    }));
+    assert!(stdout.starts_with("Skills · project scope · cursor agent"));
 
     let (code, stdout, _) = run(&fixture, &["doctor", "skills", "--scope", "user"]);
     assert_eq!(code, 0, "{stdout}");
-    assert!(
-        stdout
-            .lines()
-            .filter(|line| !line.is_empty() && !line.starts_with("  "))
-            .all(|line| line.contains(" user "))
-    );
+    assert!(stdout.starts_with("Skills · user scope · 3 agents"));
+    assert!(!stdout.contains(" project "));
 }
 
 #[test]
@@ -73,7 +61,7 @@ fn undeclared_and_unsupported_projections_are_reported() {
     );
     let (code, stdout, _) = run(&fixture, &["doctor", "skills"]);
     assert_eq!(code, 0);
-    assert!(stdout.contains("unsupported skills: claude user skill projection"));
+    assert!(stdout.contains("UNSUPPORTED claude user skill projection"));
 
     let fixture = Fixture::new();
     fixture.write_home(
@@ -112,5 +100,5 @@ fn doctor_without_resource_does_not_aggregate_skills_yet() {
     let (code, stdout, _) = run(&fixture, &["doctor"]);
 
     assert_eq!(code, 0);
-    assert_eq!(stdout, "healthy manifest: manifest is valid\n");
+    assert_eq!(stdout, "Manifest\n✓ 1 healthy\n");
 }


### PR DESCRIPTION
## Summary
- summarize healthy diagnostics by default and restore their details with -v/--verbose
- group skill problems and unsupported capabilities by agent, with structured drift details
- preserve exhaustive JSON, canonical order, exit codes, and read-only behavior

## Test plan
- cargo fmt --manifest-path tooling/arnes/Cargo.toml --check
- cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path tooling/arnes/Cargo.toml
- manual arnes doctor skills and arnes doctor skills -v on macOS

## Verification scope
Local barriers passed on macOS. GitHub Actions validates the same Rust barriers on ubuntu-latest.