### PR TITLE
fix(codegraph): trigger the skill on repository audits

### DIFF
--- a/.agents/skills/codegraph/SKILL.md
+++ b/.agents/skills/codegraph/SKILL.md
@@ -31,15 +31,18 @@ monorepo`.
    measuring or initializing CodeGraph.
 2. For structural exploration, check whether `.codegraph/` exists.
 3. When the index exists, prefix the CLI environment below and run `codegraph status --json`.
-4. If status is healthy, use `codegraph_explore` before broad grep, find, or file reads.
-5. If status reports stale or incomplete state, run `codegraph sync` once and check status again.
-6. When the index is absent, run `codegraph-repository-size .`.
-7. If `initialize` is true, prefix the CLI environment, run `codegraph init`, confirm status, then
+4. If status reports a non-null `worktreeMismatch`, the index belongs to another working tree: do
+   not query it. Measure this worktree and initialize here when the threshold is met, otherwise
+   continue with `rg` and `fd`.
+5. If status is healthy, use `codegraph_explore` before broad grep, find, or file reads.
+6. If status reports stale or incomplete state, run `codegraph sync` once and check status again.
+7. When the index is absent, run `codegraph-repository-size .`.
+8. If `initialize` is true, prefix the CLI environment, run `codegraph init`, confirm status, then
    use `codegraph_explore`.
-8. If `initialize` is false, continue with `rg` and `fd` without initializing.
-9. If measurement, initialization, synchronization, or the second status check fails, name the
-   failure and fall back explicitly to `rg` and `fd`.
-10. Verify important graph claims in the source before editing.
+9. If `initialize` is false, continue with `rg` and `fd` without initializing.
+10. If measurement, initialization, synchronization, or the second status check fails, name the
+    failure and fall back explicitly to `rg` and `fd`.
+11. Verify important graph claims in the source before editing.
 
 Prefix every CodeGraph CLI call with:
 
@@ -56,6 +59,9 @@ threshold. Initialization uses OR: 50000 source lines or 500 source files.
   the task first and keep literals, regular expressions, and known paths on `rg` or `fd`.
 - **Trusting unchecked graph state** — a stale index can produce obsolete conclusions; run status
   before structural exploration and synchronize at most once when required.
+- **Querying a sibling working tree** — an index resolved from a parent repository reports
+  `state: complete` while describing another checkout; read `worktreeMismatch` before trusting
+  freshness.
 - **Recovering destructively** — automatic uninitialization or reindexing can discard useful state;
   diagnose corruption, locks, or incompatibility and request approval before recovery.
 - **Treating retrieval as refactoring or debugging** — graph results do not provide semantic edits

--- a/.agents/skills/codegraph/SKILL.md
+++ b/.agents/skills/codegraph/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: codegraph
 description: >
-  Explore large repositories structurally with CodeGraph. Use when locating architecture, call
-  paths, dependencies, cross-package behavior, change impact, or validating an existing .codegraph
-  index. Make sure to use this skill before broad file-by-file exploration, even if CodeGraph was
-  not requested.
+  Explore large repositories structurally with CodeGraph. Use when auditing an unfamiliar
+  repository, or when locating architecture, call paths, dependencies, cross-package behavior,
+  change impact, or validating an existing .codegraph index. Make sure to use this skill before any
+  broad exploration, including an audit or a technical-debt review, even if CodeGraph was not
+  requested.
 metadata:
   category: dev
 ---

--- a/.agents/skills/codegraph/evals/trigger-queries.json
+++ b/.agents/skills/codegraph/evals/trigger-queries.json
@@ -18,6 +18,16 @@
       "reason": "Existing index freshness and synchronization"
     },
     {
+      "query": "Fais un audit de ce dépôt et liste-moi la dette technique",
+      "should_activate": true,
+      "reason": "Repository-wide audit is open-ended structural exploration before file-by-file reading"
+    },
+    {
+      "query": "Je découvre ce monorepo, aide-moi à le cartographier",
+      "should_activate": true,
+      "reason": "First contact with an unfamiliar repository needs structural retrieval, not targeted reads"
+    },
+    {
       "query": "Trouve exactement la chaîne FEATURE_FLAG_DISABLED avec rg",
       "should_activate": false,
       "reason": "Exact literal lookup must stay on rg"

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -21,6 +21,11 @@ skills:
       - { agent: claude, scope: user }
       - { agent: cursor, scope: user }
       - { agent: codex, scope: user }
+  - slug: codegraph
+    installations:
+      - { agent: claude, scope: user }
+      - { agent: cursor, scope: user }
+      - { agent: codex, scope: user }
 external:
   roots:
     - agent: codex

--- a/tooling/arnes/tests/measure_hook/support.rs
+++ b/tooling/arnes/tests/measure_hook/support.rs
@@ -36,7 +36,14 @@ impl Harness {
 
     pub(super) fn run(&self, agent: &str, payload: &[u8]) -> Output {
         let mut child = self.command(agent).spawn().unwrap();
-        child.stdin.take().unwrap().write_all(payload).unwrap();
+        let mut stdin = child.stdin.take().unwrap();
+        // clap rejects an invalid --agent and exits before reading stdin, so EPIPE is expected.
+        match stdin.write_all(payload) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(error) => panic!("writing the hook payload failed: {error}"),
+        }
+        drop(stdin);
         child.wait_with_output().unwrap()
     }
 


### PR DESCRIPTION
## Contexte

Un audit lancé dans un monorepo de 319 002 lignes source n'a pas déclenché la skill `codegraph`,
et ce dépôt n'avait aucun index. Le diagnostic écarte la panne : CLI 1.5.0 installé, serveur MCP
enregistré en scope `user`, symlinks de la skill sains sur les trois agents, et
`make codegraph-test` vert de bout en bout.

Deux défauts indépendants restaient.

## 1. Déclencheur de la skill

La description nommait « architecture, call paths, dependencies, change impact » mais aucune
formulation réellement employée pour lancer un audit de dépôt. Sans activation, la skill n'a jamais
mesuré le dépôt ni initialisé l'index que l'ADR-039 impose au-delà de 50 000 lignes ou 500 fichiers.

La description couvre désormais l'audit et la première prise de contact avec un dépôt inconnu
(381 caractères, sous la cible locale de 400). Deux scénarios positifs sont ajoutés aux evals.

## 2. Déclaration `arnes`

Le `Makefile` installe la skill `codegraph` dans les scopes `user` de Claude Code, Cursor et Codex,
mais le manifeste ne la déclarait pas. `arnes doctor skills` la signalait comme skill externe
inattendue sur les trois agents :

```
DRIFT codegraph · managed · enabled · healthy · unexpected
```

Le manifeste la déclare maintenant, et le diagnostic est vert sur les trois agents.

## 3. Index résolu depuis un autre arbre de travail

Depuis un worktree, codegraph résout l'index le plus proche à partir du chemin et remonte donc à
celui du dépôt parent, qu'il déclare sain — `state: complete`, `pendingChanges` vide,
`reindexRecommended: false`. Seul le champ `worktreeMismatch` nomme l'écart, et la skill ne le lisait
pas : un agent travaillant dans un worktree interrogeait un index décrivant un autre checkout.

Vérifié dans `modelo-hub/.worktrees/socle` (HEAD détaché) contre un index construit depuis `staging`.
Le dépôt ignore `.worktrees/`, donc aucun fichier du worktree ne figurait dans cet index : ni index
vide, ni index pollué — un index faux.

La skill lit désormais `worktreeMismatch` avant de conclure à la fraîcheur, et retombe sur la mesure
puis `rg` et `fd`. `docs/codegraph.md` et l'ADR-039 ne sont pas modifiés : ils ne mentionnent le
worktree que pour son coût disque.

## Vérification — macOS 25.5.0, Linux non exercé

| Barrière | Résultat |
| --- | --- |
| `measure_repository_test.sh` | vert |
| `tooling/codegraph-configure-test` | vert |
| `tooling/codegraph-mcp-test` | vert — init, sync, bascule de branche, redémarrage, arrêt daemon |
| `tooling/codegraph-network-test` | vert — 0 socket réseau observé |
| `cargo test` (arnes) | 449 tests, 0 échec |
| Index `.agents/skills/README.md` | régénéré byte-identique, idempotent |
| Contrôles doctor de la skill | aucune régression |

La validation standard `skills-ref` reste indisponible : l'outil n'est pas installé et les
conventions interdisent de l'installer pendant une validation.

## Réserves

1. Les evals ajoutées sont des **scénarios**, pas des exécutions enregistrées. Les conventions
   exigent un contexte d'agent frais ; aucun n'a été lancé ici. Le prochain audit réel servira de
   mesure, et la convention §9 restera la référence avant tout ajout de règle de routage.
2. Aucun index n'est versionné ni créé par cette PR. L'index construit pendant le diagnostic vit
   hors dépôt, dans le monorepo concerné, et reste ignoré par le `core.excludesFile` global.
3. Chaque worktree paie son propre index, conformément à l'ADR-039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PieUiAgE3tf41c5EuwkLx
