### PR TITLE
feat(arnes): audit agent model defaults

### DIFF
--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -2,10 +2,21 @@ version: 1
 agents:
   - id: claude
     scopes: [user, project]
+    user_config:
+      model: opus[1m]
+      effort: high
+      auto_compact_window: 600000
   - id: cursor
     scopes: [user, project]
+    user_config:
+      model: grok-4.6
+      max_mode: false
   - id: codex
     scopes: [user, project]
+    user_config:
+      model: gpt-5.6-sol
+      effort: medium
+      context_window: 270000
 skills:
   - slug: claude-developer
     installations:

--- a/tooling/arnes/src/config.rs
+++ b/tooling/arnes/src/config.rs
@@ -6,20 +6,10 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
 
-#[derive(Clone, Copy)]
-enum ConfigFormat {
-    Json,
-    Toml,
-}
+mod defaults;
+mod format;
 
-impl Display for ConfigFormat {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(match self {
-            Self::Json => "JSON",
-            Self::Toml => "TOML",
-        })
-    }
-}
+use format::{ConfigFormat, ParseError};
 
 struct Specification {
     root: &'static str,
@@ -49,11 +39,11 @@ pub fn diagnose(
 
     combinations
         .into_iter()
-        .map(|(agent, scope)| diagnose_one(roots, agent, scope))
+        .map(|(agent, scope)| diagnose_one(roots, manifest, agent, scope))
         .collect()
 }
 
-fn diagnose_one(roots: &Roots, agent: Agent, scope: Scope) -> Diagnostic {
+fn diagnose_one(roots: &Roots, manifest: &Manifest, agent: Agent, scope: Scope) -> Diagnostic {
     let specification = specification(agent, scope);
     let base = match scope {
         Scope::User => roots.home(),
@@ -76,12 +66,8 @@ fn diagnose_one(roots: &Roots, agent: Agent, scope: Scope) -> Diagnostic {
         Err(diagnostic) => return diagnostic,
     };
 
-    match validate(&input, specification.format) {
-        Ok(()) => Diagnostic::new(
-            "config",
-            State::Healthy,
-            format!("{subject} file {file_label} is valid"),
-        ),
+    match format::parse(&input, specification.format) {
+        Ok(value) => diagnose_defaults(manifest, agent, scope, &value, &subject, &file_label),
         Err(ParseError::Malformed) => Diagnostic::new(
             "config",
             State::Error,
@@ -98,6 +84,39 @@ fn diagnose_one(roots: &Roots, agent: Agent, scope: Scope) -> Diagnostic {
                 specification.format
             ),
         ),
+    }
+}
+
+fn diagnose_defaults(
+    manifest: &Manifest,
+    agent: Agent,
+    scope: Scope,
+    value: &serde_json::Value,
+    subject: &str,
+    file_label: &str,
+) -> Diagnostic {
+    let mismatches = match scope {
+        Scope::User => manifest
+            .user_config(agent)
+            .map(|config| defaults::mismatches(agent, config, value))
+            .unwrap_or_default(),
+        Scope::Project => Vec::new(),
+    };
+    if mismatches.is_empty() {
+        Diagnostic::new(
+            "config",
+            State::Healthy,
+            format!("{subject} file {file_label} is valid"),
+        )
+    } else {
+        Diagnostic::new(
+            "config",
+            State::Drift,
+            format!(
+                "{subject} file {file_label} differs from manifest defaults: {}",
+                mismatches.join(", ")
+            ),
+        )
     }
 }
 
@@ -154,26 +173,6 @@ fn unreadable(subject: &str, kind: &str, path: &str) -> Diagnostic {
         State::Error,
         format!("{subject} {kind} {path} could not be read"),
     )
-}
-
-enum ParseError {
-    Malformed,
-    WrongRoot,
-}
-
-fn validate(input: &str, format: ConfigFormat) -> Result<(), ParseError> {
-    match format {
-        ConfigFormat::Json => match serde_json::from_str::<serde_json::Value>(input) {
-            Ok(serde_json::Value::Object(_)) => Ok(()),
-            Ok(_) => Err(ParseError::WrongRoot),
-            Err(_) => Err(ParseError::Malformed),
-        },
-        ConfigFormat::Toml => match toml::from_str::<toml::Value>(input) {
-            Ok(toml::Value::Table(_)) => Ok(()),
-            Ok(_) => Err(ParseError::WrongRoot),
-            Err(_) => Err(ParseError::Malformed),
-        },
-    }
 }
 
 fn specification(agent: Agent, scope: Scope) -> Specification {

--- a/tooling/arnes/src/config/defaults.rs
+++ b/tooling/arnes/src/config/defaults.rs
@@ -1,0 +1,71 @@
+use crate::manifest::{Agent, UserConfig};
+use serde_json::{Value, json};
+
+pub(super) fn mismatches(agent: Agent, config: &UserConfig, actual: &Value) -> Vec<String> {
+    let mut expected = vec![("model", json!(config.model))];
+    match agent {
+        Agent::Claude => {
+            push(&mut expected, "effortLevel", config.effort.as_ref());
+            push(
+                &mut expected,
+                "autoCompactWindow",
+                config.auto_compact_window,
+            );
+        }
+        Agent::Cursor => {
+            expected[0].0 = "model.modelId";
+            push(&mut expected, "maxMode", config.max_mode);
+        }
+        Agent::Codex => {
+            push(
+                &mut expected,
+                "model_reasoning_effort",
+                config.effort.as_ref(),
+            );
+            push(&mut expected, "model_context_window", config.context_window);
+            push(
+                &mut expected,
+                "model_auto_compact_token_limit",
+                config.auto_compact_window,
+            );
+        }
+    }
+    expected
+        .into_iter()
+        .filter_map(|(path, expected)| mismatch(actual, path, expected))
+        .collect()
+}
+
+fn push<T: serde::Serialize>(
+    expected: &mut Vec<(&'static str, Value)>,
+    path: &'static str,
+    value: Option<T>,
+) {
+    if let Some(value) = value {
+        expected.push((path, json!(value)));
+    }
+}
+
+fn mismatch(actual: &Value, path: &str, expected: Value) -> Option<String> {
+    match lookup(actual, path) {
+        Some(actual) if actual == &expected => None,
+        Some(actual) => Some(format!(
+            "{path} is {} (expected {})",
+            display(actual),
+            display(&expected)
+        )),
+        None => Some(format!(
+            "{path} is missing (expected {})",
+            display(&expected)
+        )),
+    }
+}
+
+fn lookup<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    path.split('.')
+        .try_fold(value, |value, part| value.get(part))
+}
+
+fn display(value: &Value) -> String {
+    serde_json::to_string(value).expect("JSON values serialize")
+}

--- a/tooling/arnes/src/config/format.rs
+++ b/tooling/arnes/src/config/format.rs
@@ -1,0 +1,39 @@
+use serde_json::Value;
+use std::fmt::{self, Display};
+
+#[derive(Clone, Copy)]
+pub(super) enum ConfigFormat {
+    Json,
+    Toml,
+}
+
+impl Display for ConfigFormat {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Json => "JSON",
+            Self::Toml => "TOML",
+        })
+    }
+}
+
+pub(super) enum ParseError {
+    Malformed,
+    WrongRoot,
+}
+
+pub(super) fn parse(input: &str, format: ConfigFormat) -> Result<Value, ParseError> {
+    match format {
+        ConfigFormat::Json => match serde_json::from_str::<Value>(input) {
+            Ok(value @ Value::Object(_)) => Ok(value),
+            Ok(_) => Err(ParseError::WrongRoot),
+            Err(_) => Err(ParseError::Malformed),
+        },
+        ConfigFormat::Toml => match toml::from_str::<toml::Value>(input) {
+            Ok(value @ toml::Value::Table(_)) => {
+                serde_json::to_value(value).map_err(|_| ParseError::Malformed)
+            }
+            Ok(_) => Err(ParseError::WrongRoot),
+            Err(_) => Err(ParseError::Malformed),
+        },
+    }
+}

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -4,12 +4,14 @@ use std::fmt::{self, Display};
 use std::path::{Path, PathBuf};
 
 mod commands;
+mod config;
 mod external;
 mod parsing;
 mod prompts;
 mod validation;
 
 pub use commands::{Command, CommandBinding};
+pub use config::UserConfig;
 pub use external::{ExternalOrigin, ExternalRoot, ExternalSkill};
 pub use parsing::{load, parse};
 pub use prompts::{Prompt, PromptProjection, PromptRepresentation};
@@ -62,6 +64,13 @@ impl Manifest {
         self.agents
             .iter()
             .flat_map(|agent| agent.scopes.iter().map(move |scope| (agent.id, *scope)))
+    }
+
+    pub fn user_config(&self, agent: Agent) -> Option<&UserConfig> {
+        self.agents
+            .iter()
+            .find(|declaration| declaration.id == agent)
+            .and_then(|declaration| declaration.user_config.as_ref())
     }
 
     pub fn instruction_resources(&self) -> impl Iterator<Item = InstructionResource<'_>> {
@@ -171,6 +180,7 @@ struct SkillInstallation {
 struct AgentDeclaration {
     id: Agent,
     scopes: Vec<Scope>,
+    user_config: Option<UserConfig>,
 }
 
 #[derive(Deserialize)]

--- a/tooling/arnes/src/manifest/config.rs
+++ b/tooling/arnes/src/manifest/config.rs
@@ -1,0 +1,129 @@
+use super::{Agent, AgentDeclaration, ManifestError, Scope};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserConfig {
+    pub model: String,
+    pub effort: Option<String>,
+    pub context_window: Option<u64>,
+    pub auto_compact_window: Option<u64>,
+    pub max_mode: Option<bool>,
+}
+
+pub(super) fn validate(
+    agents: &[AgentDeclaration],
+    agent_index: usize,
+) -> Result<(), ManifestError> {
+    let declaration = &agents[agent_index];
+    let Some(config) = &declaration.user_config else {
+        return Ok(());
+    };
+    let field = |name: &str| format!("agents[{agent_index}].user_config.{name}");
+    if !declaration.scopes.contains(&Scope::User) {
+        return Err(ManifestError::new(
+            format!("agents[{agent_index}].user_config"),
+            "requires the user scope",
+        ));
+    }
+    if config.model.is_empty() {
+        return Err(ManifestError::new(field("model"), "cannot be empty"));
+    }
+    validate_effort(config, declaration.id, &field)?;
+    validate_capabilities(config, declaration.id, &field)
+}
+
+fn validate_effort(
+    config: &UserConfig,
+    agent: Agent,
+    field: &impl Fn(&str) -> String,
+) -> Result<(), ManifestError> {
+    let Some(effort) = config.effort.as_deref() else {
+        return Ok(());
+    };
+    if agent == Agent::Cursor {
+        return Err(ManifestError::new(
+            field("effort"),
+            "cursor does not expose a persistent effort setting",
+        ));
+    }
+    if matches!(effort, "low" | "medium" | "high" | "xhigh") {
+        Ok(())
+    } else {
+        Err(ManifestError::new(
+            field("effort"),
+            "expected low, medium, high, or xhigh",
+        ))
+    }
+}
+
+fn validate_capabilities(
+    config: &UserConfig,
+    agent: Agent,
+    field: &impl Fn(&str) -> String,
+) -> Result<(), ManifestError> {
+    if config.context_window == Some(0) {
+        return Err(ManifestError::new(
+            field("context_window"),
+            "must be greater than zero",
+        ));
+    }
+    if config.auto_compact_window == Some(0) {
+        return Err(ManifestError::new(
+            field("auto_compact_window"),
+            "must be greater than zero",
+        ));
+    }
+    if agent == Agent::Claude
+        && config
+            .auto_compact_window
+            .is_some_and(|window| !(100_000..=1_000_000).contains(&window))
+    {
+        return Err(ManifestError::new(
+            field("auto_compact_window"),
+            "must be between 100000 and 1000000",
+        ));
+    }
+    if agent == Agent::Codex
+        && config
+            .context_window
+            .zip(config.auto_compact_window)
+            .is_some_and(|(context, compact)| compact >= context)
+    {
+        return Err(ManifestError::new(
+            field("auto_compact_window"),
+            "must be smaller than context_window",
+        ));
+    }
+    match agent {
+        Agent::Codex if config.max_mode.is_some() => Err(ManifestError::new(
+            field("max_mode"),
+            "codex does not expose max mode",
+        )),
+        Agent::Claude if config.context_window.is_some() || config.max_mode.is_some() => {
+            let name = if config.context_window.is_some() {
+                "context_window"
+            } else {
+                "max_mode"
+            };
+            Err(ManifestError::new(
+                field(name),
+                "claude does not expose this persistent setting",
+            ))
+        }
+        Agent::Cursor
+            if config.context_window.is_some() || config.auto_compact_window.is_some() =>
+        {
+            let name = if config.context_window.is_some() {
+                "context_window"
+            } else {
+                "auto_compact_window"
+            };
+            Err(ManifestError::new(
+                field(name),
+                "cursor does not expose this persistent setting",
+            ))
+        }
+        _ => Ok(()),
+    }
+}

--- a/tooling/arnes/src/manifest/validation.rs
+++ b/tooling/arnes/src/manifest/validation.rs
@@ -74,6 +74,7 @@ pub(super) fn validate(manifest: &Manifest) -> Result<(), ManifestError> {
                 ));
             }
         }
