### PR TITLE
fix(arnes): resolve active Codex plugin artifacts

### DIFF
--- a/docs/arnes-capacites-externes.md
+++ b/docs/arnes-capacites-externes.md
@@ -40,15 +40,26 @@ d'implémentation local explicite, pas une convention Codex universelle. Arnes p
 `openai-docs` sous cette racine sans transformer une observation de HOME en table Rust. Une autre
 installation doit déclarer sa propre racine stable ou accepter un diagnostic `unsupported`.
 
-Les plugins ont une identité `.codex-plugin/plugin.json`, un état on/off dans
-`~/.codex/config.toml` et un cache versionné sous
-`~/.codex/plugins/cache/$MARKETPLACE/$PLUGIN/$VERSION`. La configuration publique ne désigne pas la
-version active du cache. Arnes rapporte donc l'état observable du plugin, mais garde sa topologie et
-ses skills `unsupported` au lieu de choisir arbitrairement une version ou d'énumérer les caches.
+Codex CLI 0.147.0 expose `codex plugin marketplace list --json` et `codex plugin list --json`. La
+première commande fournit les marketplaces considérées ; la seconde fournit la sélection installée,
+son état on/off et son identifiant d'artefact. Son champ `source.path` désigne la source marketplace,
+pas l'artefact actif, et n'est jamais inspecté par Arnes. Il s'agit du schéma structuré du binaire
+installé et de son code source tagué, pas d'une interface publique stable. Un schéma absent, invalide
+ou incompatible reste donc `unsupported`.
+
+Arnes joint exhaustivement cette sélection à `~/.codex/config.toml` par l'identifiant complet du
+plugin et exige une sélection, une identité et une marketplace uniques. Il reconstruit ensuite le
+chemin avec le contrat `PluginStore::plugin_root` de Codex 0.147.0, puis le confine sous
+`~/.codex/plugins/cache` avant inspection. L'identifiant d'artefact Codex reste distinct de la
+version sémantique de `.codex-plugin/plugin.json` : une révision marketplace `11c74d6b` peut ainsi
+contenir un manifeste `5.1.3`. Les skills proviennent uniquement de cet artefact résolu. Le contenu
+du cache ne choisit jamais la version, même lorsqu'un plugin ne contient qu'un seul répertoire.
 
 Sources : [Build skills](https://learn.chatgpt.com/docs/build-skills),
 [Plugins](https://learn.chatgpt.com/docs/plugins),
-[Package your plugin](https://developers.openai.com/plugins/build/plugins).
+[Package your plugin](https://developers.openai.com/plugins/build/plugins),
+[`plugin_cmd.rs` de Codex CLI 0.147.0](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/cli/src/plugin_cmd.rs),
+[`store.rs` de Codex CLI 0.147.0](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/core-plugins/src/store.rs).
 
 ## Claude Code
 
@@ -92,5 +103,9 @@ Sources : [Skills](https://cursor.com/docs/skills),
 Chaque scan part d'une racine déclarée, d'un registre installé ou d'une configuration effectivement
 lue par l'agent. Les symlinks absolus et relatifs sont acceptés seulement si leur cible canonique
 reste dans cette racine. Un lien pendant ou une sortie par un composant intermédiaire est rapporté
-sans être traversé. `doctor` n'appelle aucun gestionnaire de plugin, n'analyse aucun cache orphelin,
-ne charge aucune capacité et ne modifie ni le repository ni HOME.
+sans être traversé. `doctor` n'analyse aucun cache orphelin et ne charge aucune capacité. La seule
+frontière exécutée est le résolveur JSON Codex pour ses plugins ; elle reçoit le HOME injecté, est
+lancée depuis HOME pour exclure les réglages du projet appelant, et possède une limite de cinq
+secondes et de 1 Mio par flux. Codex 0.147.0 crée et supprime pendant son démarrage des alias
+temporaires sous `CODEX_HOME/tmp/arg0` ; Arnes n'effectue aucune installation ni écriture durable
+dans le repository ou HOME.

--- a/tooling/arnes/Cargo.toml
+++ b/tooling/arnes/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-rustix = { version = "1.1", features = ["fs", "stdio"] }
+rustix = { version = "1.1", features = ["fs", "process", "stdio"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_path_to_error = "0.1"
 serde_json = "1.0"

--- a/tooling/arnes/src/skills/external/claude.rs
+++ b/tooling/arnes/src/skills/external/claude.rs
@@ -77,6 +77,7 @@ fn inspect_skills_directory_entry(
     Some(Plugin {
         exposure: settings::exposure(settings, &id),
         id,
+        artifact: None,
         version: inspected.version,
         path: Some(path),
         topology: inspected.topology,

--- a/tooling/arnes/src/skills/external/claude/registry.rs
+++ b/tooling/arnes/src/skills/external/claude/registry.rs
@@ -137,6 +137,7 @@ fn plugins_for_id(
             .join(",");
         plugins.push(Plugin {
             id: id.clone(),
+            artifact: None,
             version: None,
             path: None,
             exposure: Exposure::Unknown,
@@ -179,6 +180,7 @@ fn matching_plugin(
         .join(",");
     Some(Plugin {
         id,
+        artifact: None,
         version: None,
         path: None,
         exposure,
@@ -207,6 +209,7 @@ fn inspect_installation(
     if let Some(detail) = invalid {
         return Plugin {
             id,
+            artifact: None,
             version: Some(installation.version),
             path: Some(path),
             exposure,
@@ -223,6 +226,7 @@ fn inspect_installation(
         .is_some_and(|manifest_version| manifest_version != version.as_str());
     Plugin {
         id,
+        artifact: None,
         version: Some(version),
         path: Some(path),
         exposure,

--- a/tooling/arnes/src/skills/external/codex.rs
+++ b/tooling/arnes/src/skills/external/codex.rs
@@ -4,9 +4,13 @@ use crate::diagnostic::{Diagnostic, State};
 use crate::files::paths::{ancestor_within, canonical_within};
 use crate::manifest::{Agent, Manifest, Scope};
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+mod command;
+mod resolution;
+mod state;
 
 #[derive(Default, Deserialize)]
 struct Config {
@@ -55,32 +59,70 @@ pub(super) fn diagnose(roots: &Roots, policy: &Manifest, scope: Scope) -> Vec<Di
             )];
         }
     };
-    let plugins = config
-        .plugins
+    let resolved = state::load(roots.home());
+    if config.plugins.is_empty()
+        && let Err(detail) = &resolved
+    {
+        return vec![resolver_failure_diagnostic(detail)];
+    }
+    let ids = configured_and_resolved_ids(&config.plugins, resolved.as_ref().ok());
+    let plugins = ids
         .into_iter()
-        .map(|(id, plugin)| Plugin {
-            id,
-            version: None,
-            path: None,
-            exposure: match plugin.enabled {
-                Some(true) => Exposure::Enabled,
-                Some(false) => Exposure::Disabled,
-                None => Exposure::Unknown,
-            },
-            topology: Topology::Unknown,
-            detail: Some("active plugin version and cache path are not recorded in config".into()),
-            skills: Vec::new(),
+        .map(|id| {
+            let enabled = config.plugins.get(&id).and_then(|plugin| plugin.enabled);
+            match &resolved {
+                Ok(state) => resolution::resolve(roots.home(), id, enabled, state),
+                Err(detail) => resolution::unresolved(id, enabled, detail.clone()),
+            }
         })
         .collect::<Vec<_>>();
+    let unresolved = resolution_diagnostic(&plugins);
     let mut diagnostics = plugin_diagnostics(policy, Agent::Codex, scope, plugins);
-    if !diagnostics.is_empty() {
-        diagnostics.push(Diagnostic::new(
-            "skills",
-            State::Unsupported,
-            "external codex user plugin skills inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=the active cache version cannot be selected reliably from config.toml",
-        ));
-    }
+    diagnostics.extend(unresolved);
     diagnostics
+}
+
+fn configured_and_resolved_ids(
+    configured: &BTreeMap<String, PluginConfig>,
+    resolved: Option<&state::ResolverState>,
+) -> BTreeSet<String> {
+    configured
+        .keys()
+        .cloned()
+        .chain(
+            resolved
+                .into_iter()
+                .flat_map(|state| state.plugins.iter().map(|plugin| plugin.plugin_id.clone())),
+        )
+        .collect()
+}
+
+fn resolution_diagnostic(plugins: &[Plugin]) -> Option<Diagnostic> {
+    let failures = plugins
+        .iter()
+        .filter(|plugin| plugin.topology == Topology::Unknown)
+        .map(|plugin| {
+            format!(
+                "{}: {}",
+                plugin.id,
+                plugin
+                    .detail
+                    .as_deref()
+                    .unwrap_or("unknown resolver failure")
+            )
+        })
+        .collect::<Vec<_>>();
+    (!failures.is_empty()).then(|| resolver_failure_diagnostic(&failures.join("; ")))
+}
+
+fn resolver_failure_diagnostic(detail: &str) -> Diagnostic {
+    Diagnostic::new(
+        "skills",
+        State::Unsupported,
+        format!(
+            "external codex user plugin resolution origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail={detail}"
+        ),
+    )
 }
 
 pub(super) fn skill_exposure(roots: &Roots, skill_file: &Path) -> Exposure {

--- a/tooling/arnes/src/skills/external/codex/command.rs
+++ b/tooling/arnes/src/skills/external/codex/command.rs
@@ -1,0 +1,161 @@
+use std::io::{ErrorKind, Read};
+use std::os::fd::AsFd;
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::{Child, ChildStderr, ChildStdout, Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const OUTPUT_LIMIT: usize = 1024 * 1024;
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy)]
+enum StreamFailure {
+    Limit,
+    Read,
+}
+
+struct BoundedStream<R> {
+    stream: R,
+    output: Vec<u8>,
+    complete: bool,
+}
+
+struct OutputStreams {
+    stdout: BoundedStream<ChildStdout>,
+    stderr: BoundedStream<ChildStderr>,
+}
+
+pub(super) fn run(home: &Path, args: &[&str], subject: &str) -> Result<Vec<u8>, String> {
+    let mut command = Command::new("codex");
+    command
+        .args(args)
+        .current_dir(home)
+        .env("HOME", home)
+        .env("CODEX_HOME", home.join(".codex"))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0);
+    let mut child = command
+        .spawn()
+        .map_err(|_| format!("Codex {subject} resolver could not be started"))?;
+    let mut streams = match OutputStreams::new(&mut child) {
+        Ok(streams) => streams,
+        Err(()) => {
+            terminate(&mut child);
+            return Err(format!("Codex {subject} resolver output could not be read"));
+        }
+    };
+    let status = wait_for_output(&mut child, &mut streams, subject)?;
+    if !status.success() {
+        return Err(exit_detail(subject, status));
+    }
+    Ok(streams.stdout.output)
+}
+
+fn wait_for_output(
+    child: &mut Child,
+    streams: &mut OutputStreams,
+    subject: &str,
+) -> Result<ExitStatus, String> {
+    let started = Instant::now();
+    let mut status = None;
+    loop {
+        if let Err(failure) = streams.drain() {
+            terminate(child);
+            return Err(stream_detail(subject, failure));
+        }
+        if status.is_none() {
+            status = match child.try_wait() {
+                Ok(status) => status,
+                Err(_) => {
+                    terminate(child);
+                    return Err(format!("Codex {subject} resolver status could not be read"));
+                }
+            };
+        }
+        if let Some(status) = status.filter(|_| streams.complete()) {
+            return Ok(status);
+        }
+        if started.elapsed() >= TIMEOUT {
+            terminate(child);
+            return Err(format!("Codex {subject} resolver timed out"));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+impl OutputStreams {
+    fn new(child: &mut Child) -> Result<Self, ()> {
+        let stdout = child.stdout.take().ok_or(())?;
+        let stderr = child.stderr.take().ok_or(())?;
+        set_nonblocking(&stdout)?;
+        set_nonblocking(&stderr)?;
+        Ok(Self {
+            stdout: BoundedStream::new(stdout),
+            stderr: BoundedStream::new(stderr),
+        })
+    }
+
+    fn drain(&mut self) -> Result<(), StreamFailure> {
+        self.stdout.drain()?;
+        self.stderr.drain()
+    }
+
+    fn complete(&self) -> bool {
+        self.stdout.complete && self.stderr.complete
+    }
+}
+
+impl<R: Read> BoundedStream<R> {
+    fn new(stream: R) -> Self {
+        Self {
+            stream,
+            output: Vec::new(),
+            complete: false,
+        }
+    }
+
+    fn drain(&mut self) -> Result<(), StreamFailure> {
+        let mut buffer = [0; 8192];
+        while !self.complete {
+            match self.stream.read(&mut buffer) {
+                Ok(0) => self.complete = true,
+                Ok(read) if self.output.len() + read > OUTPUT_LIMIT => {
+                    return Err(StreamFailure::Limit);
+                }
+                Ok(read) => self.output.extend_from_slice(&buffer[..read]),
+                Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+                Err(error) if error.kind() == ErrorKind::Interrupted => {}
+                Err(_) => return Err(StreamFailure::Read),
+            }
+        }
+        Ok(())
+    }
+}
+
+fn set_nonblocking(stream: &impl AsFd) -> Result<(), ()> {
+    let flags = rustix::fs::fcntl_getfl(stream).map_err(|_| ())?;
+    rustix::fs::fcntl_setfl(stream, flags | rustix::fs::OFlags::NONBLOCK).map_err(|_| ())
+}
+
+fn terminate(child: &mut Child) {
+    let pid = rustix::process::Pid::from_child(child);
+    let _ = rustix::process::kill_process_group(pid, rustix::process::Signal::KILL);
+    let _ = child.wait();
+}
+
+fn exit_detail(subject: &str, status: ExitStatus) -> String {
+    let status = status.code().map_or_else(
+        || "from a signal".to_owned(),
+        |code| format!("with status {code}"),
+    );
+    format!("Codex {subject} resolver exited {status}")
+}
+
+fn stream_detail(subject: &str, failure: StreamFailure) -> String {
+    match failure {
+        StreamFailure::Limit => format!("Codex {subject} resolver exceeded its output limit"),
+        StreamFailure::Read => format!("Codex {subject} resolver output could not be read"),
+    }
+}

--- a/tooling/arnes/src/skills/external/codex/resolution.rs
+++ b/tooling/arnes/src/skills/external/codex/resolution.rs
@@ -1,0 +1,218 @@
+use super::state::{ResolverState, SelectedPlugin};
+use crate::files::paths::canonical_within;
+use crate::skills::external::manifest;
+use crate::skills::external::model::{Exposure, Plugin, Topology};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+struct PluginIdentity {
+    name: String,
+    marketplace: String,
+}
+
+pub(super) fn resolve(
+    home: &Path,
+    id: String,
+    configured: Option<bool>,
+    state: &ResolverState,
+) -> Plugin {
+    let selected = match selected_plugin(&id, state) {
+        Ok(selected) => selected,
+        Err(detail) => return unresolved(id, configured, detail),
+    };
+    if configured.is_some_and(|enabled| enabled != selected.enabled) {
+        return unresolved(
+            id,
+            configured,
+            "Codex resolver exposure does not match configuration",
+        );
+    }
+    let identity = match selected_identity(&id, selected) {
+        Ok(identity) => identity,
+        Err(detail) => return unresolved(id, Some(selected.enabled), detail),
+    };
+    if let Err(detail) = selected_marketplace(&identity.marketplace, state) {
+        return unresolved(id, Some(selected.enabled), detail);
+    }
+    let artifact = match selected_artifact(selected) {
+        Ok(artifact) => artifact,
+        Err(detail) => return unresolved(id, Some(selected.enabled), detail),
+    };
+    inspect_artifact(home, id, identity, artifact, exposure(selected.enabled))
+}
+
+fn selected_plugin<'a>(
+    id: &str,
+    state: &'a ResolverState,
+) -> Result<&'a SelectedPlugin, &'static str> {
+    let selected = state
+        .plugins
+        .iter()
+        .filter(|plugin| plugin.plugin_id == id)
+        .collect::<Vec<_>>();
+    match selected.as_slice() {
+        [] => Err("Codex resolver did not select this configured plugin"),
+        [selected] => Ok(*selected),
+        _ => Err("Codex resolver returned duplicate plugin selection"),
+    }
+}
+
+fn selected_identity(id: &str, selected: &SelectedPlugin) -> Result<PluginIdentity, &'static str> {
+    let Some((name, marketplace)) = id.split_once('@') else {
+        return Err("Codex resolver plugin identifier is invalid");
+    };
+    if !safe_segment(name) || !safe_segment(marketplace) || marketplace.contains('@') {
+        return Err("Codex resolver plugin identifier is invalid");
+    }
+    if selected.name != name {
+        return Err("Codex resolver plugin name does not match its identifier");
+    }
+    if selected.marketplace_name != marketplace {
+        return Err("Codex resolver marketplace does not match its identifier");
+    }
+    Ok(PluginIdentity {
+        name: name.to_owned(),
+        marketplace: marketplace.to_owned(),
+    })
+}
+
+fn selected_marketplace(marketplace: &str, state: &ResolverState) -> Result<(), &'static str> {
+    match state
+        .marketplaces
+        .iter()
+        .filter(|candidate| candidate.name == marketplace)
+        .count()
+    {
+        0 => Err("Codex marketplace selection is missing"),
+        1 => Ok(()),
+        _ => Err("Codex resolver returned duplicate marketplace selection"),
+    }
+}
+
+fn selected_artifact(selected: &SelectedPlugin) -> Result<&str, &'static str> {
+    if !selected.installed {
+        return Err("Codex resolver selected a plugin that is not installed");
+    }
+    let artifact = selected
+        .version
+        .as_deref()
+        .ok_or("Codex resolver has no active artifact identifier")?;
+    if !safe_segment(artifact) {
+        return Err("Codex resolver artifact identifier is invalid");
+    }
+    Ok(artifact)
+}
+
+fn inspect_artifact(
+    home: &Path,
+    id: String,
+    identity: PluginIdentity,
+    artifact: &str,
+    exposure: Exposure,
+) -> Plugin {
+    let canonical_path = match resolved_artifact_path(home, &identity, artifact) {
+        Ok(path) => path,
+        Err((path, detail)) => return broken(id, artifact, path, exposure, detail),
+    };
+    let inspected = manifest::inspect(&canonical_path, &[".codex-plugin/plugin.json"]);
+    if inspected.topology == Topology::Healthy
+        && inspected.name.as_deref() != Some(identity.name.as_str())
+    {
+        return broken(
+            id,
+            artifact,
+            canonical_path,
+            exposure,
+            "plugin manifest name does not match Codex selection",
+        );
+    }
+    Plugin {
+        id,
+        artifact: Some(artifact.to_owned()),
+        version: inspected.version,
+        path: Some(canonical_path),
+        exposure,
+        topology: inspected.topology,
+        detail: inspected.detail,
+        skills: inspected.skills,
+    }
+}
+
+fn resolved_artifact_path(
+    home: &Path,
+    identity: &PluginIdentity,
+    artifact: &str,
+) -> Result<PathBuf, (PathBuf, &'static str)> {
+    let cache = home.join(".codex/plugins/cache");
+    let path = cache
+        .join(&identity.marketplace)
+        .join(&identity.name)
+        .join(artifact);
+    if fs::symlink_metadata(&path).is_err() {
+        return Err((path, "resolved plugin artifact is missing"));
+    }
+    let Some(canonical_path) = canonical_within(&path, &cache) else {
+        return Err((path, "resolved plugin path escapes the Codex plugin cache"));
+    };
+    let base = cache.join(&identity.marketplace).join(&identity.name);
+    let Some(canonical_cache) = fs::canonicalize(&cache).ok() else {
+        return Err((path, "Codex plugin cache root could not be resolved"));
+    };
+    let Some(canonical_base) = canonical_within(&base, &cache) else {
+        return Err((path, "resolved plugin path aliases another cache identity"));
+    };
+    if canonical_base
+        != canonical_cache
+            .join(&identity.marketplace)
+            .join(&identity.name)
+        || canonical_path != canonical_base.join(artifact)
+    {
+        return Err((path, "resolved plugin path aliases another cache identity"));
+    }
+    Ok(canonical_path)
+}
+
+fn safe_segment(value: &str) -> bool {
+    let mut components = Path::new(value).components();
+    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+}
+
+pub(super) fn unresolved(id: String, enabled: Option<bool>, detail: impl Into<String>) -> Plugin {
+    Plugin {
+        id,
+        artifact: None,
+        version: None,
+        path: None,
+        exposure: enabled.map_or(Exposure::Unknown, exposure),
+        topology: Topology::Unknown,
+        detail: Some(detail.into()),
+        skills: Vec::new(),
+    }
+}
+
+fn broken(
+    id: String,
+    artifact: &str,
+    path: PathBuf,
+    exposure: Exposure,
+    detail: impl Into<String>,
+) -> Plugin {
+    Plugin {
+        id,
+        artifact: Some(artifact.to_owned()),
+        version: None,
+        path: Some(path),
+        exposure,
+        topology: Topology::Broken,
+        detail: Some(detail.into()),
+        skills: Vec::new(),
+    }
+}
+
+fn exposure(enabled: bool) -> Exposure {
+    if enabled {
+        Exposure::Enabled
+    } else {
+        Exposure::Disabled
+    }
+}

--- a/tooling/arnes/src/skills/external/codex/state.rs
+++ b/tooling/arnes/src/skills/external/codex/state.rs
@@ -1,0 +1,51 @@
+use super::command;
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SelectedPlugin {
+    pub plugin_id: String,
+    pub name: String,
+    pub marketplace_name: String,
+    pub version: Option<String>,
+    pub installed: bool,
+    pub enabled: bool,
+}
+
+pub(super) struct ResolverState {
+    pub marketplaces: Vec<Marketplace>,
+    pub plugins: Vec<SelectedPlugin>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct Marketplace {
+    pub name: String,
+}
+
+#[derive(Deserialize)]
+struct MarketplaceList {
+    marketplaces: Vec<Marketplace>,
+}
+
+#[derive(Deserialize)]
+struct PluginList {
+    installed: Vec<SelectedPlugin>,
+}
+
+pub(super) fn load(home: &Path) -> Result<ResolverState, String> {
+    let marketplaces = command::run(
+        home,
+        &["plugin", "marketplace", "list", "--json"],
+        "marketplace",
+    )?;
+    let marketplaces: MarketplaceList = serde_json::from_slice(&marketplaces)
+        .map_err(|_| "Codex marketplace resolver returned invalid JSON".to_owned())?;
+    let plugins = command::run(home, &["plugin", "list", "--json"], "plugin")?;
+    let plugins: PluginList = serde_json::from_slice(&plugins)
+        .map_err(|_| "Codex plugin resolver returned invalid JSON".to_owned())?;
+    Ok(ResolverState {
+        marketplaces: marketplaces.marketplaces,
+        plugins: plugins.installed,
+    })
+}

--- a/tooling/arnes/src/skills/external/cursor.rs
+++ b/tooling/arnes/src/skills/external/cursor.rs
@@ -73,6 +73,7 @@ fn inspect_plugin(root: &Path, entry: DirEntry) -> Option<Plugin> {
         Err(_) => {
             return Some(Plugin {
                 id: entry.file_name().to_string_lossy().into_owned(),
+                artifact: None,
                 version: None,
                 path: Some(entry.path()),
                 exposure: Exposure::Unknown,
@@ -87,6 +88,7 @@ fn inspect_plugin(root: &Path, entry: DirEntry) -> Option<Plugin> {
     if fs::metadata(&path).is_err() || canonical_within(&path, root).is_none() {
         return Some(Plugin {
             id: entry.file_name().to_string_lossy().into_owned(),
+            artifact: None,
             version: None,
             path: Some(path),
             exposure: Exposure::Enabled,
@@ -108,6 +110,7 @@ fn inspect_plugin(root: &Path, entry: DirEntry) -> Option<Plugin> {
     };
     Some(Plugin {
         id,
+        artifact: None,
         version: inspected.version,
         path: Some(path),
         exposure: Exposure::Enabled,

--- a/tooling/arnes/src/skills/external/model.rs
+++ b/tooling/arnes/src/skills/external/model.rs
@@ -44,6 +44,7 @@ impl Display for Topology {
 
 pub(super) struct Plugin {
     pub id: String,
+    pub artifact: Option<String>,
     pub version: Option<String>,
     pub path: Option<PathBuf>,
     pub exposure: Exposure,
@@ -107,9 +108,10 @@ fn plugin_diagnostic(agent: Agent, scope: Scope, plugin: &Plugin, allowed: bool)
         "skills",
         state(plugin.topology, plugin.exposure, allowed),
         format!(
-            "external {agent} {scope} plugin {} origin=plugin ownership=external version={} exposure={} topology={} policy={} activation={} path={}{}",
+            "external {agent} {scope} plugin {} origin=plugin ownership=external version={}{} exposure={} topology={} policy={} activation={} path={}{}",
             plugin.id,
             plugin.version.as_deref().unwrap_or("unknown"),
+            artifact(plugin.artifact.as_deref()),
             plugin.exposure,
             plugin.topology,
             policy(allowed),
@@ -138,10 +140,11 @@ fn skill_diagnostic(
         "skills",
         state(skill.topology, plugin.exposure, allowed),
         format!(
-            "external {agent} {scope} skill {} origin=plugin ownership=external container={} version={} exposure={} topology={} policy={} activation={} path={}{}",
+            "external {agent} {scope} skill {} origin=plugin ownership=external container={} version={}{} exposure={} topology={} policy={} activation={} path={}{}",
             skill.slug,
             plugin.id,
             plugin.version.as_deref().unwrap_or("unknown"),
+            artifact(plugin.artifact.as_deref()),
             plugin.exposure,
             skill.topology,
             policy(allowed),
@@ -205,4 +208,8 @@ fn activation(exposure: Exposure) -> &'static str {
 
 fn detail(value: Option<&str>) -> String {
     value.map_or_else(String::new, |value| format!(" detail={value}"))
+}
+
+fn artifact(value: Option<&str>) -> String {
+    value.map_or_else(String::new, |value| format!(" artifact={value}"))
 }

--- a/tooling/arnes/src/skills/external/model/human.rs
+++ b/tooling/arnes/src/skills/external/model/human.rs
@@ -6,15 +6,20 @@ pub(super) fn plugin_group(agent: Agent, scope: Scope, plugin: &Plugin) -> Strin
     format!(
         "{agent} {scope} plugin {}@{}",
         plugin.id,
-        plugin.version.as_deref().unwrap_or("?")
+        plugin
+            .version
+            .as_deref()
+            .or(plugin.artifact.as_deref())
+            .unwrap_or("?")
     )
 }
 
 pub(super) fn plugin_summary(plugin: &Plugin, policy: &str) -> String {
     format!(
-        "plugin · {} · {} · {policy}{}{}",
+        "plugin · {} · {} · {policy}{}{}{}",
         plugin.exposure,
         plugin.topology,
+        artifact(plugin.artifact.as_deref()),
         path(plugin.topology, plugin.path.as_deref()),
         detail(plugin.detail.as_deref()),
     )
@@ -44,6 +49,10 @@ pub(super) fn system_skill_summary(skill: &SystemSkill, policy: &str) -> String 
 
 fn detail(value: Option<&str>) -> String {
     value.map_or_else(String::new, |value| format!(" — {value}"))
+}
+
+fn artifact(value: Option<&str>) -> String {
+    value.map_or_else(String::new, |value| format!(" · artifact={value}"))
 }
 
 fn path(topology: Topology, path: Option<&Path>) -> String {

--- a/tooling/arnes/tests/external_codex_command_failures.rs
+++ b/tooling/arnes/tests/external_codex_command_failures.rs
@@ -1,0 +1,145 @@
+#[path = "support/codex.rs"]
+pub mod codex_support;
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use codex_support::{install_script, marketplace, plugin};
+use serde_json::json;
+use skill_support::{MANIFEST, configured_fixture, run};
+use std::time::{Duration, Instant};
+
+fn fixture() -> support::Fixture {
+    let fixture = configured_fixture();
+    let manifest = MANIFEST.replacen(
+        "resources:",
+        "external:\n  roots: []\n  plugins:\n    - { agent: codex, scope: user, id: demo@marketplace }\n  skills: []\nresources:",
+        1,
+    );
+    fixture.write_home(".arnes.yaml", &manifest);
+    fixture.write_home(
+        ".codex/config.toml",
+        "[plugins.\"demo@marketplace\"]\nenabled = true\n",
+    );
+    fixture
+}
+
+fn diagnose(fixture: &support::Fixture) -> (i32, String, String) {
+    run(
+        fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    )
+}
+
+#[test]
+fn resolver_spawn_and_exit_failures_remain_visible() {
+    let missing = fixture();
+    let (code, stdout, _) = diagnose(&missing);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Codex marketplace resolver could not be started"));
+
+    let failed = fixture();
+    install_script(
+        &failed,
+        "#!/bin/sh\nprintf 'resolver failed' >&2\nexit 23\n",
+    );
+    let (code, stdout, _) = diagnose(&failed);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Codex marketplace resolver exited with status 23"));
+}
+
+#[test]
+fn resolver_failure_is_visible_when_user_config_has_no_plugins() {
+    let fixture = fixture();
+    fixture.write_home(".codex/config.toml", "");
+    install_script(&fixture, "#!/bin/sh\nexit 23\n");
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("UNSUPPORTED external codex user plugin resolution"));
+    assert!(stdout.contains("resolver exited with status 23"));
+}
+
+#[test]
+fn resolver_timeout_is_bounded_and_visible() {
+    let fixture = fixture();
+    install_script(&fixture, "#!/bin/sh\n/bin/sleep 10 &\nwait\n");
+    assert_timeout(&fixture);
+}
+
+#[test]
+fn resolver_descendant_cannot_hold_output_open_past_timeout() {
+    let fixture = fixture();
+    install_script(
+        &fixture,
+        "#!/bin/sh\nif [ \"$2\" = \"marketplace\" ]; then /bin/sleep 10 & printf '{\"marketplaces\":[]}\\n'; exit 0; fi\nprintf '{\"installed\":[]}\\n'\n",
+    );
+    assert_timeout(&fixture);
+}
+
+fn assert_timeout(fixture: &support::Fixture) {
+    let started = Instant::now();
+    let (code, stdout, _) = diagnose(fixture);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(started.elapsed() < Duration::from_secs(7));
+    assert!(stdout.contains("Codex marketplace resolver timed out"));
+}
+
+#[test]
+fn oversized_resolver_output_is_bounded_and_visible() {
+    let fixture = fixture();
+    fixture.write_home(
+        ".codex-test-marketplaces.json",
+        &"x".repeat(1024 * 1024 + 1),
+    );
+    fixture.write_home(".codex-test-plugins.json", r#"{"installed":[]}"#);
+    install_script(
+        &fixture,
+        "#!/bin/sh\nif [ \"$2\" = \"marketplace\" ]; then file=\"$HOME/.codex-test-marketplaces.json\"; else file=\"$HOME/.codex-test-plugins.json\"; fi\nwhile IFS= read -r line || [ -n \"$line\" ]; do printf '%s\\n' \"$line\"; done < \"$file\"\n",
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Codex marketplace resolver exceeded its output limit"));
+}
+
+#[test]
+fn resolver_runs_outside_the_callers_project_context() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    fixture.write_home(
+        ".codex/plugins/cache/marketplace/demo/revision/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"1.0.0"}"#,
+    );
+    fixture.write_home(
+        ".codex-test-marketplaces.json",
+        &json!({"marketplaces": [marketplace("marketplace", &root)]}).to_string(),
+    );
+    fixture.write_home(
+        ".codex-test-plugins.json",
+        &json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", true, &path)], "available": []}).to_string(),
+    );
+    install_script(
+        &fixture,
+        "#!/bin/sh\n[ -f .codex-test-marketplaces.json ] || { printf 'project override leaked'; exit 0; }\nif [ \"$2\" = \"marketplace\" ]; then file=\"$HOME/.codex-test-marketplaces.json\"; else file=\"$HOME/.codex-test-plugins.json\"; fi\nwhile IFS= read -r line || [ -n \"$line\" ]; do printf '%s\\n' \"$line\"; done < \"$file\"\n",
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "skills",
+            "--agent",
+            "codex",
+            "--scope",
+            "user",
+            "--verbose",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("demo@marketplace@1.0.0"), "{stdout}");
+}

--- a/tooling/arnes/tests/external_codex_consistency_failures.rs
+++ b/tooling/arnes/tests/external_codex_consistency_failures.rs
@@ -1,0 +1,141 @@
+#[path = "support/codex.rs"]
+pub mod codex_support;
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use codex_support::{install, marketplace, plugin};
+use serde_json::json;
+use skill_support::{MANIFEST, configured_fixture, run};
+
+fn fixture() -> support::Fixture {
+    let fixture = configured_fixture();
+    let manifest = MANIFEST.replacen(
+        "resources:",
+        "external:\n  roots: []\n  plugins:\n    - { agent: codex, scope: user, id: demo@marketplace }\n  skills: []\nresources:",
+        1,
+    );
+    fixture.write_home(".arnes.yaml", &manifest);
+    fixture.write_home(
+        ".codex/config.toml",
+        "[plugins.\"demo@marketplace\"]\nenabled = true\n",
+    );
+    fixture
+}
+
+fn diagnose(fixture: &support::Fixture) -> (i32, String, String) {
+    run(
+        fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    )
+}
+
+#[test]
+fn changed_exposure_between_config_and_resolver_is_unsupported() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    fixture.write_home(
+        ".codex/.tmp/plugins/plugins/demo/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"1.0.0"}"#,
+    );
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", false, &path)], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("UNSUPPORTED plugin · enabled · unknown · allowed"));
+    assert!(stdout.contains("Codex resolver exposure does not match configuration"));
+}
+
+#[test]
+fn resolver_marketplace_must_match_the_plugin_identifier() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    fixture.write_home(
+        ".codex/.tmp/plugins/plugins/demo/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"1.0.0"}"#,
+    );
+    let selected = plugin("demo@marketplace", "evil", "revision", true, &path);
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [selected], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("UNSUPPORTED plugin · enabled · unknown · allowed"));
+    assert!(stdout.contains("Codex resolver marketplace does not match its identifier"));
+}
+
+#[test]
+fn manifest_name_must_match_the_selected_plugin() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    fixture.write_home(
+        ".codex/plugins/cache/marketplace/demo/revision/.codex-plugin/plugin.json",
+        r#"{"name":"evil","version":"1.0.0","skills":["skills"]}"#,
+    );
+    fixture.write_home(
+        ".codex/plugins/cache/marketplace/demo/revision/skills/evil/SKILL.md",
+        "evil\n",
+    );
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", true, &path)], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("plugin manifest name does not match Codex selection"));
+    assert!(!stdout.contains("skill evil"));
+}
+
+#[test]
+fn empty_artifact_identifier_is_explicitly_unsupported() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    fixture.write_home(
+        ".codex/.tmp/plugins/plugins/demo/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"1.0.0"}"#,
+    );
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "", true, &path)], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("UNSUPPORTED plugin · enabled · unknown · allowed"));
+    assert!(stdout.contains("Codex resolver artifact identifier is invalid"));
+}
+
+#[test]
+fn artifact_identifier_cannot_escape_the_cache_layout() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "../outside", true, &path)], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Codex resolver artifact identifier is invalid"));
+}

--- a/tooling/arnes/tests/external_codex_plugins.rs
+++ b/tooling/arnes/tests/external_codex_plugins.rs
@@ -1,28 +1,128 @@
+#[path = "support/codex.rs"]
+pub mod codex_support;
 #[path = "support/skills.rs"]
 pub mod skill_support;
 pub mod support;
 
+use codex_support::{install, marketplace, plugin};
+use serde_json::json;
 use skill_support::{MANIFEST, configured_fixture, run};
 
-fn manifest(allowed: bool) -> String {
-    let plugins = if allowed {
+fn manifest(plugin_allowed: bool, skill_allowed: bool) -> String {
+    let plugins = if plugin_allowed {
         "    - { agent: codex, scope: user, id: demo@marketplace }\n"
+    } else {
+        ""
+    };
+    let skills = if skill_allowed {
+        "    - { agent: codex, scope: user, origin: plugin, plugin: demo@marketplace, slug: brainstorm }\n"
     } else {
         ""
     };
     MANIFEST.replacen(
         "resources:",
         &format!(
-            "external:\n  roots:\n    - {{ agent: codex, scope: user, origin: system, location: {{ root: home, path: .codex/skills/.system }} }}\n  plugins:\n{plugins}  skills: []\nresources:"
+            "external:\n  roots:\n    - {{ agent: codex, scope: user, origin: system, location: {{ root: home, path: .codex/skills/.system }} }}\n  plugins:\n{plugins}  skills:\n{skills}resources:"
         ),
         1,
     )
 }
 
 #[test]
-fn codex_plugin_policy_uses_config_but_never_guesses_active_cache_version() {
+fn active_plugin_uses_codex_selection_and_inventories_skills() {
     let fixture = configured_fixture();
-    fixture.write_home(".arnes.yaml", &manifest(false));
+    fixture.write_home(".arnes.yaml", &manifest(true, true));
+    fixture.write_home(
+        ".codex/config.toml",
+        "[plugins.\"demo@marketplace\"]\nenabled = true\n",
+    );
+    fixture.write_home(
+        ".codex/plugins/cache/marketplace/demo/11c74d6b/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"5.1.3","skills":["skills"]}"#,
+    );
+    fixture.write_home(
+        ".codex/plugins/cache/marketplace/demo/11c74d6b/skills/brainstorm/SKILL.md",
+        "brainstorm\n",
+    );
+    fixture.write_home(
+        ".codex/.tmp/plugins/plugins/demo/skills/source-only/SKILL.md",
+        "source only\n",
+    );
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "11c74d6b", true, &path)], "available": []}),
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "skills",
+            "--agent",
+            "codex",
+            "--scope",
+            "user",
+            "--verbose",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("codex user plugin demo@marketplace@5.1.3"));
+    assert!(stdout.contains("artifact=11c74d6b"));
+    assert!(stdout.contains("plugin · enabled · healthy · allowed"));
+    assert!(stdout.contains("skill brainstorm · enabled · healthy · allowed"));
+    assert!(!stdout.contains("@?"));
+    assert!(!stdout.contains("path=unknown"));
+    assert!(!stdout.contains("topology=unknown"));
+    assert!(!stdout.contains("source-only"));
+}
+
+#[test]
+fn disabled_plugin_is_classified_from_the_resolved_artifact() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false, false));
+    fixture.write_home(
+        ".codex/config.toml",
+        "[plugins.\"demo@marketplace\"]\nenabled = false\n",
+    );
+    fixture.write_home(
+        ".codex/plugins/cache/marketplace/demo/revision/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"1.0.0"}"#,
+    );
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", false, &path)], "available": []}),
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "skills",
+            "--agent",
+            "codex",
+            "--scope",
+            "user",
+            "--verbose",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("demo@marketplace@1.0.0"));
+    assert!(stdout.contains("plugin · disabled · healthy · unexpected"));
+    assert!(!stdout.contains("UNSUPPORTED plugin"));
+}
+
+#[test]
+fn a_lone_cache_artifact_never_proves_activation() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false, false));
     fixture.write_home(
         ".codex/config.toml",
         "[plugins.\"demo@marketplace\"]\nenabled = true\n",
@@ -31,6 +131,11 @@ fn codex_plugin_policy_uses_config_but_never_guesses_active_cache_version() {
         ".codex/plugins/cache/marketplace/demo/0.9.0/skills/orphan/SKILL.md",
         "orphan\n",
     );
+    install(
+        &fixture,
+        json!({"marketplaces": []}),
+        json!({"installed": [], "available": []}),
+    );
 
     let (code, stdout, _) = run(
         &fixture,
@@ -38,41 +143,91 @@ fn codex_plugin_policy_uses_config_but_never_guesses_active_cache_version() {
     );
 
     assert_eq!(code, 1, "{stdout}");
-    assert!(stdout.contains("codex user plugin demo@marketplace@?"));
     assert!(stdout.contains("DRIFT plugin · enabled · unknown · unexpected"));
-    assert!(stdout.contains("· enabled · unknown · unexpected"));
-    assert!(stdout.contains("active cache version cannot be selected reliably"));
+    assert!(stdout.contains("UNSUPPORTED external codex user plugin resolution"));
+    assert!(stdout.contains("Codex resolver did not select this configured plugin"));
     assert!(!stdout.contains("orphan"));
     assert!(!stdout.contains("0.9.0"));
 }
 
 #[test]
-fn allowed_or_disabled_codex_plugin_does_not_create_false_policy_drift() {
+fn resolver_order_does_not_change_human_or_json_diagnostics() {
     let fixture = configured_fixture();
-    fixture.write_home(".arnes.yaml", &manifest(true));
+    fixture.write_home(".arnes.yaml", &manifest(true, false));
     fixture.write_home(
         ".codex/config.toml",
-        "[plugins.\"demo@marketplace\"]\nenabled = true\n",
+        "[plugins.\"demo@marketplace\"]\nenabled = true\n[plugins.\"other@second\"]\nenabled = false\n",
     );
-    let (code, stdout, _) = run(
+    for (path, name) in [
+        (".codex/plugins/cache/marketplace/demo/first", "demo"),
+        (".codex/plugins/cache/second/other/second", "other"),
+    ] {
+        fixture.write_home(
+            format!("{path}/.codex-plugin/plugin.json"),
+            &format!(r#"{{"name":"{name}","version":"1.0.0"}}"#),
+        );
+    }
+    let first_root = fixture.home().join(".codex/.tmp/first");
+    let second_root = fixture.home().join(".codex/.tmp/second");
+    let first_marketplace = marketplace("marketplace", &first_root);
+    let second_marketplace = marketplace("second", &second_root);
+    let first_plugin = plugin(
+        "demo@marketplace",
+        "marketplace",
+        "first",
+        true,
+        &first_root.join("plugins/demo"),
+    );
+    let second_plugin = plugin(
+        "other@second",
+        "second",
+        "second",
+        false,
+        &second_root.join("plugins/other"),
+    );
+    install(
         &fixture,
-        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+        json!({"marketplaces": [second_marketplace.clone(), first_marketplace.clone()]}),
+        json!({"installed": [second_plugin.clone(), first_plugin.clone()], "available": []}),
     );
-    assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("codex user plugin demo@marketplace@?"));
-    assert!(stdout.contains("UNSUPPORTED plugin · enabled · unknown · allowed"));
-    assert!(stdout.contains("· enabled · unknown · allowed"));
+    let args = ["doctor", "skills", "--agent", "codex", "--scope", "user"];
+    let (_, first_human, _) = run(&fixture, &args);
+    let (_, first_json, _) = run(&fixture, &[&args[..], &["--format", "json"]].concat());
 
-    fixture.write_home(".arnes.yaml", &manifest(false));
-    fixture.write_home(
-        ".codex/config.toml",
-        "[plugins.\"demo@marketplace\"]\nenabled = false\n",
+    install(
+        &fixture,
+        json!({"marketplaces": [first_marketplace, second_marketplace]}),
+        json!({"installed": [first_plugin, second_plugin], "available": []}),
     );
+    let (_, second_human, _) = run(&fixture, &args);
+    let (_, second_json, _) = run(&fixture, &[&args[..], &["--format", "json"]].concat());
+
+    assert_eq!(first_human, second_human);
+    assert_eq!(first_json, second_json);
+}
+
+#[test]
+fn resolver_only_installed_plugin_is_not_dropped_by_the_config_join() {
+    let fixture = configured_fixture();
+    fixture.write_home(".arnes.yaml", &manifest(false, false));
+    fixture.write_home(".codex/config.toml", "");
+    fixture.write_home(
+        ".codex/plugins/cache/marketplace/demo/revision/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"1.0.0"}"#,
+    );
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", true, &path)], "available": []}),
+    );
+
     let (code, stdout, _) = run(
         &fixture,
         &["doctor", "skills", "--agent", "codex", "--scope", "user"],
     );
-    assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("· disabled · unknown · unexpected"));
-    assert!(!stdout.contains("DRIFT plugin"));
+
+    assert_eq!(code, 1, "{stdout}");
+    assert!(stdout.contains("DRIFT plugin · enabled · healthy · unexpected"));
 }

--- a/tooling/arnes/tests/external_codex_resolver_failures.rs
+++ b/tooling/arnes/tests/external_codex_resolver_failures.rs
@@ -1,0 +1,249 @@
+#[path = "support/codex.rs"]
+pub mod codex_support;
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use codex_support::{install, install_script, marketplace, plugin};
+use serde_json::json;
+use skill_support::{MANIFEST, configured_fixture, run};
+use std::os::unix::fs::symlink;
+
+fn fixture() -> support::Fixture {
+    let fixture = configured_fixture();
+    let manifest = MANIFEST.replacen(
+        "resources:",
+        "external:\n  roots: []\n  plugins:\n    - { agent: codex, scope: user, id: demo@marketplace }\n  skills: []\nresources:",
+        1,
+    );
+    fixture.write_home(".arnes.yaml", &manifest);
+    fixture.write_home(
+        ".codex/config.toml",
+        "[plugins.\"demo@marketplace\"]\nenabled = true\n",
+    );
+    fixture
+}
+
+fn diagnose(fixture: &support::Fixture) -> (i32, String, String) {
+    run(
+        fixture,
+        &["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    )
+}
+
+#[test]
+fn missing_marketplace_state_is_explicitly_unsupported() {
+    let fixture = fixture();
+    let path = fixture.home().join("must-not-be-read/demo");
+    install(
+        &fixture,
+        json!({"marketplaces": []}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", true, &path)], "available": []}),
+    );
+    let (code, stdout, _) = diagnose(&fixture);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("UNSUPPORTED plugin · enabled · unknown · allowed"));
+    assert!(stdout.contains("marketplace selection is missing"));
+    assert!(!stdout.contains("plugin manifest is missing"));
+}
+
+#[test]
+fn malformed_resolver_metadata_is_explicitly_unsupported() {
+    let fixture = fixture();
+    fixture.write_home(".codex-test-marketplaces.json", "not json");
+    fixture.write_home(".codex-test-plugins.json", r#"{"installed":[]}"#);
+    install_script(
+        &fixture,
+        "#!/bin/sh\nif [ \"$2\" = \"marketplace\" ]; then file=\"$HOME/.codex-test-marketplaces.json\"; else file=\"$HOME/.codex-test-plugins.json\"; fi\nwhile IFS= read -r line || [ -n \"$line\" ]; do printf '%s\\n' \"$line\"; done < \"$file\"\n",
+    );
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Codex marketplace resolver returned invalid JSON"));
+    assert!(stdout.contains("UNSUPPORTED plugin · enabled · unknown · allowed"));
+}
+
+#[test]
+fn missing_resolved_artifact_is_broken_without_panicking() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    fixture.write_home(".codex/.tmp/plugins/.keep", "");
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", true, &path)], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("demo@marketplace@revision"));
+    assert!(stdout.contains("ERROR plugin · enabled · broken · allowed"));
+    assert!(stdout.contains("resolved plugin artifact is missing"));
+}
+
+#[test]
+fn source_marketplace_payload_is_not_mistaken_for_the_active_artifact() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    fixture.write_home(
+        ".codex/.tmp/plugins/plugins/demo/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"9.9.9"}"#,
+    );
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", true, &path)], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("demo@marketplace@revision"));
+    assert!(stdout.contains("resolved plugin artifact is missing"));
+    assert!(!stdout.contains("9.9.9"));
+}
+
+#[test]
+fn resolved_path_escape_is_rejected_before_inspection() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    fixture.write_home(
+        "outside/demo/.codex-plugin/plugin.json",
+        r#"{"name":"sentinel","version":"9.9.9"}"#,
+    );
+    fixture.write_home(".codex/plugins/cache/marketplace/demo/.keep", "");
+    symlink(
+        fixture.home().join("outside/demo"),
+        fixture
+            .home()
+            .join(".codex/plugins/cache/marketplace/demo/revision"),
+    )
+    .unwrap();
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", true, &path)], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("resolved plugin path escapes the Codex plugin cache"));
+    assert!(!stdout.contains("9.9.9"));
+    assert!(!stdout.contains("sentinel"));
+}
+
+#[test]
+fn resolved_artifact_cannot_alias_another_plugin_identity() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let source = root.join("plugins/demo");
+    fixture.write_home(
+        ".codex/plugins/cache/evil/demo/revision/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"9.9.9"}"#,
+    );
+    fixture.write_home(".codex/plugins/cache/marketplace/demo/.keep", "");
+    symlink(
+        "../../evil/demo/revision",
+        fixture
+            .home()
+            .join(".codex/plugins/cache/marketplace/demo/revision"),
+    )
+    .unwrap();
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [plugin("demo@marketplace", "marketplace", "revision", true, &source)], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("resolved plugin path aliases another cache identity"));
+    assert!(!stdout.contains("9.9.9"));
+}
+
+#[test]
+fn ambiguous_active_selection_is_explicitly_unsupported() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    fixture.write_home(
+        ".codex/.tmp/plugins/plugins/demo/.codex-plugin/plugin.json",
+        r#"{"name":"demo","version":"1.0.0"}"#,
+    );
+    let selected = plugin("demo@marketplace", "marketplace", "revision", true, &path);
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [selected.clone(), selected], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Codex resolver returned duplicate plugin selection"));
+    assert!(stdout.contains("UNSUPPORTED plugin · enabled · unknown · allowed"));
+}
+
+#[test]
+fn malformed_plugin_metadata_is_explicitly_unsupported() {
+    let fixture = fixture();
+    install(
+        &fixture,
+        json!({"marketplaces": []}),
+        json!({"installed": [{"pluginId": "demo@marketplace"}], "available": []}),
+    );
+
+    let (code, stdout, _) = diagnose(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Codex plugin resolver returned invalid JSON"));
+}
+
+#[test]
+fn nullable_artifact_version_is_a_plugin_local_failure() {
+    let fixture = fixture();
+    let root = fixture.home().join(".codex/.tmp/plugins");
+    let path = root.join("plugins/demo");
+    let mut selected = plugin("demo@marketplace", "marketplace", "revision", true, &path);
+    selected["version"] = serde_json::Value::Null;
+    fixture.write_home(
+        ".codex/plugins/cache/marketplace/other/stable/.codex-plugin/plugin.json",
+        r#"{"name":"other","version":"1.0.0"}"#,
+    );
+    let sibling = plugin(
+        "other@marketplace",
+        "marketplace",
+        "stable",
+        false,
+        &root.join("plugins/other"),
+    );
+    install(
+        &fixture,
+        json!({"marketplaces": [marketplace("marketplace", &root)]}),
+        json!({"installed": [selected, sibling], "available": []}),
+    );
+
+    let (code, stdout, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "skills",
+            "--agent",
+            "codex",
+            "--scope",
+            "user",
+            "--verbose",
+        ],
+    );
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Codex resolver has no active artifact identifier"));
+    assert!(stdout.contains("other@marketplace@1.0.0"));
+    assert!(!stdout.contains("returned invalid JSON"));
+}

--- a/tooling/arnes/tests/support/codex.rs
+++ b/tooling/arnes/tests/support/codex.rs
@@ -1,0 +1,52 @@
+use crate::support::Fixture;
+use serde_json::{Value, json};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+pub fn install(fixture: &Fixture, marketplaces: Value, plugins: Value) {
+    fixture.write_home(
+        ".codex-test-marketplaces.json",
+        &serde_json::to_string(&marketplaces).unwrap(),
+    );
+    fixture.write_home(
+        ".codex-test-plugins.json",
+        &serde_json::to_string(&plugins).unwrap(),
+    );
+    install_script(
+        fixture,
+        "#!/bin/sh\nif [ \"$1 $2 $3 $4\" = \"plugin marketplace list --json\" ]; then file=\"$HOME/.codex-test-marketplaces.json\"; elif [ \"$1 $2 $3\" = \"plugin list --json\" ]; then file=\"$HOME/.codex-test-plugins.json\"; else exit 64; fi\nwhile IFS= read -r line || [ -n \"$line\" ]; do printf '%s\\n' \"$line\"; done < \"$file\"\n",
+    );
+}
+
+pub fn install_script(fixture: &Fixture, script: &str) {
+    let path = fixture.home().join("bin/codex");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, script).unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+pub fn marketplace(name: &str, root: &Path) -> Value {
+    json!({"name": name, "root": root})
+}
+
+pub fn plugin(
+    id: &str,
+    marketplace_name: &str,
+    artifact: &str,
+    enabled: bool,
+    path: &Path,
+) -> Value {
+    let name = id.split_once('@').map_or(id, |(name, _)| name);
+    json!({
+        "pluginId": id,
+        "name": name,
+        "marketplaceName": marketplace_name,
+        "version": artifact,
+        "installed": true,
+        "enabled": enabled,
+        "source": {"source": "local", "path": path}
+    })
+}

--- a/tooling/arnes/tests/support/mod.rs
+++ b/tooling/arnes/tests/support/mod.rs
@@ -44,6 +44,7 @@ impl Fixture {
             .current_dir(&self.repository)
             .env_clear()
             .env("HOME", &self.home)
+            .env("PATH", self.home.join("bin"))
             .output()
             .unwrap()
     }


### PR DESCRIPTION
## Résumé

- résout les plugins installés via `codex plugin marketplace list --json` et `codex plugin list --json`, puis reconstruit l’artefact actif avec le contrat `PluginStore::plugin_root` de Codex 0.147.0 ; la table humaine, `source.path` et les caches singletons ne participent pas à la sélection
- conserve séparément l’identifiant d’artefact Codex et la version sémantique du manifeste, inventorie les skills de l’artefact actif et joint exhaustivement configuration et sélection runtime
- valide identité, marketplace et confinement canonique ; rend explicites les schémas invalides, sélections ambiguës, artefacts absents/échappés et incohérences d’exposition
- borne le resolver à cinq secondes et 1 Mio par flux, y compris lorsqu’un descendant conserve les pipes, et l’exécute depuis HOME pour exclure les overrides projet

## Vérification

- `cargo fmt --manifest-path tooling/arnes/Cargo.toml --check`
- `cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tooling/arnes/Cargo.toml` — 449 tests, 0 échec, 0 ignoré
- diagnostic réel macOS 26.5.2 arm64 avec Codex CLI 0.147.0 : 11 plugins résolus, 52 diagnostics sains ; `superpowers@openai-curated@5.1.3` sain/autorisé, artefact `11c74d6b`
- la commande réelle demandée reste exit 1 à cause de trois symlinks managed préexistants et hors périmètre : `handoff`, `enforcement-code`, `merge-verdict`

## Portée

- cible supportée exercée : macOS arm64
- Ubuntu non exercé localement ; le workflow `Arnes tests` couvre fmt, clippy et tests Rust sur `ubuntu-latest`
- Markdown modifié sans linter dédié ; aucun commentaire de code ajouté

Closes #166
