### PR TITLE
fix(git): resolve Bitbucket main branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -112,6 +112,7 @@ jobs:
             | grep -Fx 'This installer supports macOS only; Linux and GitHub Codespaces are unsupported.'
 
           tooling/agent-handoff-test
+          tooling/git-main-branch-test
           tooling/upgrade-test
           tooling/ci-smoke-targets-test
           tooling/makefile-test

--- a/.github/workflows/test-fish.yml
+++ b/.github/workflows/test-fish.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Test main branch detection
+        run: tooling/git-main-branch-test
+
       - name: Install Fish on macOS
         if: runner.os == 'macOS'
         run: brew install fish

--- a/docs/adr/021-branche-main-detectee.md
+++ b/docs/adr/021-branche-main-detectee.md
@@ -14,17 +14,43 @@ eux.
 ## Décision
 
 Ce dépôt utilise `main`. L'abbreviation `grbm` passe par
-`tooling/git-main-branch`, qui interroge le dépôt courant et retombe sur
-`master` le cas échéant.
+`tooling/git-main-branch`, source unique de détection. Son mode générique
+conserve la détection locale de `main`, `master` puis `trunk` pour les usages
+interactifs existants. Ce mode ne constitue pas une preuve de la branche
+canonique d'un fournisseur.
+
+Le mode `--bitbucket-cloud` établit en plus l'identité du dépôt depuis les URL
+de fetch Bitbucket Cloud, interroge le `HEAD` publié par chaque remote et exige
+leur convergence. Il interroge explicitement chaque identité auprès de l'API,
+valide `uuid`, `full_name` et `mainbranch.name`, fusionne les remotes de même
+UUID, puis exige l'accord entre le `HEAD` Git distant et `mainbranch.name`. Les
+références locales et les branches de suivi ne font pas autorité dans ce mode :
+elles peuvent être absentes ou périmées. Le dépôt du contexte `bkt` actif
+n'est jamais utilisé comme portée implicite.
+
+Le mode `--strict` échoue lorsqu'aucune branche ne peut être établie. Le mode
+Bitbucket est toujours strict : dépôt, remotes, identité et branche principale
+absents, invalides, ambigus ou discordants sont des erreurs. Hors de ces modes
+stricts, `main` reste le repli historique interactif.
 
 ## Conséquences
 
 - Les mêmes raccourcis fonctionnent sur les dépôts anciens et récents.
 - Une indirection de plus dans chaque fonction concernée.
 - La logique de détection est centralisée en un point unique.
+- La détection Bitbucket dépend du réseau, de `bkt`, de `jq` et d'une
+  authentification Bitbucket Cloud valide.
+- Une configuration à plusieurs remotes n'est acceptée que si leurs branches
+  principales convergent ; en mode Bitbucket, leurs UUID doivent aussi
+  converger.
 
 ## Alternatives écartées
 
 - Nom en dur : casse sur les dépôts restés en `master`.
 - Variable de configuration par dépôt : à renseigner manuellement à chaque
   clone.
+- Première branche locale parmi `main`, `master` et `trunk` comme autorité du
+  fournisseur : une branche plausible peut masquer sa valeur canonique. Cette
+  heuristique reste limitée au mode générique interactif.
+- `refs/remotes/<remote>/HEAD` : cache local facultatif, donc potentiellement
+  absent ou périmé.

