### PR TITLE
fix(rust): eliminate application unsafe code

### DIFF
--- a/.github/workflows/test-arnes.yml
+++ b/.github/workflows/test-arnes.yml
@@ -3,6 +3,7 @@ name: Arnes tests
 on:
   push:
     paths:
+      - .cargo/**
       - Makefile
       - home/.arnes.yaml
       - harness/**
@@ -10,6 +11,7 @@ on:
       - .github/workflows/test-arnes.yml
   pull_request:
     paths:
+      - .cargo/**
       - Makefile
       - home/.arnes.yaml
       - harness/**
@@ -19,6 +21,8 @@ on:
 jobs:
   arnes:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -Funsafe-code
     steps:
       - uses: actions/checkout@v5
       - run: cargo fmt --manifest-path tooling/arnes/Cargo.toml --check

--- a/.github/workflows/test-daily-routine.yml
+++ b/.github/workflows/test-daily-routine.yml
@@ -3,18 +3,22 @@ name: Daily Routine tests
 on:
   push:
     paths:
+      - .cargo/**
       - tooling/daily-routine/**
       - .github/workflows/test-daily-routine.yml
   pull_request:
     paths:
+      - .cargo/**
       - tooling/daily-routine/**
       - .github/workflows/test-daily-routine.yml
 
 jobs:
   daily-routine:
     runs-on: macos-latest
+    env:
+      RUSTFLAGS: -Funsafe-code
     steps:
       - uses: actions/checkout@v5
       - run: cargo fmt --manifest-path tooling/daily-routine/Cargo.toml --check
-      - run: cargo clippy --manifest-path tooling/daily-routine/Cargo.toml -- -D warnings
+      - run: cargo clippy --manifest-path tooling/daily-routine/Cargo.toml --all-targets -- -D warnings
       - run: cargo test --manifest-path tooling/daily-routine/Cargo.toml

--- a/tooling/arnes/Cargo.toml
+++ b/tooling/arnes/Cargo.toml
@@ -3,6 +3,9 @@ name = "arnes"
 version = "0.1.0"
 edition = "2024"
 
+[lints.rust]
+unsafe_code = "forbid"
+
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 rustix = { version = "1.1", features = ["fs", "process", "stdio"] }

--- a/tooling/arnes/src/measure/store.rs
+++ b/tooling/arnes/src/measure/store.rs
@@ -27,7 +27,14 @@ pub struct Store {
 
 impl Store {
     pub fn open(repositories: &[PathBuf]) -> Result<Self, MeasureError> {
-        let resolved = resolve_candidate(&state_base()?)?.join("dotfiles/agent-harness");
+        Self::open_from_state_base(&state_base()?, repositories)
+    }
+
+    fn open_from_state_base(
+        state_base: &Path,
+        repositories: &[PathBuf],
+    ) -> Result<Self, MeasureError> {
+        let resolved = resolve_candidate(state_base)?.join("dotfiles/agent-harness");
         reject_repositories(&resolved, repositories)?;
         let directory = path::open_root(&resolved)?;
         Ok(Self {

--- a/tooling/arnes/src/measure/store/tests.rs
+++ b/tooling/arnes/src/measure/store/tests.rs
@@ -68,9 +68,8 @@ fn opened_store_anchors_new_existing_and_invalid_writes() {
     fs::create_dir_all(repository.join("dotfiles/agent-harness/runs/existing/artifacts/hooks"))
         .unwrap();
     symlink(&external, &state_link).unwrap();
-    let previous = std::env::var_os("XDG_STATE_HOME");
-    unsafe { std::env::set_var("XDG_STATE_HOME", &state_link) };
-    let store = Store::open(std::slice::from_ref(&repository)).unwrap();
+    let store =
+        Store::open_from_state_base(&state_link, std::slice::from_ref(&repository)).unwrap();
     fs::remove_file(&state_link).unwrap();
     symlink(&repository, &state_link).unwrap();
 
@@ -83,7 +82,6 @@ fn opened_store_anchors_new_existing_and_invalid_writes() {
         .append_invalid(&serde_json::json!({"safe":true}))
         .unwrap();
 
-    restore_xdg(previous);
     assert!(
         root.join("runs/existing/artifacts/hooks/existing.json")
             .is_file()
@@ -97,13 +95,6 @@ fn opened_store_anchors_new_existing_and_invalid_writes() {
             .join("dotfiles/agent-harness/invalid.jsonl")
             .exists()
     );
-}
-
-fn restore_xdg(previous: Option<std::ffi::OsString>) {
-    match previous {
-        Some(value) => unsafe { std::env::set_var("XDG_STATE_HOME", value) },
-        None => unsafe { std::env::remove_var("XDG_STATE_HOME") },
-    }
 }
 
 #[test]

--- a/tooling/daily-routine/Cargo.lock
+++ b/tooling/daily-routine/Cargo.lock
@@ -3,9 +3,16 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "daily-routine"
 version = "0.1.0"
 dependencies = [
+ "rustix",
  "serde",
  "serde_json",
  "toml",
@@ -16,6 +23,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "hashbrown"
@@ -40,6 +57,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +90,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -170,6 +212,21 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "winnow"

--- a/tooling/daily-routine/Cargo.toml
+++ b/tooling/daily-routine/Cargo.toml
@@ -3,7 +3,11 @@ name = "daily-routine"
 version = "0.1.0"
 edition = "2024"
 
+[lints.rust]
+unsafe_code = "forbid"
+
 [dependencies]
+rustix = { version = "1.1", features = ["process"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 toml = "1.1.4"

--- a/tooling/daily-routine/src/command.rs
+++ b/tooling/daily-routine/src/command.rs
@@ -13,36 +13,24 @@ const MAX_COMMAND_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 const COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 mod posix {
-    use std::ffi::c_int;
+    use rustix::io::Errno;
+    use rustix::process::{Pid, Signal};
     use std::io;
 
-    const SIGKILL: c_int = 9;
-    const ESRCH: c_int = 3;
-
-    unsafe extern "C" {
-        #[link_name = "kill"]
-        fn kill_process(process: c_int, signal: c_int) -> c_int;
-    }
-
     pub fn kill_process_group(process_group: u32) -> io::Result<()> {
-        let process_group = c_int::try_from(process_group)
+        let process_group = i32::try_from(process_group)
             .map_err(|_| io::Error::other("process group ID does not fit in a POSIX pid_t"))?;
         if process_group <= 1 {
             return Err(io::Error::other(
                 "refusing to signal an unsafe process group ID",
             ));
         }
+        let process_group = Pid::from_raw(process_group)
+            .ok_or_else(|| io::Error::other("process group ID cannot be zero"))?;
 
-        // SAFETY: kill accepts scalar integers, and the validated negative PID targets one group.
-        if unsafe { kill_process(-process_group, SIGKILL) } == 0 {
-            return Ok(());
-        }
-
-        let error = io::Error::last_os_error();
-        if error.raw_os_error() == Some(ESRCH) {
-            Ok(())
-        } else {
-            Err(error)
+        match rustix::process::kill_process_group(process_group, Signal::KILL) {
+            Ok(()) | Err(Errno::SRCH) => Ok(()),
+            Err(error) => Err(error.into()),
         }
     }
 }
@@ -608,8 +596,8 @@ pub fn run_json<T: DeserializeOwned>(program: &str, args: &[String]) -> Result<T
 #[cfg(test)]
 mod tests {
     use super::{
-        ChildOutcome, CommandError, CommandErrorKind, ExecutionLimits, finish_execution, run,
-        run_json, run_with_limits,
+        ChildOutcome, CommandError, CommandErrorKind, ExecutionLimits, finish_execution, posix,
+        run, run_json, run_with_limits,
     };
     use serde::Deserialize;
     use std::error::Error as _;
@@ -620,6 +608,18 @@ mod tests {
     #[derive(Debug, Deserialize, Eq, PartialEq)]
     struct Response {
         value: u32,
+    }
+
+    #[test]
+    fn process_group_kill_rejects_dangerous_and_out_of_range_ids() {
+        assert!(posix::kill_process_group(0).is_err());
+        assert!(posix::kill_process_group(1).is_err());
+        assert!(posix::kill_process_group(u32::MAX).is_err());
+    }
+
+    #[test]
+    fn missing_process_group_is_already_stopped() {
+        posix::kill_process_group(i32::MAX as u32).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Description

- remove process-global environment mutation from the Arnes store test by injecting its state base
- replace Daily Routine's handwritten `kill(2)` FFI with the safe `rustix` process-group API
- forbid unsafe code in both Rust packages and enforce it across all current targets in CI
- make Cargo configuration changes trigger both Rust workflows

## Useful Links

- Issue: N/A

## How to Test

- `RUSTFLAGS=-Funsafe-code cargo fmt --manifest-path tooling/arnes/Cargo.toml --check`
- `RUSTFLAGS=-Funsafe-code cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings`
- `RUSTFLAGS=-Funsafe-code cargo test --manifest-path tooling/arnes/Cargo.toml`
- `RUSTFLAGS=-Funsafe-code cargo fmt --manifest-path tooling/daily-routine/Cargo.toml --check`
- `RUSTFLAGS=-Funsafe-code cargo clippy --manifest-path tooling/daily-routine/Cargo.toml --all-targets -- -D warnings`
- `RUSTFLAGS=-Funsafe-code cargo test --manifest-path tooling/daily-routine/Cargo.toml`
- `actionlint .github/workflows/test-arnes.yml .github/workflows/test-daily-routine.yml`

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
