### PR TITLE
feat(arnes): color human diagnostics

### DIFF
--- a/docs/arnes-capacites-externes.md
+++ b/docs/arnes-capacites-externes.md
@@ -23,7 +23,10 @@ La sortie humaine affiche le nombre de diagnostics `healthy`, masque leur détai
 problèmes ainsi que les limites `unsupported`. Pour les skills, elle regroupe cet inventaire par
 agent et place les agents en défaut en premier. `-v` ou `--verbose` rétablit le détail des
 diagnostics `healthy` pour tous les doctors. `--format json` reste exhaustif et conserve l'ordre
-canonique ; il ne se combine pas avec `--verbose`.
+canonique ; il ne se combine pas avec `--verbose`. `--color auto|always|never` règle la couleur de
+toutes les sorties humaines, avec `auto` par défaut : stdout doit être un TTY et `NO_COLOR` doit être
+absent ou vide. `always` garde priorité sur `NO_COLOR`; `never` et le JSON ne produisent aucun ANSI.
+`--format json --color always` échoue avant tout diagnostic.
 
 ## Codex
 

--- a/docs/superpowers/specs/2026-08-18-arnes-human-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-18-arnes-human-diagnostics-design.md
@@ -9,6 +9,9 @@ observe. La vue par défaut indique combien de diagnostics sont sains, masque le
 affiche tous les diagnostics `error`, `drift` et `unsupported`. L'option globale `-v, --verbose`
 réinsère les diagnostics `healthy` dans cette même vue.
 
+La couleur ajoute un signal visuel à cette projection sans remplacer les états, symboles ou textes.
+Elle est automatique sur un terminal, contrôlable explicitement et absente du JSON.
+
 Pour `doctor skills`, les diagnostics sont présentés par agent. L'agent qui porte l'état le plus
 grave apparaît en premier afin que la configuration effectivement incorrecte ne soit plus noyée
 par les capacités saines ou non observables.
@@ -18,14 +21,15 @@ par les capacités saines ou non observables.
 - modifier collecte, états, exit codes, schéma JSON ou ordre canonique des diagnostics ;
 - réparer une ressource, suggérer une commande ou coupler Arnes à une procédure externe ;
 - déduire une structure humaine en parsant `resource` ou `message` ;
-- ajouter couleurs, détection TTY ou dépendance, ni adopter les ressources externes.
+- ajouter une dépendance de rendu, ni adopter les ressources externes.
 
 ## Interface CLI
 
-`-v, --verbose` est une option de `doctor`, disponible pour toutes les ressources :
+`-v, --verbose` et `--color` sont des options de `doctor`, disponibles pour toutes les ressources :
 
 ```text
-arnes doctor [RESOURCE] [--agent AGENT] [--scope SCOPE] [--format FORMAT] [-v|--verbose]
+arnes doctor [RESOURCE] [--agent AGENT] [--scope SCOPE] [--format FORMAT]
+  [--color auto|always|never] [-v|--verbose]
 ```
 
 Le raccourci `-v` est libre ; `-V` reste réservé à la version par Clap. L'option ne change que le