--- a/tooling/git-main-branch
+++ b/tooling/git-main-branch
@@ -31,7 +31,8 @@ remote_main_branch() {
   if ! response=$(command git "${git_arguments[@]}" ls-remote --symref "$remote" HEAD); then
     return 1
   fi
-  branch=$(printf '%s\n' "$response" | awk '$1 == "ref:" && $3 == "HEAD" {sub("refs/heads/", "", $2); print $2}')
+  branch=$(printf '%s\n' "$response" |
+    awk '$1 == "ref:" && $2 ~ /^refs\/heads\// && $3 == "HEAD" {sub("refs/heads/", "", $2); print $2}')
   if [[ -z $branch || $branch == *$'\n'* ]] ||
     ! command git "${git_arguments[@]}" check-ref-format --branch "$branch" >/dev/null; then
     return 1
@@ -87,7 +88,7 @@ provider_repository() {
   '
 }
 
-if [[ -n $strict ]]; then
+if [[ -n $strict || -n $provider ]]; then
   if ! command git "${git_arguments[@]}" rev-parse --git-dir >/dev/null; then
     exit 1
   fi

--- a/tooling/git-main-branch
+++ b/tooling/git-main-branch
@@ -1,32 +1,176 @@
 #!/usr/bin/env bash
 
 strict=
-if [[ ${1-} == "--strict" ]]; then
-  strict=1
-  shift
-fi
+provider=
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --strict)
+      strict=1
+      shift
+      ;;
+    --bitbucket-cloud)
+      provider=bitbucket-cloud
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+git_arguments=("$@")
+
+fail_or_default() {
+  if [[ -n $strict || -n $provider ]]; then
+    return 1
+  fi
+  printf '%s\n' main
+}
+
+remote_main_branch() {
+  local remote=$1 response branch
+  if ! response=$(command git "${git_arguments[@]}" ls-remote --symref "$remote" HEAD); then
+    return 1
+  fi
+  branch=$(printf '%s\n' "$response" | awk '$1 == "ref:" && $3 == "HEAD" {sub("refs/heads/", "", $2); print $2}')
+  if [[ -z $branch || $branch == *$'\n'* ]] ||
+    ! command git "${git_arguments[@]}" check-ref-format --branch "$branch" >/dev/null; then
+    return 1
+  fi
+  printf '%s\n' "$branch"
+}
+
+bitbucket_identity() {
+  local url=$1 path workspace repository
+  case $url in
+    git@bitbucket.org:*) path=${url#git@bitbucket.org:} ;;
+    ssh://git@bitbucket.org/*) path=${url#ssh://git@bitbucket.org/} ;;
+    https://bitbucket.org/*) path=${url#https://bitbucket.org/} ;;
+    https://*@bitbucket.org/*) path=${url#https://*@bitbucket.org/} ;;
+    *bitbucket.org*) return 2 ;;
+    *) return 1 ;;
+  esac
+  path=${path%.git}
+  workspace=${path%%/*}
+  repository=${path#*/}
+  if [[ -z $workspace || -z $repository || $repository == */* ||
+    ! $workspace =~ ^[A-Za-z0-9._-]+$ || ! $repository =~ ^[A-Za-z0-9._-]+$ ]]; then
+    return 2
+  fi
+  printf '%s/%s\n' "$workspace" "$repository"
+}
+
+cloud_context() {
+  local response
+  if ! response=$(command bkt context list --json); then
+    return 1
+  fi
+  printf '%s\n' "$response" | command jq -er '
+    [.contexts[]? | select(.host == "api.bitbucket.org") | .name
+      | select(type == "string" and length > 0)]
+    | unique | sort | .[0] // error("Bitbucket Cloud context unavailable")
+  '
+}
+
+provider_repository() {
+  local context=$1 identity=$2 response
+  if ! response=$(command bkt --context "$context" api "/repositories/$identity" --json); then
+    return 1
+  fi
+  printf '%s\n' "$response" | command jq -er --arg identity "$identity" '
+    if (.uuid | type == "string" and
+        test("^\\{[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}\\}$")) and
+      (.full_name | type == "string" and . == $identity) and
+      (.mainbranch.name | type == "string" and length > 0)
+    then [.uuid, .mainbranch.name] | @tsv
+    else error("Invalid Bitbucket repository response")
+    end
+  '
+}
 
 if [[ -n $strict ]]; then
-  if ! command git "$@" rev-parse --git-dir >/dev/null; then
+  if ! command git "${git_arguments[@]}" rev-parse --git-dir >/dev/null; then
     exit 1
   fi
-elif ! command git "$@" rev-parse --git-dir &>/dev/null; then
-  echo "main"
+elif ! command git "${git_arguments[@]}" rev-parse --git-dir >/dev/null 2>&1; then
+  printf '%s\n' main
   exit 0
 fi
 
-# Try common branch names that exist locally
-for branch in main master trunk; do
-  if git "$@" show-ref -q --verify "refs/heads/$branch"; then
-    echo "$branch"
-    exit 0
-  else
-    show_ref_status=$?
-    if [[ $show_ref_status -ne 1 && -n $strict ]]; then
-      exit "$show_ref_status"
+if [[ -z $provider ]]; then
+  for branch in main master trunk; do
+    if command git "${git_arguments[@]}" show-ref -q --verify "refs/heads/$branch"; then
+      printf '%s\n' "$branch"
+      exit 0
+    else
+      show_ref_status=$?
+      if [[ $show_ref_status -ne 1 && -n $strict ]]; then
+        exit "$show_ref_status"
+      fi
     fi
+  done
+  fail_or_default
+  exit $?
+fi
+
+if ! remotes=$(command git "${git_arguments[@]}" remote) || [[ -z $remotes ]]; then
+  fail_or_default
+  exit $?
+fi
+
+main_branch=
+identities=
+for remote in $remotes; do
+  if ! urls=$(command git "${git_arguments[@]}" remote get-url --all "$remote"); then
+    fail_or_default
+    exit $?
   fi
+  while IFS= read -r url; do
+    if identity=$(bitbucket_identity "$url"); then
+      identities+="$identity"$'\n'
+    else
+      fail_or_default
+      exit $?
+    fi
+  done <<<"$urls"
+
+  if ! detected_branch=$(remote_main_branch "$remote"); then
+    fail_or_default
+    exit $?
+  fi
+  if [[ -n $main_branch && $main_branch != "$detected_branch" ]]; then
+    fail_or_default
+    exit $?
+  fi
+  main_branch=$detected_branch
 done
 
-# Default to main
-echo "main"
+if [[ $provider == bitbucket-cloud ]]; then
+  if ! context=$(cloud_context); then
+    fail_or_default
+    exit $?
+  fi
+  provider_uuid=
+  provider_branch=
+  while IFS= read -r identity; do
+    [[ -n $identity ]] || continue
+    if ! repository=$(provider_repository "$context" "$identity"); then
+      fail_or_default
+      exit $?
+    fi
+    IFS=$'\t' read -r uuid branch <<<"$repository"
+    if ! command git "${git_arguments[@]}" check-ref-format --branch "$branch" >/dev/null ||
+      [[ -n $provider_uuid && $provider_uuid != "$uuid" ]] ||
+      [[ -n $provider_branch && $provider_branch != "$branch" ]]; then
+      fail_or_default
+      exit $?
+    fi
+    provider_uuid=$uuid
+    provider_branch=$branch
+  done < <(printf '%s' "$identities" | sort -u)
+  if [[ -z $provider_uuid || $provider_branch != "$main_branch" ]]; then
+    fail_or_default
+    exit $?
+  fi
+fi
+
+printf '%s\n' "$main_branch"

--- a/tooling/git-main-branch-test
+++ b/tooling/git-main-branch-test
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tooling_dir=$(cd "$(dirname "$0")" && pwd)
+helper=$tooling_dir/git-main-branch
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/git-main-branch-test.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_equal() {
+  [[ $1 == "$2" ]] || fail "$3: expected '$2', got '$1'"
+}
+
+assert_fails() {
+  local name=$1
+  shift
+  if "$@" >"$test_root/$name.out" 2>"$test_root/$name.err"; then
+    fail "$name succeeded"
+  fi
+  [[ ! -s $test_root/$name.out ]] || fail "$name returned a branch"
+}
+
+real_git=$(command -v git)
+mock_bin=$test_root/bin
+fixture_dir=$test_root/fixtures
+bkt_log=$test_root/bkt.log
+mkdir -p "$mock_bin" "$fixture_dir"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'repository=' \
+  'previous=' \
+  'for argument in "$@"; do' \
+  '  if [[ $previous == -C ]]; then repository=$argument; fi' \
+  '  previous=$argument' \
+  'done' \
+  'if [[ $* == *"ls-remote --symref"* ]]; then' \
+  '  remote=${*: -2:1}' \
+  '  url=$("$REAL_GIT" -C "$repository" remote get-url "$remote")' \
+  '  case $url in' \
+  '    *bitbucket.org*)' \
+  '      identity=${url#*bitbucket.org[:/]}' \
+  '      identity=${identity%.git}' \
+  '      fixture=${identity//\//__}' \
+  '      [[ -f $BKT_FIXTURE_DIR/$fixture.head ]] || exit 1' \
+  '      branch=$(cat "$BKT_FIXTURE_DIR/$fixture.head")' \
+  '      printf "ref: refs/heads/%s\\tHEAD\\n%s\\tHEAD\\n" "$branch" 1111111111111111111111111111111111111111' \
+  '      exit 0' \
+  '      ;;' \
+  '  esac' \
+  'fi' \
+  'exec "$REAL_GIT" "$@"' >"$mock_bin/git"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s\n" "$*" >>"$BKT_LOG"' \
+  'if [[ $* == *"context list"* ]]; then' \
+  '  printf '\''{"active_context":"wrong","contexts":[{"name":"wrong","host":"example.test"},{"name":"cloud","host":"api.bitbucket.org"}]}'\''' \
+  '  exit 0' \
+  'fi' \
+  'for argument in "$@"; do' \
+  '  case $argument in' \
+  '    /repositories/*)' \
+  '      fixture=${argument#/repositories/}' \
+  '      fixture=${fixture//\//__}' \
+  '      [[ -f $BKT_FIXTURE_DIR/$fixture.json ]] || exit 1' \
+  '      cat "$BKT_FIXTURE_DIR/$fixture.json"' \
+  '      exit 0' \
+  '      ;;' \
+  '  esac' \
+  'done' \
+  'exit 2' >"$mock_bin/bkt"
+chmod +x "$mock_bin/bkt" "$mock_bin/git"
+
+write_fixture() {
+  local identity=$1 uuid=$2 main_branch=$3 full_name=${4-$1}
+  jq -n \
+    --arg uuid "$uuid" \
+    --arg full_name "$full_name" \
+    --arg main_branch "$main_branch" \
+    '{uuid: $uuid, full_name: $full_name, mainbranch: {name: $main_branch}}' \
+    >"$fixture_dir/${identity//\//__}.json"
+}
+
+create_repository() {
+  local name=$1 remote_url=$2 remote_branch=$3
+  repository=$test_root/$name
+  remote=$test_root/$name.git
+  "$real_git" init -q --bare "$remote"
+  "$real_git" init -q -b main "$repository"
+  "$real_git" -C "$repository" config user.email test@example.com
+  "$real_git" -C "$repository" config user.name Test
+  printf 'base\n' >"$repository/file"
+  "$real_git" -C "$repository" add file
+  "$real_git" -C "$repository" commit -qm base
+  "$real_git" -C "$repository" branch "$remote_branch"
+  "$real_git" -C "$repository" push -q "$remote" "$remote_branch"
+  "$real_git" --git-dir="$remote" symbolic-ref HEAD "refs/heads/$remote_branch"
+  "$real_git" -C "$repository" remote add origin "$remote_url"
+  case $remote_url in
+    *bitbucket.org*)
+      identity=${remote_url#*bitbucket.org[:/]}
+      identity=${identity%.git}
+      printf '%s\n' "$remote_branch" >"$fixture_dir/${identity//\//__}.head"
+      ;;
+  esac
+}
+
+run_helper() {
+  env \
+    PATH="$mock_bin:$PATH" \
+    REAL_GIT="$real_git" \
+    BKT_FIXTURE_DIR="$fixture_dir" \
+    BKT_LOG="$bkt_log" \
+    "$helper" "$@"
+}
+
+create_repository generic "$test_root/generic.git" develop
+assert_equal "$(run_helper --strict -C "$repository")" main "generic compatibility"
+
+create_repository bitbucket git@bitbucket.org:acme/service.git develop
+"$real_git" -C "$repository" update-ref refs/remotes/origin/main HEAD
+"$real_git" -C "$repository" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+write_fixture acme/service '{11111111-1111-1111-1111-111111111111}' develop
+: >"$bkt_log"
+assert_equal "$(run_helper --strict --bitbucket-cloud -C "$repository")" develop "Bitbucket main branch"
+grep -Fq -- '--context cloud api /repositories/acme/service --json' "$bkt_log" ||
+  fail "Bitbucket lookup did not use the remote identity and Cloud context"
+
+"$real_git" -C "$repository" remote add mirror https://user@bitbucket.org/acme/service.git
+: >"$bkt_log"
+assert_equal "$(run_helper --strict --bitbucket-cloud -C "$repository")" develop "equivalent Bitbucket remotes"
+assert_equal "$(grep -Fc '/repositories/acme/service' "$bkt_log")" 1 "duplicate provider lookup"
+
+create_repository ambiguous git@bitbucket.org:acme/service.git develop
+"$real_git" -C "$repository" remote add other ssh://git@bitbucket.org/acme/other.git
+write_fixture acme/other '{22222222-2222-2222-2222-222222222222}' develop
+printf '%s\n' develop >"$fixture_dir/acme__other.head"
+assert_fails ambiguous run_helper --strict --bitbucket-cloud -C "$repository"
+
+create_repository missing-main git@bitbucket.org:acme/missing-main.git develop
+jq -n '{uuid: "{33333333-3333-3333-3333-333333333333}", full_name: "acme/missing-main", mainbranch: null}' \
+  >"$fixture_dir/acme__missing-main.json"
+assert_fails missing-main run_helper --strict --bitbucket-cloud -C "$repository"
+
+create_repository mismatched-name git@bitbucket.org:acme/mismatched-name.git develop
+write_fixture acme/mismatched-name '{44444444-4444-4444-4444-444444444444}' develop acme/elsewhere
+assert_fails mismatched-name run_helper --strict --bitbucket-cloud -C "$repository"
+
+create_repository mismatched-branch git@bitbucket.org:acme/mismatched-branch.git develop
+write_fixture acme/mismatched-branch '{55555555-5555-5555-5555-555555555555}' main
+assert_fails mismatched-branch run_helper --strict --bitbucket-cloud -C "$repository"
+
+create_repository invalid-branch git@bitbucket.org:acme/invalid-branch.git develop
+write_fixture acme/invalid-branch '{66666666-6666-6666-6666-666666666666}' '-invalid'
+assert_fails invalid-branch run_helper --strict --bitbucket-cloud -C "$repository"
+
+create_repository unavailable git@bitbucket.org:acme/unavailable.git develop
+assert_fails unavailable run_helper --strict --bitbucket-cloud -C "$repository"
+assert_fails unavailable-permissive run_helper --bitbucket-cloud -C "$repository"
+
+create_repository mixed git@bitbucket.org:acme/service.git develop
+"$real_git" -C "$repository" remote add github git@github.com:acme/service.git
+assert_fails mixed run_helper --strict --bitbucket-cloud -C "$repository"
+
+empty_repository=$test_root/empty
+"$real_git" init -q -b main "$empty_repository"
+assert_fails no-remote run_helper --strict -C "$empty_repository"
+assert_equal "$(run_helper -C "$empty_repository")" main "permissive repository fallback"
+
+assert_fails outside run_helper --strict -C "$test_root"
+assert_equal "$(run_helper -C "$test_root")" main "permissive outside fallback"
+
+printf 'git-main-branch tests passed\n'

--- a/tooling/git-main-branch-test
+++ b/tooling/git-main-branch-test
@@ -47,8 +47,9 @@ printf '%s\n' \
   '      identity=${identity%.git}' \
   '      fixture=${identity//\//__}' \
   '      [[ -f $BKT_FIXTURE_DIR/$fixture.head ]] || exit 1' \
-  '      branch=$(cat "$BKT_FIXTURE_DIR/$fixture.head")' \
-  '      printf "ref: refs/heads/%s\\tHEAD\\n%s\\tHEAD\\n" "$branch" 1111111111111111111111111111111111111111' \
+  '      ref=$(cat "$BKT_FIXTURE_DIR/$fixture.head")' \
+  '      case $ref in refs/*) ;; *) ref=refs/heads/$ref ;; esac' \
+  '      printf "ref: %s\\tHEAD\\n%s\\tHEAD\\n" "$ref" 1111111111111111111111111111111111111111' \
   '      exit 0' \
   '      ;;' \
   '  esac' \
@@ -159,6 +160,11 @@ create_repository invalid-branch git@bitbucket.org:acme/invalid-branch.git devel
 write_fixture acme/invalid-branch '{66666666-6666-6666-6666-666666666666}' '-invalid'
 assert_fails invalid-branch run_helper --strict --bitbucket-cloud -C "$repository"
 
+create_repository invalid-head git@bitbucket.org:acme/invalid-head.git develop
+write_fixture acme/invalid-head '{77777777-7777-7777-7777-777777777777}' v1
+printf '%s\n' refs/tags/v1 >"$fixture_dir/acme__invalid-head.head"
+assert_fails invalid-head run_helper --bitbucket-cloud -C "$repository"
+
 create_repository unavailable git@bitbucket.org:acme/unavailable.git develop
 assert_fails unavailable run_helper --strict --bitbucket-cloud -C "$repository"
 assert_fails unavailable-permissive run_helper --bitbucket-cloud -C "$repository"
@@ -173,6 +179,7 @@ assert_fails no-remote run_helper --strict -C "$empty_repository"
 assert_equal "$(run_helper -C "$empty_repository")" main "permissive repository fallback"
 
 assert_fails outside run_helper --strict -C "$test_root"
+assert_fails outside-provider run_helper --bitbucket-cloud -C "$test_root"
 assert_equal "$(run_helper -C "$test_root")" main "permissive outside fallback"
 
 printf 'git-main-branch tests passed\n'


### PR DESCRIPTION
Closes #181.

## Outcome

- Keeps ADR-021 as the active decision and documents the generic versus canonical provider contracts.
- Adds an intrinsically strict `--bitbucket-cloud` mode to the shared helper.
- Resolves repository identity only from effective Git fetch URLs, selects a Bitbucket Cloud context by host, validates `uuid`, `full_name`, and `mainbranch.name`, and requires all Git remote HEADs and provider results to converge.
- Keeps the generic interactive path local, so existing `grbm`, fetch/pull cleanup, and upgrade consumers gain no extra network or authentication dependency.
- Adds the dedicated failure-path test to the existing shell CI gate.

No #179 implementation is included.

## Validation

Authenticated local validation on macOS 26.5.2 arm64, Git 2.50.1, bkt 0.31.1:

- `tooling/git-main-branch-test`
- `tooling/upgrade-test`
- `fish --no-config home/.config/fish/tests/git_cleanup_test.fish`
- `shellcheck --severity=error tooling/git-main-branch tooling/git-main-branch-test tooling/upgrade-test`
- `bash -n tooling/git-main-branch tooling/git-main-branch-test tooling/upgrade-test`
- `actionlint`
- `git diff --check`
- Authenticated representative Bitbucket lookup: `modelo-suite` resolves to `develop`, matching live Git remote HEAD and `repository.mainbranch.name` despite a stale local `origin/HEAD` pointing to `main`.

CI on head `b1b90c6531f2320d965aa536cc7e5ad6527d4bb3` passed 15 checks with no failure. The provider test passed in the macOS and Ubuntu Fish jobs; Linux was not reproduced locally.
