### PR TITLE
feat(make): add bilingual Hunspell for Claude Code

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -7,6 +7,8 @@ on:
       - harness/**
       - tooling/makefile-test
       - tooling/fish-deployment-test
+      - tooling/install-hunspell-dictionary
+      - tooling/hunspell-dictionaries-test
       - Makefile
       - .github/workflows/test-deployment.yml
   pull_request:
@@ -15,6 +17,8 @@ on:
       - harness/**
       - tooling/makefile-test
       - tooling/fish-deployment-test
+      - tooling/install-hunspell-dictionary
+      - tooling/hunspell-dictionaries-test
       - Makefile
       - .github/workflows/test-deployment.yml
 
@@ -29,3 +33,4 @@ jobs:
       - uses: actions/checkout@v5
       - run: tooling/makefile-test
       - run: tooling/fish-deployment-test
+      - run: tooling/hunspell-dictionaries-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,16 @@ jobs:
         run: |
           make trust-taps "${{ matrix.target }}" SKIP_PAID_APPS=1
           make trust-taps "${{ matrix.target }}" SKIP_PAID_APPS=1
+
+      - name: Verify Hunspell dictionaries
+        if: matrix.target == 'hunspell' || matrix.target == 'all'
+        run: |
+          discovery=$(hunspell -D </dev/null 2>&1)
+          printf '%s\n' "$discovery"
+          printf '%s\n' "$discovery" | grep -F "$HOME/Library/Spelling/fr"
+          printf '%s\n' "$discovery" | grep -F "$HOME/Library/Spelling/en_US"
+
+          misspellings=$(printf '%s\n' français hello bonjouurr hellloo | hunspell -d fr,en_US -l)
+          expected=$(printf '%s\n' bonjouurr hellloo)
+          printf '%s\n' "$misspellings"
+          test "$misspellings" = "$expected"

--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,7 @@ cursor-measurement-hooks: arnes
 	"${LOCAL_BIN}/arnes" measure install-hooks --agent cursor --command "${LOCAL_BIN}/arnes"
 
 .PHONY: claude-code
-claude-code: ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/commands/pr-feedback.md ~/.claude/hooks/agent_handoff ~/.claude/rules/agent-instructions.md ~/.claude/skills/handoff ~/.claude/skills/enforcement-code ~/.claude/skills/merge-verdict claude-code-measurement-hooks
+claude-code: hunspell ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/commands/pr-feedback.md ~/.claude/hooks/agent_handoff ~/.claude/rules/agent-instructions.md ~/.claude/skills/handoff ~/.claude/skills/enforcement-code ~/.claude/skills/merge-verdict claude-code-measurement-hooks
 ${LOCAL_BIN}/claude:
 	curl -fsSL https://claude.ai/install.sh | bash -s latest
 ~/.claude:
@@ -418,6 +418,18 @@ ${LOCAL_BIN}/claude:
 .PHONY: claude-code-measurement-hooks
 claude-code-measurement-hooks: arnes
 	"${LOCAL_BIN}/arnes" measure install-hooks --agent claude-code --command "${LOCAL_BIN}/arnes"
+
+.PHONY: hunspell
+hunspell: brew ${BREW_BIN}/hunspell hunspell-dictionaries
+${BREW_BIN}/hunspell:
+	brew install hunspell
+
+.PHONY: hunspell-dictionaries
+hunspell-dictionaries:
+	"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/fr_FR/dictionaries/fr.aff" "c176610cd5dc4846806a65ddd029f422d87978bf58f224aa44222662a16a2de5" "$(HOME)/Library/Spelling/fr.aff"
+	"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/fr_FR/dictionaries/fr.dic" "b78a868e31dd6e373b6c3217969afb898a9acde828a5e7ef97308da42218c88c" "$(HOME)/Library/Spelling/fr.dic"
+	"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.aff" "e746c882dd6f303c2c46e7452804b9201115a6942cfeb15f18f8edf774d2e24e" "$(HOME)/Library/Spelling/en_US.aff"
+	"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.dic" "f0b1a234bd178bdd01875b2a392a9647f888b8fe879f79c52aae62c2759b3647" "$(HOME)/Library/Spelling/en_US.dic"
 
 .PHONY: codex
 codex: ${VOLTA_BIN}/codex ${BREW_BIN}/jq ~/.codex/AGENTS.md ~/.agents/skills/handoff ~/.agents/skills/enforcement-code ~/.agents/skills/merge-verdict codex-measurement-hooks

--- a/tooling/hunspell-dictionaries-test
+++ b/tooling/hunspell-dictionaries-test
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+installer=$repository/tooling/install-hunspell-dictionary
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/hunspell-dictionaries-test.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+  echo "hunspell-dictionaries-test: $*" >&2
+  exit 1
+}
+
+assert_failure() {
+  if "$@" >"$test_root/stdout" 2>"$test_root/stderr"; then
+    fail "command unexpectedly succeeded: $*"
+  fi
+}
+
+fake_bin=$test_root/bin
+source_file=$test_root/source
+destination=$test_root/Library/Spelling/fr.aff
+mkdir -p "$fake_bin"
+printf 'dictionary\n' >"$source_file"
+checksum=$(shasum -a 256 "$source_file" | awk '{print $1}')
+real_shasum=$(command -v shasum)
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  '[[ -z ${CURL_MARKER:-} ]] || : >"$CURL_MARKER"' \
+  '[[ ${CURL_SHOULD_FAIL:-0} == 0 ]] || exit 99' \
+  'while (( $# > 0 )); do' \
+  '  if [[ $1 == -o ]]; then' \
+  '    cp "$CURL_SOURCE" "$2"' \
+  '    if [[ -n ${RACE_DESTINATION:-} ]]; then' \
+  '      printf "racing writer\n" >"$RACE_DESTINATION"' \
+  '    fi' \
+  '    if [[ -n ${RACE_DIRECTORY:-} ]]; then' \
+  '      mkdir "$RACE_DIRECTORY"' \
+  '    fi' \
+  '    exit 0' \
+  '  fi' \
+  '  shift' \
+  'done' \
+  'exit 64' >"$fake_bin/curl"
+chmod +x "$fake_bin/curl"
+
+env HOME="$test_root" CURL_SOURCE="$source_file" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+
+cmp -s "$source_file" "$destination" || fail "downloaded dictionary differs from source"
+
+env HOME="$test_root" CURL_SHOULD_FAIL=1 PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+
+printf 'local dictionary\n' >"$destination"
+assert_failure env HOME="$test_root" CURL_SOURCE="$source_file" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+[[ $(cat "$destination") == "local dictionary" ]] || fail "existing dictionary changed"
+
+rm "$destination"
+victim=$test_root/victim
+printf 'keep\n' >"$victim"
+ln -s "$victim" "$destination"
+assert_failure env HOME="$test_root" CURL_SOURCE="$source_file" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+[[ -L $destination ]] || fail "dictionary symlink was replaced"
+[[ $(cat "$victim") == keep ]] || fail "dictionary symlink target changed"
+
+rm "$destination"
+printf 'corrupted\n' >"$source_file"
+assert_failure env HOME="$test_root" CURL_SOURCE="$source_file" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+[[ ! -e $destination ]] || fail "corrupted dictionary was published"
+
+printf 'dictionary\n' >"$source_file"
+assert_failure env HOME="$test_root" CURL_SOURCE="$source_file" RACE_DESTINATION="$destination" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+[[ $(cat "$destination") == "racing writer" ]] || fail "concurrent dictionary was replaced"
+
+rm "$destination"
+assert_failure env HOME="$test_root" CURL_SOURCE="$source_file" RACE_DIRECTORY="$destination" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+[[ -d $destination ]] || fail "concurrent dictionary directory was replaced"
+[[ -z $(find "$destination" -mindepth 1 -print -quit) ]] || fail "dictionary was linked inside a concurrent directory"
+
+rmdir "$destination"
+curl_marker=$test_root/curl-called
+assert_failure env HOME="$test_root" CURL_MARKER="$curl_marker" CURL_SOURCE="$source_file" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff not-a-sha "$destination"
+[[ ! -e $curl_marker ]] || fail "invalid checksum reached curl"
+
+workflow=$repository/.github/workflows/test-deployment.yml
+[[ $(grep -F -c -- '      - tooling/install-hunspell-dictionary' "$workflow") == 2 ]] || fail "dictionary installer does not trigger deployment tests"
+[[ $(grep -F -c -- '      - tooling/hunspell-dictionaries-test' "$workflow") == 2 ]] || fail "dictionary tests do not trigger deployment tests"
+grep -F -q -- '      - run: tooling/hunspell-dictionaries-test' "$workflow" || fail "dictionary tests are not executed by deployment tests"
+
+symlink_home=$test_root/symlink-home
+actual_spelling=$test_root/actual-spelling
+mkdir -p "$symlink_home/Library" "$actual_spelling"
+ln -s "$actual_spelling" "$symlink_home/Library/Spelling"
+assert_failure env HOME="$symlink_home" CURL_SOURCE="$source_file" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$symlink_home/Library/Spelling/fr.aff"
+[[ -z $(find "$actual_spelling" -mindepth 1 -print -quit) ]] || fail "dictionary was installed through a directory symlink"
+
+ancestor_home=$test_root/ancestor-home
+actual_library=$test_root/actual-library
+mkdir "$ancestor_home" "$actual_library"
+ln -s "$actual_library" "$ancestor_home/Library"
+assert_failure env HOME="$ancestor_home" CURL_SOURCE="$source_file" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$ancestor_home/Library/Spelling/fr.aff"
+[[ -z $(find "$actual_library" -mindepth 1 -print -quit) ]] || fail "dictionary was installed through an ancestor symlink"
+
+assert_failure env HOME="$test_root" CURL_SHOULD_FAIL=1 PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+[[ ! -e $destination ]] || fail "failed download published a dictionary"
+
+printf 'dictionary\n' >"$destination"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'path=${@: -1}' \
+  'if [[ $path == "$SWAP_DESTINATION" ]]; then' \
+  '  rm "$SWAP_DESTINATION"' \
+  '  ln -s "$SWAP_TARGET" "$SWAP_DESTINATION"' \
+  'fi' \
+  'exec "$REAL_SHASUM" "$@"' >"$fake_bin/shasum"
+chmod +x "$fake_bin/shasum"
+assert_failure env HOME="$test_root" REAL_SHASUM="$real_shasum" SWAP_DESTINATION="$destination" SWAP_TARGET="$source_file" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+[[ -L $destination ]] || fail "dictionary replacement race did not run"
+
+rm "$destination"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 127' >"$fake_bin/shasum"
+chmod +x "$fake_bin/shasum"
+assert_failure env HOME="$test_root" CURL_SOURCE="$source_file" PATH="$fake_bin:$PATH" \
+  "$installer" https://example.test/fr.aff "$checksum" "$destination"
+[[ ! -e $destination ]] || fail "dictionary was published without checksum verification"
+[[ -z $(find "$(dirname "$destination")" -name '.hunspell-dictionary.*' -print -quit) ]] || fail "temporary dictionary was not removed"
+
+echo "Hunspell dictionary tests passed"

--- a/tooling/hunspell-dictionaries-test
+++ b/tooling/hunspell-dictionaries-test
@@ -95,6 +95,9 @@ workflow=$repository/.github/workflows/test-deployment.yml
 [[ $(grep -F -c -- '      - tooling/install-hunspell-dictionary' "$workflow") == 2 ]] || fail "dictionary installer does not trigger deployment tests"
 [[ $(grep -F -c -- '      - tooling/hunspell-dictionaries-test' "$workflow") == 2 ]] || fail "dictionary tests do not trigger deployment tests"
 grep -F -q -- '      - run: tooling/hunspell-dictionaries-test' "$workflow" || fail "dictionary tests are not executed by deployment tests"
+smoke_workflow=$repository/.github/workflows/test.yml
+grep -F -q -- 'hunspell -D' "$smoke_workflow" || fail "smoke tests do not verify dictionary discovery"
+grep -F -q -- 'hunspell -d fr,en_US -l' "$smoke_workflow" || fail "smoke tests do not verify bilingual spelling"
 
 symlink_home=$test_root/symlink-home
 actual_spelling=$test_root/actual-spelling

--- a/tooling/install-hunspell-dictionary
+++ b/tooling/install-hunspell-dictionary
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+url=${1:?missing source URL}
+expected_checksum=${2:?missing SHA-256 checksum}
+destination=${3:?missing destination path}
+
+if [[ ! $expected_checksum =~ ^[0-9a-f]{64}$ ]]; then
+  echo "Invalid SHA-256 checksum: $expected_checksum" >&2
+  exit 64
+fi
+
+if [[ ! -x /usr/bin/perl ]]; then
+  echo "Missing required runtime: /usr/bin/perl" >&2
+  exit 69
+fi
+
+checksum_file() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+ensure_directory() {
+  local directory=$1
+
+  if [[ -e $directory || -L $directory ]]; then
+    if [[ ! -d $directory || -L $directory ]]; then
+      echo "Refusing non-regular dictionary directory: $directory" >&2
+      exit 1
+    fi
+    return
+  fi
+
+  mkdir "$directory"
+}
+
+destination_directory=$(dirname "$destination")
+spelling_directory=$HOME/Library/Spelling
+if [[ $destination_directory != "$spelling_directory" ]]; then
+  echo "Refusing dictionary destination outside $spelling_directory: $destination" >&2
+  exit 1
+fi
+if [[ ! -d $HOME || -L $HOME ]]; then
+  echo "Refusing non-regular home directory: $HOME" >&2
+  exit 1
+fi
+ensure_directory "$HOME/Library"
+ensure_directory "$spelling_directory"
+
+if [[ -e $destination || -L $destination ]]; then
+  if [[ ! -f $destination || -L $destination ]]; then
+    echo "Refusing non-regular dictionary destination: $destination" >&2
+    exit 1
+  fi
+  actual_checksum=$(checksum_file "$destination")
+  if [[ $actual_checksum == "$expected_checksum" && -f $destination && ! -L $destination ]]; then
+    exit 0
+  fi
+  echo "Refusing to replace existing dictionary: $destination" >&2
+  exit 1
+fi
+
+temporary=$(mktemp "$destination_directory/.hunspell-dictionary.XXXXXX")
+trap 'rm -f "$temporary"' EXIT
+
+curl -fsSL -o "$temporary" "$url"
+actual_checksum=$(checksum_file "$temporary")
+if [[ $actual_checksum != "$expected_checksum" ]]; then
+  echo "SHA-256 mismatch for $url" >&2
+  exit 1
+fi
+
+chmod 0644 "$temporary"
+if /usr/bin/perl -e 'link($ARGV[0], $ARGV[1]) or die "$!\n"' "$temporary" "$destination"; then
+  if [[ ! -f $destination || -L $destination ]] || [[ $(checksum_file "$destination") != "$expected_checksum" ]]; then
+    echo "Dictionary publication postcondition failed: $destination" >&2
+    exit 1
+  fi
+  rm "$temporary"
+  trap - EXIT
+  exit 0
+fi
+
+if [[ -f $destination && ! -L $destination ]]; then
+  actual_checksum=$(checksum_file "$destination")
+  if [[ $actual_checksum == "$expected_checksum" ]]; then
+    exit 0
+  fi
+fi
+
+echo "Refusing to replace concurrent dictionary destination: $destination" >&2
+exit 1

--- a/tooling/makefile-test
+++ b/tooling/makefile-test
@@ -199,4 +199,26 @@ handoff_line=$(grep -n -F -- 'old_command=' "$case_root/codex" | cut -d: -f1)
 measurement_line=$(grep -n -F -- 'measure install-hooks --agent codex' "$case_root/codex" | cut -d: -f1)
 [[ -n $handoff_line && -n $measurement_line && $handoff_line -lt $measurement_line ]] || fail "Codex handoff hook is not installed before measurement hooks"
 
+case_root=$test_root/hunspell_wiring
+test_home=$case_root/home
+fake_bin=$case_root/bin
+mkdir -p "$test_home" "$fake_bin"
+hunspell_trace=$case_root/hunspell
+claude_trace=$case_root/claude-code
+revision=f2ff99058268502bdcf4cad25c1ca2935ad8aa7d
+base_url=https://raw.githubusercontent.com/LibreOffice/dictionaries/$revision
+env HOME="$test_home" make -n -f "$repository/Makefile" DOTFILES_PATH="$repository" BREW_BIN="$fake_bin" hunspell >"$hunspell_trace"
+[[ $(grep -F -c -- 'brew install hunspell' "$hunspell_trace") == 1 ]] || fail "hunspell does not install its Homebrew formula exactly once"
+for specification in \
+  "fr_FR/dictionaries/fr.aff c176610cd5dc4846806a65ddd029f422d87978bf58f224aa44222662a16a2de5 fr.aff" \
+  "fr_FR/dictionaries/fr.dic b78a868e31dd6e373b6c3217969afb898a9acde828a5e7ef97308da42218c88c fr.dic" \
+  "en/en_US.aff e746c882dd6f303c2c46e7452804b9201115a6942cfeb15f18f8edf774d2e24e en_US.aff" \
+  "en/en_US.dic f0b1a234bd178bdd01875b2a392a9647f888b8fe879f79c52aae62c2759b3647 en_US.dic"; do
+  read -r source checksum destination_name <<<"$specification"
+  expected="\"$repository/tooling/install-hunspell-dictionary\" \"$base_url/$source\" \"$checksum\" \"$test_home/Library/Spelling/$destination_name\""
+  [[ $(grep -F -c -- "$expected" "$hunspell_trace") == 1 ]] || fail "hunspell does not deploy $destination_name exactly once"
+done
+env HOME="$test_home" make -n -f "$repository/Makefile" DOTFILES_PATH="$repository" BREW_BIN="$fake_bin" claude-code >"$claude_trace"
+grep -F -q -- 'brew install hunspell' "$claude_trace" || fail "claude-code does not depend on hunspell"
+
 echo "Makefile tests passed"


### PR DESCRIPTION
## Summary

- install Hunspell through the canonical Makefile and make `claude-code` depend on it
- deploy pinned LibreOffice `fr` and `en_US` dictionaries after SHA-256 verification, without replacing existing files or following stable symlink destinations
- run deployment guards on macOS/Linux and verify real bilingual Hunspell discovery and witnesses in the macOS smoke job
- leave CSpell and its Neovim integration unchanged

## Manual Claude setting

Merge this block manually into the existing `~/.claude/settings.json`; do not replace the file:

```json
"spellcheck": {
  "enabled": true,
  "checker": "hunspell",
  "language": "fr,en_US"
}
```

Claude ignores this setting at project scope. French stays first because Hunspell uses the first dictionary as its base.

## Verification

- `tooling/makefile-test`
- `tooling/fish-deployment-test`
- `tooling/hunspell-dictionaries-test`
- `tooling/ci-smoke-targets-test`
- `bash -n` and ShellCheck on every changed shell script
- CSpell trace and lint: 3 files checked, 0 issues
- `make -n hunspell`
- live temporary downloads reproduced all four pinned SHA-256 values

The macOS smoke job installs twice, checks `hunspell -D`, accepts French and English witnesses, and rejects one misspelling in each language. Linux exercises the installer and failure paths only; dictionary discovery is not claimed there. `actionlint` was unavailable locally and remains enforced by CI.

## Safety boundary

Publication is atomic and no-clobber for each dictionary file. Stable symlink, non-regular, divergent, corrupted, incomplete, and tested concurrent final-name creation cases fail closed. This personal installer is not a security boundary against a hostile local process concurrently replacing destinations or renaming parent directories.

Closes #171