@@ -38,9 +42,25 @@ refusée avant la collecte avec l'erreur suivante sur stderr et l'exit code `2` 
 --verbose cannot be used with --format json
 ```
 
+`--color` vaut `auto` par défaut. `auto` colore seulement lorsque stdout est un TTY et que
+`NO_COLOR` est absent ou vide. `never` ne génère aucune séquence ANSI. `always` colore même une
+sortie redirigée et garde priorité sur toute valeur non vide de `NO_COLOR`. La valeur de
+`NO_COLOR` est traitée comme un `OsStr` : toute suite d'octets non vide, UTF-8 ou non, désactive
+`auto`.
+
+Le JSON accepte `auto` et `never`, reste toujours sans ANSI et refuse `always` avant la collecte,
+avant toute lecture de `HOME`, avec stderr et exit code `2` :
+
+```text
+--color always cannot be used with --format json
+```
+
+Lorsque verbose et `always` sont tous deux incompatibles avec JSON, l'erreur verbose existante
+garde priorité.
+
 La validation porte sur les valeurs typées produites par Clap, indépendamment de l'ordre des
-arguments ou de la forme `--format=json`. Une option inconnue, une valeur de format inconnue ou un
-argument dupliqué conserve le contrat d'erreur de Clap.
+arguments ou des formes `--format=json` et `--color=always`. Une option inconnue, une valeur de
+format ou de couleur inconnue, ou un argument dupliqué conserve le contrat d'erreur de Clap.
 
 ## Sortie humaine commune
 
@@ -66,6 +86,13 @@ les lignes `healthy` à la fin de leur section. Elle ne recalcule aucun diagnost
 
 Un rapport vide affiche `No diagnostics`. Il ne doit jamais afficher un symbole vert ou laisser
 entendre que l'absence de diagnostic prouve un état sain.
+
+Quand la politique active la couleur, `ERROR` est rouge, `DRIFT` jaune, `UNSUPPORTED` cyan et
+`HEALTHY` vert. Le renderer colore les libellés d'état et les segments de résumé correspondants,
+jamais les messages ou détails canoniques. Un segment `issue(s)` regroupant error et drift est rouge
+s'il contient au moins une error, sinon jaune. Les en-têtes restent sans couleur. Après retrait des
+séquences ANSI, les octets, espaces, textes, symboles et retours à la ligne sont identiques à la
+sortie `never`.
 
 Pour les ressources sans regroupement structuré, les diagnostics visibles conservent leur ordre de
 production. Le masquage des lignes saines s'applique néanmoins à toutes les ressources de
@@ -160,14 +187,26 @@ Le renderer suit deux chemins :
 - sans section structurée, il conserve les groupes et l'ordre humain existants tout en appliquant
   le total et le filtre `healthy`.
 
+La couche humaine reçoit une politique couleur typée, le résultat injectable de la détection TTY et
+la valeur injectable de `NO_COLOR`. La CLI obtient ces valeurs avec `std::io::IsTerminal` et
+`std::env::var_os`, sans dépendance supplémentaire. Le renderer associe directement chaque `State`
+à son style ; il ne parse jamais une chaîne rendue pour retrouver l'état. Le texte brut est formaté
+et paddé avant d'être enveloppé par ANSI afin que sa largeur logique reste inchangée.
+
 Les champs de présentation restent exclus de Serde. `Report::json()` conserve donc exactement
-`resource`, `state` et `message`, dans l'ordre de collecte. `main` valide d'abord la combinaison
-format/verbosité, appelle ensuite `diagnose`, puis choisit le renderer ; aucune branche de rendu ne
+`resource`, `state` et `message`, dans l'ordre de collecte. `main` valide d'abord les combinaisons
+format/options, appelle ensuite `diagnose`, puis choisit le renderer ; aucune branche de rendu ne
 peut modifier l'exit code déjà dérivé du rapport.
+
+`Diagnostic::Display`, `Diagnostic`, ses messages canoniques et le chemin JSON ne contiennent aucun
+code ANSI. La politique et les séquences résident uniquement dans la projection humaine.
 
 ## Erreurs et cas limites
 
 - `-v --format json` échoue avant tout chargement du manifeste ou accès à `HOME` ;
+- `--color always --format json` échoue au même endroit, sans résoudre TTY ni `NO_COLOR` ;
+- `--format json --color auto|never` produit le JSON canonique sans ANSI ;
+- `NO_COLOR` vide ne désactive pas `auto`, une valeur non vide le désactive et `always` la surpasse ;
 - un rapport sans diagnostic dit `No diagnostics`, sans faux vert ;
 - un rapport sans diagnostic sain affiche `✓ 0 healthy` puis ses autres états ;
 - un rapport entièrement sain affiche son total seul en mode normal et son inventaire en verbose ;
@@ -185,16 +224,19 @@ peut modifier l'exit code déjà dérivé du rapport.
 3. Invariant without a constraint : non applicable, aucune donnée persistée.
 4. Authorization as a side effect : non applicable, aucune autorisation.
 5. Tenant scope : non applicable, aucun tenant ni identifiant client.
-6. Error contract : tient parce que la combinaison verbose/JSON, son stderr et son exit code sont
-   documentés et testés au niveau CLI.
+6. Error contract : tient parce que les combinaisons verbose/JSON et always/JSON, leur priorité,
+   leur stderr et leur exit code sont documentés et testés au niveau CLI avant toute collecte.
 7. Deferred functionality : non applicable, la remédiation est explicitement hors contrat et aucun
    contrôle métier ou réglementaire n'est différé.
-8. Parsing versus assertion : tient parce que Clap produit un booléen et un enum typés, puis la
-   validation refuse le couple canonique `(verbose, json)` sans valeur permissive par défaut.
+8. Parsing versus assertion : tient parce que Clap produit le booléen et les enums typés, puis la
+   validation refuse les couples canoniques `(verbose, json)` et `(always, json)` sans valeur
+   permissive par défaut. `NO_COLOR` n'est pas converti en UTF-8 : son emptiness est évaluée sur
+   l'`OsStr`, y compris pour une valeur non UTF-8.
 9. Upstream control as a trust boundary : non applicable, le rendu ne fait confiance à aucun
    allowlist upstream pour valider une ressource.
-10. Claim stronger than mechanism : tient parce qu'un rapport vide ne prétend pas être sain et que
-    `unsupported` est décrit comme une limite d'observation non bloquante.
+10. Claim stronger than mechanism : tient parce qu'un rapport vide ne prétend pas être sain,
+    `unsupported` est décrit comme une limite d'observation non bloquante et la couleur reste un
+    signal additif dont l'égalité textuelle est testée après retrait ANSI.
 
 ## Tests
 
@@ -207,19 +249,29 @@ Les tests unitaires du renderer couvrent :
 - l'ordre des diagnostics par sévérité dans une section et sa stabilité à égalité ;
 - le fallback sans section structurée ;
 - un rapport vide sans affirmation de santé ;
-- l'échappement des retours chariot et sauts de ligne existant.
+- l'échappement des retours chariot et sauts de ligne existant ;
+- les modes `auto`, `always` et `never` avec détection TTY injectée ;
+- `NO_COLOR` absent, vide, non vide et non UTF-8, ainsi que la priorité de `always` ;
+- chaque `State`, les résumés globaux et de section, en vue normale et verbose ;
+- l'égalité byte-for-byte entre la sortie plate et la sortie colorée après retrait ANSI ;
+- l'absence de contamination du JSON après un rendu humain coloré.
 
 Les tests d'intégration CLI couvrent :
 
 - `-v` et `--verbose`, avant ou après la ressource ;
+- `--color` avant ou après la ressource, avec forme séparée ou `=` ;
 - la sortie normale et verbose de `doctor skills` avec plusieurs agents et états ;
 - une ressource entièrement saine dans les deux modes ;
 - le comportement générique sur au moins une ressource autre que `skills`, dont `commands` ;
 - le JSON byte-for-byte inchangé sans `-v` ;
+- le JSON sans ANSI avec `auto` ou `never` ;
+- le refus de `always` avec JSON avant lecture de `HOME`, dans chaque ordre d'arguments ;
 - le refus de `-v --format json`, `--format=json --verbose` et de l'ordre inverse, avec stdout vide,
   stderr documenté, exit code `2` et aucun accès à `HOME` ;
 - les exit codes inchangés pour `healthy`, `unsupported`, `drift` et `error` ;
-- l'absence de mutation de `HOME` et du dépôt via les snapshots avant/après existants.
+- l'absence de mutation de `HOME` et du dépôt via les snapshots avant/après existants ;
+- le défaut `auto`, les choix affichés dans l'aide, les valeurs inconnues et les options dupliquées ;
+- `always` en redirection malgré `NO_COLOR`, et son égalité avec `never` après retrait ANSI.
 
 Les fixtures de sortie plate historiques sont remplacées ou complétées par des fixtures qui rendent
 le contrat normal et verbose intentionnel. Les tests ne doivent pas se limiter à des fragments si

--- a/tooling/arnes/src/cli.rs
+++ b/tooling/arnes/src/cli.rs
@@ -1,0 +1,81 @@
+use arnes::diagnostic::ColorMode;
+use arnes::manifest::{Agent, Scope};
+use clap::{Parser, Subcommand, ValueEnum};
+
+#[derive(Parser)]
+#[command(version, about = "Diagnose agent harness resources")]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    pub(crate) command: Command,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Command {
+    Doctor {
+        #[arg(value_enum)]
+        resource: Option<Resource>,
+        #[arg(long, value_enum)]
+        agent: Option<Agent>,
+        #[arg(long, value_enum, default_value = "user")]
+        scope: Option<Scope>,
+        #[arg(long, value_enum, default_value_t)]
+        format: Format,
+        #[arg(long, value_enum, default_value_t)]
+        color: Color,
+        #[arg(short, long)]
+        verbose: bool,
+    },
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, ValueEnum)]
+pub(crate) enum Resource {
+    Manifest,
+    Config,
+    Instructions,
+    Skills,
+    Prompts,
+    Commands,
+    Rules,
+    Hooks,
+    Mcp,
+    Statusline,
+}
+
+#[derive(Clone, Copy, Default, Eq, PartialEq, ValueEnum)]
+pub(crate) enum Format {
+    #[default]
+    Human,
+    Json,
+}
+
+#[derive(Clone, Copy, Default, Eq, PartialEq, ValueEnum)]
+pub(crate) enum Color {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+impl From<Color> for ColorMode {
+    fn from(color: Color) -> Self {
+        match color {
+            Color::Auto => Self::Auto,
+            Color::Always => Self::Always,
+            Color::Never => Self::Never,
+        }
+    }
+}
+
+pub(crate) fn validate_render_options(
+    format: Format,
+    verbose: bool,
+    color: Color,
+) -> Result<(), &'static str> {
+    if verbose && format == Format::Json {
+        return Err("--verbose cannot be used with --format json");
+    }
+    if color == Color::Always && format == Format::Json {
+        return Err("--color always cannot be used with --format json");
+    }
+    Ok(())
+}

--- a/tooling/arnes/src/diagnostic.rs
+++ b/tooling/arnes/src/diagnostic.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 
 mod human;
 
-pub use human::{HumanContext, HumanOptions};
+pub use human::{ColorMode, HumanContext, HumanOptions};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]

--- a/tooling/arnes/src/diagnostic/human.rs
+++ b/tooling/arnes/src/diagnostic/human.rs
@@ -1,6 +1,11 @@
 use super::{Diagnostic, State, human_field};
+use std::ffi::OsStr;
 
+mod color;
 mod sections;
+
+pub use color::ColorMode;
+use color::Colorizer;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct SectionCount {
@@ -58,19 +63,40 @@ impl HumanContext {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct HumanOptions {
     verbose: bool,
+    color: bool,
 }
 
 impl HumanOptions {
     pub fn normal() -> Self {
-        Self { verbose: false }
+        Self {
+            verbose: false,
+            color: false,
+        }
     }
 
     pub fn verbose() -> Self {
-        Self { verbose: true }
+        Self {
+            verbose: true,
+            color: false,
+        }
     }
 
     pub fn includes_healthy(self) -> bool {
         self.verbose
+    }
+
+    pub fn with_color(
+        mut self,
+        mode: ColorMode,
+        stdout_is_terminal: bool,
+        no_color: Option<&OsStr>,
+    ) -> Self {
+        self.color = mode.enabled(stdout_is_terminal, no_color);
+        self
+    }
+
+    fn colorizer(self) -> Colorizer {
+        Colorizer::new(self.color)
     }
 }
 
@@ -85,19 +111,26 @@ pub(super) fn render(
     let structured = diagnostics
         .iter()
         .all(|diagnostic| diagnostic.section().is_some());
+    let color = options.colorizer();
     let (section_count, body) = if structured {
-        let (count, lines) = sections::render(diagnostics, options);
+        let (count, lines) = sections::render(diagnostics, options, color);
         (Some(count), lines)
     } else {
-        (None, render_flat(diagnostics, options))
+        (None, render_flat(diagnostics, options, color))
     };
     let mut lines = vec![
         context.heading(section_count),
-        format!("✓ {} healthy", state_count(diagnostics, State::Healthy)),
+        color.paint(
+            State::Healthy,
+            format!("✓ {} healthy", state_count(diagnostics, State::Healthy)),
+        ),
     ];
     let unsupported = state_count(diagnostics, State::Unsupported);
     if unsupported > 0 {
-        lines.push(format!("! {unsupported} unsupported (non-blocking)"));
+        lines.push(color.paint(
+            State::Unsupported,
+            format!("! {unsupported} unsupported (non-blocking)"),
+        ));
     }
     lines.push(String::new());
     lines.extend(body);
@@ -112,7 +145,7 @@ fn state_count(diagnostics: &[Diagnostic], state: State) -> usize {
         .count()
 }
 
-fn render_flat(diagnostics: &[Diagnostic], options: HumanOptions) -> Vec<String> {
+fn render_flat(diagnostics: &[Diagnostic], options: HumanOptions, color: Colorizer) -> Vec<String> {
     let mut lines = Vec::new();
     let mut group = None;
     for diagnostic in diagnostics
@@ -127,14 +160,20 @@ fn render_flat(diagnostics: &[Diagnostic], options: HumanOptions) -> Vec<String>
                 lines.push(human_field(human.group()));
                 group = Some(human.group());
             }
+            let state = format!("{:11}", diagnostic.state.to_string());
             lines.push(format!(
-                "  {:11} {}",
-                diagnostic.state.to_string(),
+                "  {} {}",
+                color.paint(diagnostic.state, state),
                 human_field(human.summary())
             ));
         } else {
             group = None;
-            lines.push(diagnostic.to_string());
+            lines.push(format!(
+                "{} {}: {}",
+                color.paint(diagnostic.state, diagnostic.state.to_string()),
+                human_field(&diagnostic.resource),
+                human_field(&diagnostic.message)
+            ));
         }
     }
     lines

--- a/tooling/arnes/src/diagnostic/human/color.rs
+++ b/tooling/arnes/src/diagnostic/human/color.rs
@@ -1,0 +1,44 @@
+use crate::diagnostic::State;
+use std::ffi::OsStr;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ColorMode {
+    Auto,
+    Always,
+    Never,
+}
+
+impl ColorMode {
+    pub(super) fn enabled(self, stdout_is_terminal: bool, no_color: Option<&OsStr>) -> bool {
+        match self {
+            Self::Auto => stdout_is_terminal && no_color.is_none_or(|value| value.is_empty()),
+            Self::Always => true,
+            Self::Never => false,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct Colorizer {
+    enabled: bool,
+}
+
+impl Colorizer {
+    pub(super) fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+
+    pub(super) fn paint(self, state: State, value: impl AsRef<str>) -> String {
+        let value = value.as_ref();
+        if !self.enabled {
+            return value.to_owned();
+        }
+        let code = match state {
+            State::Error => 31,
+            State::Healthy => 32,
+            State::Drift => 33,
+            State::Unsupported => 36,
+        };
+        format!("\x1b[{code}m{value}\x1b[0m")
+    }
+}

--- a/tooling/arnes/src/diagnostic/human/sections.rs
+++ b/tooling/arnes/src/diagnostic/human/sections.rs
@@ -1,3 +1,4 @@
+use super::color::Colorizer;
 use super::{HumanOptions, human_field};
 use crate::diagnostic::{Diagnostic, State};
 
@@ -8,7 +9,11 @@ struct Section<'a> {
     diagnostics: Vec<(usize, &'a Diagnostic)>,
 }
 
-pub(super) fn render(diagnostics: &[Diagnostic], options: HumanOptions) -> (usize, Vec<String>) {
+pub(super) fn render(
+    diagnostics: &[Diagnostic],
+    options: HumanOptions,
+    color: Colorizer,
+) -> (usize, Vec<String>) {
     let mut sections = collect(diagnostics);
     let count = sections.len();
     sections.sort_by(|left, right| {
@@ -18,7 +23,7 @@ pub(super) fn render(diagnostics: &[Diagnostic], options: HumanOptions) -> (usiz
     });
     let mut lines = Vec::new();
     for section in sections {
-        render_section(&mut lines, section, options);
+        render_section(&mut lines, section, options, color);
     }
     (count, lines)
 }
@@ -43,7 +48,12 @@ fn collect(diagnostics: &[Diagnostic]) -> Vec<Section<'_>> {
     sections
 }
 
-fn render_section(lines: &mut Vec<String>, mut section: Section<'_>, options: HumanOptions) {
+fn render_section(
+    lines: &mut Vec<String>,
+    mut section: Section<'_>,
+    options: HumanOptions,
+    color: Colorizer,
+) {
     if !options.includes_healthy()
         && section
             .diagnostics
@@ -56,20 +66,21 @@ fn render_section(lines: &mut Vec<String>, mut section: Section<'_>, options: Hu
         lines.push(String::new());
     }
     lines.push(human_field(section.label));
-    lines.push(format!("  {}", counts(&section.diagnostics)));
+    lines.push(format!("  {}", counts(&section.diagnostics, color)));
     lines.push(String::new());
     section.diagnostics.sort_by(|left, right| {
         state_rank(right.1.state)
             .cmp(&state_rank(left.1.state))
             .then(left.0.cmp(&right.0))
     });
-    render_diagnostics(lines, &section.diagnostics, options);
+    render_diagnostics(lines, &section.diagnostics, options, color);
 }
 
 fn render_diagnostics(
     lines: &mut Vec<String>,
     diagnostics: &[(usize, &Diagnostic)],
     options: HumanOptions,
+    color: Colorizer,
 ) {
     let mut group = None;
     for (_, diagnostic) in diagnostics
@@ -90,7 +101,10 @@ fn render_diagnostics(
         let summary = human.map_or(diagnostic.message.as_str(), |metadata| metadata.summary());
         lines.push(format!(
             "{indent}{} {}",
-            diagnostic.state.to_string().to_uppercase(),
+            color.paint(
+                diagnostic.state,
+                diagnostic.state.to_string().to_uppercase()
+            ),
             human_field(summary)
         ));
         if let Some(metadata) = human {
@@ -105,7 +119,7 @@ fn render_diagnostics(
     }
 }
 
-fn counts(diagnostics: &[(usize, &Diagnostic)]) -> String {
+fn counts(diagnostics: &[(usize, &Diagnostic)], color: Colorizer) -> String {
     let issues = count(diagnostics, |state| {
         matches!(state, State::Error | State::Drift)
     });
@@ -113,15 +127,20 @@ fn counts(diagnostics: &[(usize, &Diagnostic)]) -> String {
     let healthy = count(diagnostics, |state| state == State::Healthy);
     let mut parts = Vec::new();
     if issues > 0 {
-        parts.push(format!(
-            "{issues} {}",
-            if issues == 1 { "issue" } else { "issues" }
+        let state = if count(diagnostics, |state| state == State::Error) > 0 {
+            State::Error
+        } else {
+            State::Drift
+        };
+        parts.push(color.paint(
+            state,
+            format!("{issues} {}", if issues == 1 { "issue" } else { "issues" }),
         ));
     }
     if unsupported > 0 {
-        parts.push(format!("{unsupported} unsupported"));
+        parts.push(color.paint(State::Unsupported, format!("{unsupported} unsupported")));
     }
-    parts.push(format!("{healthy} healthy"));
+    parts.push(color.paint(State::Healthy, format!("{healthy} healthy")));
     parts.join(" · ")
 }
 

--- a/tooling/arnes/src/main.rs
+++ b/tooling/arnes/src/main.rs
@@ -1,59 +1,18 @@
-use clap::{Parser, Subcommand, ValueEnum};
-use std::io;
+mod cli;
+
+use clap::Parser;
+use std::io::{self, IsTerminal};
 use std::process::ExitCode;
 
 use arnes::Roots;
 use arnes::commands;
 use arnes::config;
-use arnes::diagnostic::{Diagnostic, HumanContext, HumanOptions, Report, State};
+use arnes::diagnostic::{ColorMode, Diagnostic, HumanContext, HumanOptions, Report, State};
 use arnes::instructions;
 use arnes::manifest::{self, Agent, Scope};
 use arnes::prompts;
 use arnes::skills;
-
-#[derive(Parser)]
-#[command(version, about = "Diagnose agent harness resources")]
-struct Cli {
-    #[command(subcommand)]
-    command: Command,
-}
-
-#[derive(Subcommand)]
-enum Command {
-    Doctor {
-        #[arg(value_enum)]
-        resource: Option<Resource>,
-        #[arg(long, value_enum)]
-        agent: Option<Agent>,
-        #[arg(long, value_enum, default_value = "user")]
-        scope: Option<Scope>,
-        #[arg(long, value_enum, default_value_t)]
-        format: Format,
-        #[arg(short, long)]
-        verbose: bool,
-    },
-}
-
-#[derive(Clone, Copy, Eq, PartialEq, ValueEnum)]
-enum Resource {
-    Manifest,
-    Config,
-    Instructions,
-    Skills,
-    Prompts,
-    Commands,
-    Rules,
-    Hooks,
-    Mcp,
-    Statusline,
-}
-
-#[derive(Clone, Copy, Default, Eq, PartialEq, ValueEnum)]
-enum Format {
-    #[default]
-    Human,
-    Json,
-}
+use cli::{Cli, Command, Format, Resource, validate_render_options};
 
 fn main() -> ExitCode {
     let Cli { command } = Cli::parse();
@@ -63,10 +22,11 @@ fn main() -> ExitCode {
         agent,
         scope,
         format,
+        color,
         verbose,
     } = command;
 
-    if let Err(error) = validate_render_options(format, verbose) {
+    if let Err(error) = validate_render_options(format, verbose, color) {
         eprintln!("{error}");
         return ExitCode::from(2);
     }
@@ -76,11 +36,16 @@ fn main() -> ExitCode {
     let output = match format {
         Format::Human => report.human(
             &human_context(resource, agent, scope),
-            if verbose {
+            (if verbose {
                 HumanOptions::verbose()
             } else {
                 HumanOptions::normal()
-            },
+            })
+            .with_color(
+                ColorMode::from(color),
+                io::stdout().is_terminal(),
+                std::env::var_os("NO_COLOR").as_deref(),
+            ),
         ),
         Format::Json => report.json().expect("diagnostics are JSON serializable"),
     };
@@ -90,13 +55,6 @@ fn main() -> ExitCode {
         return ExitCode::from(2);
     }
     ExitCode::from(report.exit_code())
-}
-
-fn validate_render_options(format: Format, verbose: bool) -> Result<(), &'static str> {
-    if verbose && format == Format::Json {
-        return Err("--verbose cannot be used with --format json");
-    }
-    Ok(())
 }
 
 impl Resource {

--- a/tooling/arnes/tests/diagnostic_color.rs
+++ b/tooling/arnes/tests/diagnostic_color.rs
@@ -1,0 +1,171 @@
+use arnes::diagnostic::{
+    ColorMode, Diagnostic, HumanContext, HumanOptions, HumanSection, Report, State,
+};
+use std::ffi::OsStr;
+
+fn report() -> Report {
+    Report::new(vec![
+        Diagnostic::new("manifest", State::Healthy, "manifest is valid"),
+        Diagnostic::new(
+            "rules",
+            State::Unsupported,
+            "cursor does not expose native user rules",
+        ),
+        Diagnostic::new("skills", State::Drift, "destination is missing"),
+        Diagnostic::new("config", State::Error, "settings.json could not be read"),
+    ])
+}
+
+fn context() -> HumanContext {
+    HumanContext::new("Diagnostics")
+}
+
+fn section(key: &str, label: &str) -> HumanSection {
+    HumanSection::new(key, label)
+}
+
+fn colored(options: HumanOptions) -> HumanOptions {
+    options.with_color(ColorMode::Always, false, Some(OsStr::new("1")))
+}
+
+fn strip_ansi(value: &str) -> String {
+    ["\x1b[31m", "\x1b[32m", "\x1b[33m", "\x1b[36m", "\x1b[0m"]
+        .into_iter()
+        .fold(value.to_owned(), |plain, sequence| {
+            plain.replace(sequence, "")
+        })
+}
+
+#[test]
+fn auto_colors_terminal_output() {
+    let output = report().human(
+        &context(),
+        HumanOptions::normal().with_color(ColorMode::Auto, true, None),
+    );
+
+    assert!(output.contains('\x1b'));
+}
+
+#[test]
+fn auto_keeps_redirected_output_plain() {
+    let output = report().human(
+        &context(),
+        HumanOptions::normal().with_color(ColorMode::Auto, false, None),
+    );
+
+    assert!(!output.contains('\x1b'));
+}
+
+#[test]
+fn auto_treats_empty_no_color_as_absent_and_non_empty_as_disabled() {
+    for no_color in [None, Some(OsStr::new(""))] {
+        let output = report().human(
+            &context(),
+            HumanOptions::normal().with_color(ColorMode::Auto, true, no_color),
+        );
+        assert!(output.contains('\x1b'), "{no_color:?}");
+    }
+    let output = report().human(
+        &context(),
+        HumanOptions::normal().with_color(ColorMode::Auto, true, Some(OsStr::new("1"))),
+    );
+    assert!(!output.contains('\x1b'));
+}
+
+#[cfg(unix)]
+#[test]
+fn auto_treats_non_utf8_no_color_as_non_empty() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let no_color = std::ffi::OsString::from_vec(vec![0xff]);
+    let output = report().human(
+        &context(),
+        HumanOptions::normal().with_color(ColorMode::Auto, true, Some(&no_color)),
+    );
+
+    assert!(!output.contains('\x1b'));
+}
+
+#[test]
+fn always_overrides_terminal_and_no_color() {
+    let output = report().human(&context(), colored(HumanOptions::normal()));
+
+    assert!(output.contains('\x1b'));
+}
+
+#[test]
+fn never_keeps_output_plain() {
+    let output = report().human(
+        &context(),
+        HumanOptions::normal().with_color(ColorMode::Never, true, None),
+    );
+
+    assert!(!output.contains('\x1b'));
+}
+
+#[test]
+fn colors_every_visible_state_and_summary() {
+    let normal = report().human(&context(), colored(HumanOptions::normal()));
+    let verbose = report().human(&context(), colored(HumanOptions::verbose()));
+
+    assert!(normal.contains("\x1b[32m✓ 1 healthy\x1b[0m"));
+    assert!(normal.contains("\x1b[36m! 1 unsupported (non-blocking)\x1b[0m"));
+    assert!(normal.contains("\x1b[36munsupported\x1b[0m rules"));
+    assert!(normal.contains("\x1b[33mdrift\x1b[0m skills"));
+    assert!(normal.contains("\x1b[31merror\x1b[0m config"));
+    assert!(verbose.contains("\x1b[32mhealthy\x1b[0m manifest"));
+}
+
+#[test]
+fn stripping_color_preserves_normal_and_verbose_output_byte_for_byte() {
+    for options in [HumanOptions::normal(), HumanOptions::verbose()] {
+        let plain = report().human(&context(), options);
+        let styled = report().human(&context(), colored(options));
+
+        assert_eq!(strip_ansi(&styled), plain);
+    }
+}
+
+#[test]
+fn structured_output_colors_states_and_each_summary_segment() {
+    let report = Report::new(vec![
+        Diagnostic::new("skills", State::Healthy, "current")
+            .with_human_section(section("cursor:user", "CURSOR")),
+        Diagnostic::new("skills", State::Unsupported, "inventory unavailable")
+            .with_human_section(section("cursor:user", "CURSOR")),
+        Diagnostic::new("skills", State::Drift, "destination missing")
+            .with_human_section(section("cursor:user", "CURSOR")),
+        Diagnostic::new("skills", State::Error, "source unreadable")
+            .with_human_section(section("cursor:user", "CURSOR")),
+    ]);
+
+    let output = report.human(&context(), colored(HumanOptions::verbose()));
+
+    assert!(output.contains(
+        "  \x1b[31m2 issues\x1b[0m · \x1b[36m1 unsupported\x1b[0m · \x1b[32m1 healthy\x1b[0m"
+    ));
+    assert!(output.contains("  \x1b[31mERROR\x1b[0m source unreadable"));
+    assert!(output.contains("  \x1b[33mDRIFT\x1b[0m destination missing"));
+    assert!(output.contains("  \x1b[36mUNSUPPORTED\x1b[0m inventory unavailable"));
+    assert!(output.contains("  \x1b[32mHEALTHY\x1b[0m current"));
+}
+
+#[test]
+fn drift_only_issue_summary_is_yellow() {
+    let report = Report::new(vec![
+        Diagnostic::new("skills", State::Drift, "destination missing")
+            .with_human_section(section("cursor:user", "CURSOR")),
+    ]);
+
+    let output = report.human(&context(), colored(HumanOptions::normal()));
+
+    assert!(output.contains("  \x1b[33m1 issue\x1b[0m · \x1b[32m0 healthy\x1b[0m"));
+}
+
+#[test]
+fn json_never_contains_renderer_ansi() {
+    let report = report();
+    let _ = report.human(&context(), colored(HumanOptions::verbose()));
+
+    assert!(!report.json().unwrap().contains('\x1b'));
+}

--- a/tooling/arnes/tests/human_cli.rs
+++ b/tooling/arnes/tests/human_cli.rs
@@ -11,6 +11,14 @@ fn run(args: &[&str]) -> Output {
         .unwrap()
 }
 
+fn strip_ansi(value: &str) -> String {
+    ["\x1b[31m", "\x1b[32m", "\x1b[33m", "\x1b[36m", "\x1b[0m"]
+        .into_iter()
+        .fold(value.to_owned(), |plain, sequence| {
+            plain.replace(sequence, "")
+        })
+}
+
 #[test]
 fn doctor_help_lists_verbose_options() {
     let output = run(&["doctor", "--help"]);
@@ -22,11 +30,28 @@ fn doctor_help_lists_verbose_options() {
 }
 
 #[test]
+fn doctor_help_lists_color_options() {
+    let output = run(&["doctor", "--help"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout.contains("--color <COLOR>"), "{stdout}");
+    for choice in ["auto", "always", "never"] {
+        assert!(stdout.contains(choice), "{stdout}");
+    }
+    assert!(stdout.contains("[default: auto]"), "{stdout}");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
 fn verbose_json_is_rejected_before_home_is_read() {
     for args in [
         vec!["doctor", "skills", "-v", "--format", "json"],
         vec!["doctor", "--verbose", "skills", "--format=json"],
         vec!["doctor", "--format", "json", "skills", "-v"],
+        vec![
+            "doctor", "skills", "--color", "always", "-v", "--format", "json",
+        ],
     ] {
         let output = run(&args);
 
@@ -41,6 +66,81 @@ fn verbose_json_is_rejected_before_home_is_read() {
 }
 
 #[test]
+fn json_rejects_color_always_before_home_is_read() {
+    for args in [
+        vec!["doctor", "skills", "--color", "always", "--format", "json"],
+        vec!["doctor", "--format=json", "--color=always", "skills"],
+        vec!["doctor", "--color", "always", "--format", "json", "skills"],
+    ] {
+        let output = run(&args);
+
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+        assert!(output.stdout.is_empty(), "{args:?}");
+        assert_eq!(
+            String::from_utf8(output.stderr).unwrap(),
+            "--color always cannot be used with --format json\n",
+            "{args:?}"
+        );
+    }
+}
+
+#[test]
+fn json_accepts_auto_and_never_without_ansi() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", "version: 1\nagents: []\nresources: []\n");
+
+    for color in ["auto", "never"] {
+        let output = fixture.command(["doctor", "manifest", "--format", "json", "--color", color]);
+
+        assert_eq!(output.status.code(), Some(0), "{color}");
+        assert!(!output.stdout.contains(&0x1b), "{color}");
+        assert!(output.stderr.is_empty(), "{color}");
+    }
+}
+
+#[test]
+fn always_colors_redirected_output_and_overrides_no_color() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", "version: 1\nagents: []\nresources: []\n");
+    let before = fixture.snapshot();
+    let plain = fixture.command(["doctor", "manifest", "--color", "never"]);
+    let output = Command::new(env!("CARGO_BIN_EXE_arnes"))
+        .args(["doctor", "manifest", "--color", "always"])
+        .current_dir(fixture.repository())
+        .env_clear()
+        .env("HOME", fixture.home())
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(output.stdout.contains(&0x1b));
+    assert_eq!(
+        strip_ansi(&String::from_utf8(output.stdout).unwrap()),
+        String::from_utf8(plain.stdout).unwrap()
+    );
+    assert!(output.stderr.is_empty());
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn redirected_auto_and_never_match_existing_plain_output() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", "version: 1\nagents: []\nresources: []\n");
+    let before = fixture.snapshot();
+    let default = fixture.command(["doctor", "manifest"]);
+
+    for color in ["auto", "never"] {
+        let output = fixture.command(["doctor", "manifest", "--color", color]);
+
+        assert_eq!(output.status.code(), Some(0), "{color}");
+        assert_eq!(output.stdout, default.stdout, "{color}");
+        assert!(output.stderr.is_empty(), "{color}");
+    }
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
 fn duplicate_format_is_rejected_by_clap() {
     let output = run(&["doctor", "skills", "--format", "human", "--format", "json"]);
     let stderr = String::from_utf8(output.stderr).unwrap();
@@ -48,6 +148,26 @@ fn duplicate_format_is_rejected_by_clap() {
     assert_eq!(output.status.code(), Some(2));
     assert!(output.stdout.is_empty());
     assert!(stderr.contains("cannot be used multiple times"), "{stderr}");
+}
+
+#[test]
+fn duplicate_color_is_rejected_by_clap() {
+    let output = run(&["doctor", "skills", "--color", "auto", "--color", "never"]);
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(stderr.contains("cannot be used multiple times"), "{stderr}");
+}
+
+#[test]
+fn unknown_color_is_rejected_by_clap() {
+    let output = run(&["doctor", "skills", "--color", "sometimes"]);
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(stderr.contains("invalid value 'sometimes'"), "{stderr}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `arnes doctor --color auto|always|never`, with TTY-aware `auto` and `NO_COLOR` support
- color human states and summary segments additively while preserving plain text, JSON, exit codes, order, and read-only behavior
- reject `--format json --color always` before diagnosis and document the approved color contract

Closes #164

## Test plan

- `cargo fmt --manifest-path tooling/arnes/Cargo.toml --check`
- `cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tooling/arnes/Cargo.toml`
- independent review of `2094a875..deef332b2ce2cd833f6fe27d8094ef95a7d5f291`

## Verification scope

Local barriers passed on macOS with rustc 1.97.1: 279/279 tests, 0 failures, 0 ignored, and 0 Clippy warnings. GitHub Actions must validate the Rust barriers on `ubuntu-latest`; no local Linux claim is made.
