### PR TITLE
fix(ci): fail closed on continued Make lines

### DIFF
--- a/tooling/ci-smoke-targets-makefile.ts
+++ b/tooling/ci-smoke-targets-makefile.ts
@@ -58,11 +58,14 @@ function classifyLine(makefile: readonly string[], line: number): string {
   if (content.startsWith("\t")) {
     return rule?.target === target ? (target ?? "all") : "all";
   }
+  if (endsWithUnescapedBackslash(content)) {
+    return "all";
+  }
   if (/^\s*$/.test(content) || content.startsWith(".PHONY: ")) {
     return target ?? "all";
   }
   if (/^\s*#/.test(content)) {
-    return endsWithUnescapedBackslash(content) ? "all" : (target ?? "all");
+    return target ?? "all";
   }
   const declaredRule = parseRule(content);
   if (declaredRule?.target === target) {

--- a/tooling/ci-smoke-targets-makefile.ts
+++ b/tooling/ci-smoke-targets-makefile.ts
@@ -39,6 +39,11 @@ function ruleAtLine(
     .findLast((rule) => rule !== undefined);
 }
 
+function endsWithUnescapedBackslash(content: string): boolean {
+  const backslashes = /\\+$/.exec(content.trimEnd())?.[0].length ?? 0;
+  return backslashes % 2 === 1;
+}
+
 function classifyLine(makefile: readonly string[], line: number): string {
   const content = makefile[line - 1] ?? "";
   const target = targetAtLine(makefile, line);
@@ -50,11 +55,14 @@ function classifyLine(makefile: readonly string[], line: number): string {
   if (rule && (rule.target === null || rule.target !== target)) {
     return "all";
   }
-  if (/^\s*(?:#.*)?$/.test(content) || content.startsWith(".PHONY: ")) {
-    return target ?? "all";
-  }
   if (content.startsWith("\t")) {
     return rule?.target === target ? (target ?? "all") : "all";
+  }
+  if (/^\s*$/.test(content) || content.startsWith(".PHONY: ")) {
+    return target ?? "all";
+  }
+  if (/^\s*#/.test(content)) {
+    return endsWithUnescapedBackslash(content) ? "all" : (target ?? "all");
   }
   const declaredRule = parseRule(content);
   if (declaredRule?.target === target) {

--- a/tooling/ci-smoke-targets-makefile.ts
+++ b/tooling/ci-smoke-targets-makefile.ts
@@ -44,9 +44,28 @@ function endsWithUnescapedBackslash(content: string): boolean {
   return backslashes % 2 === 1;
 }
 
+function isInsideDefine(makefile: readonly string[], line: number): boolean {
+  return (
+    makefile.slice(0, line - 1).reduce((depth, content) => {
+      if (/^[ ]*endef(?:\s|$)/.test(content)) {
+        return Math.max(0, depth - 1);
+      }
+      if (
+        /^[ ]*(?:(?:export|override|private)\s+)*define(?:\s|$)/.test(content)
+      ) {
+        return depth + 1;
+      }
+      return depth;
+    }, 0) > 0
+  );
+}
+
 function classifyLine(makefile: readonly string[], line: number): string {
   const content = makefile[line - 1] ?? "";
   const target = targetAtLine(makefile, line);
+  if (isInsideDefine(makefile, line)) {
+    return "all";
+  }
   if (assignmentPattern.test(content) || directivePattern.test(content)) {
     return "all";
   }

--- a/tooling/ci-smoke-targets-makefile.ts
+++ b/tooling/ci-smoke-targets-makefile.ts
@@ -44,10 +44,31 @@ function endsWithUnescapedBackslash(content: string): boolean {
   return backslashes % 2 === 1;
 }
 
+function logicalLineStart(makefile: readonly string[], line: number): number {
+  let start = line - 1;
+  while (start > 0 && endsWithUnescapedBackslash(makefile[start - 1] ?? "")) {
+    start -= 1;
+  }
+  return start;
+}
+
+function isGlobalContinuation(
+  makefile: readonly string[],
+  line: number,
+): boolean {
+  const start = logicalLineStart(makefile, line);
+  return start < line - 1 && !makefile[start]?.startsWith("\t");
+}
+
 function isInsideDefine(makefile: readonly string[], line: number): boolean {
   return (
-    makefile.slice(0, line - 1).reduce((depth, content) => {
-      if (/^[ ]*endef(?:\s|$)/.test(content)) {
+    makefile.slice(0, line - 1).reduce((depth, content, index) => {
+      const startsLogicalLine =
+        index === 0 || !endsWithUnescapedBackslash(makefile[index - 1] ?? "");
+      if (!startsLogicalLine) {
+        return depth;
+      }
+      if (/^[ ]*endef[ ]*$/.test(content)) {
         return Math.max(0, depth - 1);
       }
       if (
@@ -63,7 +84,7 @@ function isInsideDefine(makefile: readonly string[], line: number): boolean {
 function classifyLine(makefile: readonly string[], line: number): string {
   const content = makefile[line - 1] ?? "";
   const target = targetAtLine(makefile, line);
-  if (isInsideDefine(makefile, line)) {
+  if (isGlobalContinuation(makefile, line) || isInsideDefine(makefile, line)) {
     return "all";
   }
   if (assignmentPattern.test(content) || directivePattern.test(content)) {

--- a/tooling/ci-smoke-targets.test.ts
+++ b/tooling/ci-smoke-targets.test.ts
@@ -150,6 +150,18 @@ describe("ci-smoke-targets entry point", () => {
     expectTargets(repository, ["all"]);
   });
 
+  test("selects all when a tab-indented global continuation changes", () => {
+    const repository = newRepository("tabbed-global-continuation");
+    const makefile = (value: string) =>
+      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\nGLOBAL = one \\\n\t${value}\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+    write(repository, "Makefile", makefile("original"));
+    commit(repository, "add tabbed global continuation");
+    write(repository, "Makefile", makefile("changed"));
+    commit(repository, "change tabbed global continuation");
+
+    expectTargets(repository, ["all"]);
+  });
+
   test("selects all when a comment starts a logical-line continuation", () => {
     const repository = newRepository("comment-continuation");
     const makefile = (suffix: string) =>
@@ -182,6 +194,18 @@ describe("ci-smoke-targets entry point", () => {
     commit(repository, "add define body");
     write(repository, "Makefile", makefile("changed"));
     commit(repository, "change define body");
+
+    expectTargets(repository, ["all"]);
+  });
+
+  test("selects all when a continued define body changes", () => {
+    const repository = newRepository("continued-define-body");
+    const makefile = (value: string) =>
+      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ndefine GLOBAL\none \\\nendef\n\t${value}\nendef\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+    write(repository, "Makefile", makefile("original"));
+    commit(repository, "add continued define body");
+    write(repository, "Makefile", makefile("changed"));
+    commit(repository, "change continued define body");
 
     expectTargets(repository, ["all"]);
   });

--- a/tooling/ci-smoke-targets.test.ts
+++ b/tooling/ci-smoke-targets.test.ts
@@ -162,6 +162,18 @@ describe("ci-smoke-targets entry point", () => {
     expectTargets(repository, ["all"]);
   });
 
+  test("selects all when an inline comment continues a logical line", () => {
+    const repository = newRepository("inline-comment-continuation");
+    const makefile = (suffix: string) =>
+      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\nalpha: # shared${suffix}\ninclude shared.mk\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+    write(repository, "Makefile", makefile(""));
+    commit(repository, "add inline comment");
+    write(repository, "Makefile", makefile(" \\"));
+    commit(repository, "continue inline comment");
+
+    expectTargets(repository, ["all"]);
+  });
+
   test("selects all when a target is deleted", () => {
     const repository = newRepository("deleted-target");
     write(

--- a/tooling/ci-smoke-targets.test.ts
+++ b/tooling/ci-smoke-targets.test.ts
@@ -150,6 +150,18 @@ describe("ci-smoke-targets entry point", () => {
     expectTargets(repository, ["all"]);
   });
 
+  test("selects all when a comment starts a logical-line continuation", () => {
+    const repository = newRepository("comment-continuation");
+    const makefile = (suffix: string) =>
+      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\n# shared${suffix}\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+    write(repository, "Makefile", makefile(""));
+    commit(repository, "add comment");
+    write(repository, "Makefile", makefile(" \\"));
+    commit(repository, "continue comment");
+
+    expectTargets(repository, ["all"]);
+  });
+
   test("selects all when a target is deleted", () => {
     const repository = newRepository("deleted-target");
     write(

--- a/tooling/ci-smoke-targets.test.ts
+++ b/tooling/ci-smoke-targets.test.ts
@@ -174,6 +174,18 @@ describe("ci-smoke-targets entry point", () => {
     expectTargets(repository, ["all"]);
   });
 
+  test("selects all when a tab-indented define body changes", () => {
+    const repository = newRepository("define-body");
+    const makefile = (value: string) =>
+      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ndefine SHARED_RECIPE\n\t${value}\nendef\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+    write(repository, "Makefile", makefile("original"));
+    commit(repository, "add define body");
+    write(repository, "Makefile", makefile("changed"));
+    commit(repository, "change define body");
+
+    expectTargets(repository, ["all"]);
+  });
+
   test("selects all when a target is deleted", () => {
     const repository = newRepository("deleted-target");
     write(


### PR DESCRIPTION
## Outcome

Close conservative-selection gaps found by mandatory self-review after #202 was merged.

## Failure mechanism

GNU Make joins non-recipe physical lines ending in an unescaped backslash. Global continuations, continued comments, and continued define bodies could therefore be mistaken for a recipe of the preceding target and publish a partial smoke matrix.

## Fix

Track physical-line continuation context before classifying tab-prefixed lines, and count define/endef only at logical-line boundaries. Ambiguous global continuations and define bodies select all; unambiguous tab-prefixed recipe continuations remain target-local. The shipped entry point has end-to-end regressions for each failure path.

## Verification

Locally on macOS Darwin arm64 at 4a08f4a:

- bun test: 28 passed / 28 run, 597 assertions
- bun run typecheck: 0 errors
- actionlint: 0 errors
- Prettier: scoped files formatted

Follow-up to #202, #201, and #190.