### PR TITLE
fix(ci): reject unknown Makefile smoke-target constructs

### DIFF
--- a/tooling/ci-smoke-targets-makefile.ts
+++ b/tooling/ci-smoke-targets-makefile.ts
@@ -50,7 +50,17 @@ function classifyLine(makefile: readonly string[], line: number): string {
   if (rule && (rule.target === null || rule.target !== target)) {
     return "all";
   }
-  return target ?? "all";
+  if (/^\s*(?:#.*)?$/.test(content) || content.startsWith(".PHONY: ")) {
+    return target ?? "all";
+  }
+  if (content.startsWith("\t")) {
+    return rule?.target === target ? (target ?? "all") : "all";
+  }
+  const declaredRule = parseRule(content);
+  if (declaredRule?.target === target) {
+    return target ?? "all";
+  }
+  return "all";
 }
 
 function parseRange(start: string, count: string | undefined): Range {

--- a/tooling/ci-smoke-targets.test.ts
+++ b/tooling/ci-smoke-targets.test.ts
@@ -123,6 +123,33 @@ describe("ci-smoke-targets entry point", () => {
     expectTargets(repository, ["all"]);
   });
 
+  test.each(["export SHARED", "unexport SHARED"])(
+    "selects all when the global directive %s is added",
+    (directive) => {
+      const repository = newRepository(`global-${directive.split(" ")[0]}`);
+      write(
+        repository,
+        "Makefile",
+        `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\n.PHONY: beta\nbeta:\n\t@echo beta\n${directive}\n`,
+      );
+      commit(repository, "add global directive");
+
+      expectTargets(repository, ["all"]);
+    },
+  );
+
+  test("selects all when a global assignment continuation changes", () => {
+    const repository = newRepository("global-continuation");
+    const makefile = (value: string) =>
+      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\nGLOBAL = one \\\n  ${value}\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+    write(repository, "Makefile", makefile("original"));
+    commit(repository, "add global continuation");
+    write(repository, "Makefile", makefile("changed"));
+    commit(repository, "change global continuation");
+
+    expectTargets(repository, ["all"]);
+  });
+
   test("selects all when a target is deleted", () => {
     const repository = newRepository("deleted-target");
     write(


### PR DESCRIPTION
## Outcome

Close a conservative-selection gap found by the mandatory self-review after #201 was merged: unknown top-level Make constructs can no longer be attributed to the preceding `.PHONY` target.

## Failure mechanism

A changed bare `export VAR`, `unexport VAR`, or global assignment continuation followed a target block. The selector treated that line as target-local and published only that target, although the construct could affect every recipe.

## Fix

Unknown top-level lines now select `all`; canonical rule headers, recipes under their matching rule, `.PHONY` declarations, blanks, and comments retain target-local selection. End-to-end tests invoke the shipped entry point for all three regressions.

## Verification

Locally on macOS Darwin arm64 at the rebased commit:

- `bun test`: 23 passed / 23 run
- `bun run typecheck`: 0 errors
- `actionlint`: 0 errors
- Prettier: all scoped files formatted

Follow-up to #201 and #190.