+        super::config::validate(&manifest.agents, agent_index)?;
         agents.insert(agent.id, scopes);
     }
 

--- a/tooling/arnes/tests/config_defaults.rs
+++ b/tooling/arnes/tests/config_defaults.rs
@@ -1,0 +1,129 @@
+mod support;
+
+use support::Fixture;
+
+const MANIFEST: &str = "version: 1
+agents:
+  - id: claude
+    scopes: [user, project]
+    user_config:
+      model: opus[1m]
+      effort: high
+      auto_compact_window: 600000
+  - id: cursor
+    scopes: [user, project]
+    user_config:
+      model: grok-4.6
+      max_mode: false
+  - id: codex
+    scopes: [user, project]
+    user_config:
+      model: gpt-5.6-sol
+      effort: medium
+      context_window: 270000
+resources: []
+";
+
+fn configured_fixture() -> Fixture {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", MANIFEST);
+    fixture.write_home(
+        ".claude/settings.json",
+        r#"{
+            "model": "opus[1m]",
+            "effortLevel": "high",
+            "autoCompactWindow": 600000,
+            "unknown": true
+        }"#,
+    );
+    fixture.write_home(
+        ".cursor/cli-config.json",
+        r#"{
+            "model": {"modelId": "grok-4.6", "displayName": "Cursor Grok 4.6"},
+            "maxMode": false,
+            "unknown": true
+        }"#,
+    );
+    fixture.write_home(
+        ".codex/config.toml",
+        "model = \"gpt-5.6-sol\"\nmodel_reasoning_effort = \"medium\"\nmodel_context_window = 270000\nunknown = true\n",
+    );
+    for path in [".claude/settings.json", ".cursor/cli.json"] {
+        fixture.write_repository(path, r#"{"unknown": true}"#);
+    }
+    fixture.write_repository(".codex/config.toml", "unknown = true\n");
+    fixture
+}
+
+fn run(fixture: &Fixture, args: &[&str]) -> (i32, String) {
+    let output = fixture.command(args);
+    (
+        output.status.code().unwrap(),
+        String::from_utf8(output.stdout).unwrap(),
+    )
+}
+
+#[test]
+fn native_user_settings_satisfy_manifest_defaults_as_subsets() {
+    let fixture = configured_fixture();
+    let before = fixture.snapshot();
+    let (code, stdout) = run(&fixture, &["doctor", "config", "-v"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(stdout.matches("healthy config:").count(), 3);
+    assert!(fixture.home().is_dir());
+    assert!(fixture.repository().is_dir());
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn missing_and_different_defaults_are_drift() {
+    let fixture = configured_fixture();
+    fixture.write_home(
+        ".claude/settings.json",
+        r#"{"model":"sonnet","effortLevel":"xhigh"}"#,
+    );
+    let (code, stdout) = run(&fixture, &["doctor", "config", "--agent", "claude", "-v"]);
+
+    assert_eq!(code, 1);
+    assert!(stdout.contains(r#"model is "sonnet" (expected "opus[1m]")"#));
+    assert!(stdout.contains(r#"effortLevel is "xhigh" (expected "high")"#));
+    assert!(stdout.contains("autoCompactWindow is missing (expected 600000)"));
+}
+
+#[test]
+fn cursor_model_id_is_compared_without_requiring_managed_metadata() {
+    let fixture = configured_fixture();
+    fixture.write_home(
+        ".cursor/cli-config.json",
+        r#"{"model":{"modelId":"auto"},"maxMode":true}"#,
+    );
+    let (code, stdout) = run(&fixture, &["doctor", "config", "--agent", "cursor", "-v"]);
+
+    assert_eq!(code, 1);
+    assert!(stdout.contains(r#"model.modelId is "auto" (expected "grok-4.6")"#));
+    assert!(stdout.contains("maxMode is true (expected false)"));
+}
+
+#[test]
+fn codex_defaults_use_toml_key_names() {
+    let fixture = configured_fixture();
+    fixture.write_home(
+        ".codex/config.toml",
+        "model = \"gpt-5.6-sol\"\nmodel_reasoning_effort = \"medium\"\n",
+    );
+    let (code, stdout) = run(&fixture, &["doctor", "config", "--agent", "codex", "-v"]);
+
+    assert_eq!(code, 1);
+    assert!(stdout.contains("model_context_window is missing (expected 270000)"));
+    assert!(!stdout.contains("model_auto_compact_token_limit"));
+}
+
+#[test]
+fn project_configurations_do_not_inherit_user_defaults() {
+    let fixture = configured_fixture();
+    let (code, stdout) = run(&fixture, &["doctor", "config", "--scope", "project", "-v"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(stdout.matches("healthy config:").count(), 3);
+}

--- a/tooling/arnes/tests/manifest_config.rs
+++ b/tooling/arnes/tests/manifest_config.rs
@@ -1,0 +1,58 @@
+use arnes::manifest;
+
+fn error(agent: &str) -> String {
+    let input = format!("version: 1\nagents:\n{agent}resources: []\n");
+    manifest::parse(&input).err().unwrap().to_string()
+}
+
+#[test]
+fn user_defaults_require_user_scope() {
+    assert_eq!(
+        error("  - id: codex\n    scopes: [project]\n    user_config:\n      model: gpt-5.6-sol\n"),
+        "agents[0].user_config: requires the user scope"
+    );
+}
+
+#[test]
+fn agent_capabilities_are_validated() {
+    for (agent, expected) in [
+        (
+            "  - id: cursor\n    scopes: [user]\n    user_config:\n      model: auto\n      effort: high\n",
+            "agents[0].user_config.effort: cursor does not expose a persistent effort setting",
+        ),
+        (
+            "  - id: claude\n    scopes: [user]\n    user_config:\n      model: opus\n      context_window: 1000000\n",
+            "agents[0].user_config.context_window: claude does not expose this persistent setting",
+        ),
+        (
+            "  - id: codex\n    scopes: [user]\n    user_config:\n      model: gpt-5.6-sol\n      max_mode: true\n",
+            "agents[0].user_config.max_mode: codex does not expose max mode",
+        ),
+    ] {
+        assert_eq!(error(agent), expected);
+    }
+}
+
+#[test]
+fn model_and_windows_are_validated() {
+    for (agent, expected) in [
+        (
+            "  - id: codex\n    scopes: [user]\n    user_config:\n      model: \"\"\n",
+            "agents[0].user_config.model: cannot be empty",
+        ),
+        (
+            "  - id: claude\n    scopes: [user]\n    user_config:\n      model: opus\n      auto_compact_window: 0\n",
+            "agents[0].user_config.auto_compact_window: must be greater than zero",
+        ),
+        (
+            "  - id: claude\n    scopes: [user]\n    user_config:\n      model: opus\n      auto_compact_window: 99999\n",
+            "agents[0].user_config.auto_compact_window: must be between 100000 and 1000000",
+        ),
+        (
+            "  - id: codex\n    scopes: [user]\n    user_config:\n      model: gpt-5.6-sol\n      context_window: 270000\n      auto_compact_window: 270000\n",
+            "agents[0].user_config.auto_compact_window: must be smaller than context_window",
+        ),
+    ] {
+        assert_eq!(error(agent), expected);
+    }
+}


### PR DESCRIPTION
## Summary

- declare portable user-level model defaults for Claude, Cursor, and Codex in the Arnes manifest
- validate each harness capability and translate defaults to its native JSON or TOML keys
- report missing or divergent values as read-only configuration drift while preserving unrelated state

## Defaults

- Claude: opus[1m], high effort, auto-compact at 600000 tokens
- Cursor: grok-4.6, max mode disabled
- Codex: gpt-5.6-sol, medium effort, 270000-token context

## Verification

- cargo fmt --manifest-path tooling/arnes/Cargo.toml --check
- cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path tooling/arnes/Cargo.toml

Full suite verified on Darwin arm64 for the original implementation; the Cursor model update was verified with formatting, strict Clippy, and the config/manifest test targets. Repository CI covers Ubuntu and remains the authority for that target.