### PR TITLE
chore(harness): remove Ponytail from the agent harness

### DIFF
--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -38,38 +38,6 @@ external:
       scope: user
       id: superpowers@openai-curated
   skills:
-    - agent: claude
-      scope: user
-      origin: managed
-      slug: ponytail
-    - agent: claude
-      scope: user
-      origin: managed
-      slug: ponytail-audit
-    - agent: claude
-      scope: user
-      origin: managed
-      slug: ponytail-debt
-    - agent: claude
-      scope: user
-      origin: managed
-      slug: ponytail-gain
-    - agent: claude
-      scope: user
-      origin: managed
-      slug: ponytail-help
-    - agent: claude
-      scope: user
-      origin: managed
-      slug: ponytail-review
-    - agent: codex
-      scope: user
-      origin: managed
-      slug: ponytail
-    - agent: codex
-      scope: user
-      origin: managed
-      slug: ponytail-help
     - agent: codex
       scope: user
       origin: system


### PR DESCRIPTION
## Summary

- remove the six Claude and two Codex Ponytail managed-skill exemptions from the Arnes manifest
- align the effective harness policy with accepted ADR-029 while preserving generic Ponytail fixtures

## Verification

- `make arnes`
- Claude runtime checks: no `ponytail@ponytail` installation, no `ponytail` marketplace, no global Ponytail skill, no Ponytail Arnes drift
- `cargo fmt --manifest-path tooling/arnes/Cargo.toml --check`
- `cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tooling/arnes/Cargo.toml`

Runtime verification: macOS 26.5.2 arm64, Claude Code 2.1.235. Repository barrier: macOS 26.5.2 arm64, Homebrew Rust/Cargo 1.97.1; GitHub Actions will exercise `ubuntu-latest`.

Closes #169
