### PR TITLE
feat(git): migrate main branch resolution to Bun

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,6 +76,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - run: bun install --frozen-lockfile
+
       - name: Install ShellCheck
         run: brew install actionlint jq shellcheck
 
@@ -128,6 +134,10 @@ jobs:
       - name: Check text syntax and formatting
         run: >-
           prettier --check .github/ISSUE_TEMPLATE/change.yml package.json tsconfig.json
+          tooling/git-main-branch-core.ts tooling/git-main-branch-core.test.ts
+          tooling/git-main-branch-cli.ts tooling/git-main-branch-entry.test.ts
+          tooling/git-main-branch.test-support/fake-command.ts
+          tooling/git-main-branch.test-support/harness.ts
           tooling/obsidian-retrieval/contract.ts tooling/obsidian-retrieval/contract.test.ts
           tooling/obsidian-retrieval/evaluation-contract.ts
           harness/skills/obsidian-retrieval/SKILL.md

--- a/.github/workflows/test-fish.yml
+++ b/.github/workflows/test-fish.yml
@@ -5,11 +5,17 @@ on:
     paths:
       - home/.config/fish/**
       - tooling/git-main-branch
+      - tooling/git-main-branch-*.ts
+      - package.json
+      - bun.lock
       - .github/workflows/test-fish.yml
   pull_request:
     paths:
       - home/.config/fish/**
       - tooling/git-main-branch
+      - tooling/git-main-branch-*.ts
+      - package.json
+      - bun.lock
       - .github/workflows/test-fish.yml
 
 jobs:
@@ -21,6 +27,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - run: bun install --frozen-lockfile
 
       - name: Install Fish on macOS
         if: runner.os == 'macOS'
@@ -34,6 +46,9 @@ jobs:
 
       - name: Test Git cleanup
         run: fish --no-config home/.config/fish/tests/git_cleanup_test.fish
+
+      - name: Test main branch rebase
+        run: fish --no-config home/.config/fish/tests/git_main_branch_test.fish
 
       - name: Test PATH idempotency
         run: fish --no-config home/.config/fish/tests/path_test.fish

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ ${BREW_BIN}/fd:
 	brew install fd
 
 .PHONY: fish
-fish: brew starship ~/.config/fish ${BREW_BIN}/fish ~/.config/fish/functions/fzf_configure_bindings.fish
+fish: brew bun starship ~/.config/fish ${BREW_BIN}/fish ~/.config/fish/functions/fzf_configure_bindings.fish
 ${BREW_BIN}/fish:
 	brew install fish fisher
 	@echo 'If you want to switch your shell to fish, please run the following command'

--- a/docs/adr/021-branche-main-detectee.md
+++ b/docs/adr/021-branche-main-detectee.md
@@ -15,13 +15,22 @@ eux.
 
 Ce dépôt utilise `main`. L'abbreviation `grbm` passe par
 `tooling/git-main-branch`, qui interroge le dépôt courant et retombe sur
-`master` le cas échéant.
+`master` ou `trunk` le cas échéant. Le mode local reste une heuristique destinée
+aux usages interactifs.
+
+Le mode Bitbucket Cloud établit l'identité du dépôt depuis les URL Git de fetch,
+interroge le `HEAD` publié par les remotes et la réponse du fournisseur, puis
+exige leur accord. Les références distantes locales ne font pas autorité dans
+ce mode. Une preuve absente, invalide, ambiguë, indisponible ou discordante est
+une erreur plutôt qu'un repli sur un nom plausible.
 
 ## Conséquences
 
 - Les mêmes raccourcis fonctionnent sur les dépôts anciens et récents.
 - Une indirection de plus dans chaque fonction concernée.
 - La logique de détection est centralisée en un point unique.
+- La résolution Bitbucket Cloud dépend explicitement de `git`, de `bkt`, du
+  réseau et d'un unique contexte Bitbucket Cloud configuré.
 
 ## Alternatives écartées
 

--- a/home/.config/fish/tests/git_main_branch_test.fish
+++ b/home/.config/fish/tests/git_main_branch_test.fish
@@ -1,0 +1,39 @@
+set project_root (path resolve (path dirname (status filename))/../../../..)
+set test_root (mktemp -d)
+
+function fail --argument-names message
+    echo "not ok - $message" >&2
+    exit 1
+end
+
+function cleanup --on-event fish_exit
+    command rm -rf -- "$test_root"
+end
+
+set -gx HOME "$test_root/home"
+mkdir -p "$HOME"
+ln -s "$project_root" "$HOME/.dotfiles"
+source "$project_root/home/.config/fish/conf.d/git-abbreviations.fish"
+
+set repository "$test_root/repository"
+git init --quiet --initial-branch=main "$repository"; or fail "repository initialization failed"
+git -C "$repository" config user.email test@example.com
+git -C "$repository" config user.name Test
+echo base >"$repository/file"
+git -C "$repository" add file
+git -C "$repository" commit --quiet --message base
+git -C "$repository" switch --quiet --create feature
+echo feature >"$repository/feature"
+git -C "$repository" add feature
+git -C "$repository" commit --quiet --message feature
+git -C "$repository" switch --quiet main
+echo main >"$repository/main"
+git -C "$repository" add main
+git -C "$repository" commit --quiet --message main
+set main_tip (git -C "$repository" rev-parse main)
+git -C "$repository" switch --quiet feature
+
+cd "$repository"
+grbm; or fail "grbm failed"
+test (git merge-base HEAD main) = "$main_tip"; or fail "grbm did not rebase onto main"
+echo "ok - grbm resolves the main branch through the shipped entrypoint"

--- a/tooling/git-main-branch
+++ b/tooling/git-main-branch
@@ -1,32 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bun
 
-strict=
-if [[ ${1-} == "--strict" ]]; then
-  strict=1
-  shift
-fi
+import { main } from "./git-main-branch-cli.ts";
 
-if [[ -n $strict ]]; then
-  if ! command git "$@" rev-parse --git-dir >/dev/null; then
-    exit 1
-  fi
-elif ! command git "$@" rev-parse --git-dir &>/dev/null; then
-  echo "main"
-  exit 0
-fi
-
-# Try common branch names that exist locally
-for branch in main master trunk; do
-  if git "$@" show-ref -q --verify "refs/heads/$branch"; then
-    echo "$branch"
-    exit 0
-  else
-    show_ref_status=$?
-    if [[ $show_ref_status -ne 1 && -n $strict ]]; then
-      exit "$show_ref_status"
-    fi
-  fi
-done
-
-# Default to main
-echo "main"
+main(process.argv.slice(2));

--- a/tooling/git-main-branch-cli.ts
+++ b/tooling/git-main-branch-cli.ts
@@ -1,0 +1,238 @@
+import {
+  parseBitbucketIdentity,
+  parseCloudContexts,
+  parseProviderRepository,
+  parseRemoteHead,
+  reconcileProviderEvidence,
+  type RepositoryEvidence,
+} from "./git-main-branch-core.ts";
+
+type CommandResult = Readonly<{
+  status: number;
+  stdout: string;
+  stderr: string;
+}>;
+
+function run(command: string, arguments_: readonly string[]): CommandResult {
+  try {
+    const result = Bun.spawnSync([command, ...arguments_], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      status: result.exitCode,
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+    };
+  } catch (error) {
+    return {
+      status: 127,
+      stdout: "",
+      stderr: `${command} is unavailable: ${String(error)}\n`,
+    };
+  }
+}
+
+function fail(message: string, detail = "", status = 1): never {
+  if (detail !== "") process.stderr.write(detail);
+  process.stderr.write(`git-main-branch: ${message}\n`);
+  process.exit(status);
+}
+
+function exitWithDetail(detail: string, status: number): never {
+  if (detail !== "") process.stderr.write(detail);
+  process.exit(status);
+}
+
+function validateBranch(
+  branch: string,
+  gitArguments: readonly string[],
+  source: string,
+) {
+  const result = run("git", [
+    ...gitArguments,
+    "check-ref-format",
+    "--branch",
+    branch,
+  ]);
+  if (result.status !== 0)
+    fail(
+      `${source} returned an invalid branch ${JSON.stringify(branch)}`,
+      result.stderr,
+    );
+}
+
+function parseArguments(arguments_: readonly string[]) {
+  let strict = false;
+  let bitbucketCloud = false;
+  let offset = 0;
+  while (offset < arguments_.length) {
+    if (arguments_[offset] === "--strict") strict = true;
+    else if (arguments_[offset] === "--bitbucket-cloud") bitbucketCloud = true;
+    else break;
+    offset += 1;
+  }
+  return {
+    strict,
+    bitbucketCloud,
+    gitArguments: arguments_.slice(offset),
+  } as const;
+}
+
+function resolveGeneric(
+  strict: boolean,
+  gitArguments: readonly string[],
+): string {
+  const repository = run("git", [...gitArguments, "rev-parse", "--git-dir"]);
+  if (repository.status !== 0) {
+    if (strict) exitWithDetail(repository.stderr, 1);
+    return "main";
+  }
+  for (const branch of ["main", "master", "trunk"] as const) {
+    const result = run("git", [
+      ...gitArguments,
+      "show-ref",
+      "-q",
+      "--verify",
+      `refs/heads/${branch}`,
+    ]);
+    if (result.status === 0) return branch;
+    if (result.status !== 1) {
+      if (strict) exitWithDetail(result.stderr, result.status);
+      process.stderr.write(result.stderr);
+    }
+  }
+  return "main";
+}
+
+function requireCommand(
+  command: string,
+  arguments_: readonly string[],
+  purpose: string,
+): string {
+  const result = run(command, arguments_);
+  if (result.status !== 0) fail(purpose, result.stderr);
+  return result.stdout;
+}
+
+function cloudContext(): string {
+  const contextOutput = requireCommand(
+    "bkt",
+    ["context", "list", "--json"],
+    "unable to list bkt contexts",
+  );
+  try {
+    return parseCloudContexts(contextOutput);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
+type ProviderRepository = Readonly<{ uuid: string; branch: string }>;
+
+function providerRepository(
+  identity: string,
+  context: string,
+  gitArguments: readonly string[],
+): ProviderRepository {
+  const output = requireCommand(
+    "bkt",
+    ["--context", context, "api", `/repositories/${identity}`, "--json"],
+    `unable to query Bitbucket repository ${identity}`,
+  );
+  let provider: ProviderRepository;
+  try {
+    provider = parseProviderRepository(output, identity);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+  validateBranch(
+    provider.branch,
+    gitArguments,
+    `Bitbucket repository ${identity}`,
+  );
+  return provider;
+}
+
+function evidenceForRemote(
+  remote: string,
+  context: string,
+  gitArguments: readonly string[],
+  providerCache: Map<string, ProviderRepository>,
+): RepositoryEvidence[] {
+  const urls = requireCommand(
+    "git",
+    [...gitArguments, "remote", "get-url", "--all", remote],
+    `unable to read fetch URLs for remote ${remote}`,
+  )
+    .split("\n")
+    .filter((url) => url !== "");
+  if (urls.length === 0) fail(`remote ${remote} has no fetch URL`);
+
+  const headOutput = requireCommand(
+    "git",
+    [...gitArguments, "ls-remote", "--symref", remote, "HEAD"],
+    `unable to read remote HEAD for ${remote}`,
+  );
+  let remoteBranch: string;
+  try {
+    remoteBranch = parseRemoteHead(headOutput);
+  } catch (error) {
+    fail(
+      `${remote}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  validateBranch(remoteBranch, gitArguments, `remote ${remote}`);
+
+  return urls.map((url) => {
+    let parsed: ReturnType<typeof parseBitbucketIdentity>;
+    try {
+      parsed = parseBitbucketIdentity(url);
+    } catch (error) {
+      fail(error instanceof Error ? error.message : String(error));
+    }
+    const provider =
+      providerCache.get(parsed.identity) ??
+      providerRepository(parsed.identity, context, gitArguments);
+    providerCache.set(parsed.identity, provider);
+    return {
+      identity: parsed.identity,
+      remoteBranch,
+      uuid: provider.uuid,
+      providerBranch: provider.branch,
+    };
+  });
+}
+
+function resolveBitbucketCloud(gitArguments: readonly string[]): string {
+  const repository = run("git", [...gitArguments, "rev-parse", "--git-dir"]);
+  if (repository.status !== 0)
+    fail("unable to inspect the Git repository", repository.stderr);
+
+  const remoteOutput = requireCommand(
+    "git",
+    [...gitArguments, "remote"],
+    "unable to list Git remotes",
+  );
+  const remotes = remoteOutput.split("\n").filter((remote) => remote !== "");
+  if (remotes.length === 0) fail("no Git remote is configured");
+
+  const context = cloudContext();
+  const providerCache = new Map<string, ProviderRepository>();
+  const evidence = remotes.flatMap((remote) =>
+    evidenceForRemote(remote, context, gitArguments, providerCache),
+  );
+  try {
+    return reconcileProviderEvidence(evidence);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export function main(arguments_: readonly string[]): void {
+  const { strict, bitbucketCloud, gitArguments } = parseArguments(arguments_);
+  const branch = bitbucketCloud
+    ? resolveBitbucketCloud(gitArguments)
+    : resolveGeneric(strict, gitArguments);
+  process.stdout.write(`${branch}\n`);
+}

--- a/tooling/git-main-branch-cli.ts
+++ b/tooling/git-main-branch-cli.ts
@@ -189,7 +189,8 @@ function evidenceForRemote(
     try {
       parsed = parseBitbucketIdentity(url);
     } catch (error) {
-      fail(error instanceof Error ? error.message : String(error));
+      const detail = error instanceof Error ? error.message : String(error);
+      fail(`remote ${remote}: ${detail}`);
     }
     const provider =
       providerCache.get(parsed.identity) ??

--- a/tooling/git-main-branch-core.test.ts
+++ b/tooling/git-main-branch-core.test.ts
@@ -28,8 +28,24 @@ describe("parseBitbucketIdentity", () => {
     "https://bitbucket.org/acme/%2Fservice",
     "ssh://someone@bitbucket.org/acme/service.git",
   ])("rejects %s", (url) =>
-    expect(() => parseBitbucketIdentity(url)).toThrow(url),
+    expect(() => parseBitbucketIdentity(url)).toThrow(),
   );
+
+  test("does not expose URL credentials in diagnostics", () => {
+    const secret = "example-secret";
+    expect(() =>
+      parseBitbucketIdentity(
+        `https://user:${secret}@bitbucket.org/acme/service/extra`,
+      ),
+    ).toThrow("unsupported Bitbucket Cloud fetch URL");
+    try {
+      parseBitbucketIdentity(
+        `https://user:${secret}@bitbucket.org/acme/service/extra`,
+      );
+    } catch (error) {
+      expect(String(error)).not.toContain(secret);
+    }
+  });
 });
 
 test("parseCloudContexts requires exactly one named Cloud context", () => {

--- a/tooling/git-main-branch-core.test.ts
+++ b/tooling/git-main-branch-core.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseBitbucketIdentity,
+  parseCloudContexts,
+  parseProviderRepository,
+  parseRemoteHead,
+  reconcileProviderEvidence,
+} from "./git-main-branch-core.ts";
+
+describe("parseBitbucketIdentity", () => {
+  test.each([
+    ["git@bitbucket.org:acme/service.git", "acme/service"],
+    ["ssh://git@bitbucket.org/acme/service.git", "acme/service"],
+    ["https://bitbucket.org/acme/service.git", "acme/service"],
+    ["https://token@bitbucket.org/acme/service", "acme/service"],
+  ])("parses %s", (url, identity) => {
+    expect(parseBitbucketIdentity(url)).toEqual({
+      identity,
+      workspace: "acme",
+      slug: "service",
+    });
+  });
+
+  test.each([
+    "git@github.com:acme/service.git",
+    "git@bitbucket.org:acme",
+    "https://bitbucket.org/acme/service/extra",
+    "https://bitbucket.org/acme/%2Fservice",
+    "ssh://someone@bitbucket.org/acme/service.git",
+  ])("rejects %s", (url) =>
+    expect(() => parseBitbucketIdentity(url)).toThrow(url),
+  );
+});
+
+test("parseCloudContexts requires exactly one named Cloud context", () => {
+  expect(
+    parseCloudContexts(
+      '{"contexts":[{"name":"cloud","host":"api.bitbucket.org"}]}',
+    ),
+  ).toBe("cloud");
+  expect(() => parseCloudContexts('{"contexts":[]}')).toThrow("exactly one");
+  expect(() =>
+    parseCloudContexts(
+      '{"contexts":[{"name":"a","host":"api.bitbucket.org"},{"name":"b","host":"api.bitbucket.org"}]}',
+    ),
+  ).toThrow("exactly one");
+  expect(() => parseCloudContexts("not json")).toThrow("valid JSON");
+});
+
+test("provider repositories require validated identity, UUID and branch", () => {
+  expect(
+    parseProviderRepository(
+      '{"uuid":"{11111111-1111-1111-1111-111111111111}","full_name":"acme/service","mainbranch":{"name":"develop"}}',
+      "acme/service",
+    ),
+  ).toEqual({
+    uuid: "{11111111-1111-1111-1111-111111111111}",
+    branch: "develop",
+  });
+  expect(() => parseProviderRepository("{}", "acme/service")).toThrow(
+    "repository response",
+  );
+  expect(() =>
+    parseProviderRepository(
+      '{"uuid":"{11111111-1111-1111-1111-111111111111}","full_name":"acme/other","mainbranch":{"name":"develop"}}',
+      "acme/service",
+    ),
+  ).toThrow("repository response");
+});
+
+test("remote HEAD parsing requires one heads symref", () => {
+  expect(parseRemoteHead("ref: refs/heads/develop\tHEAD\nabc\tHEAD\n")).toBe(
+    "develop",
+  );
+  expect(() => parseRemoteHead("abc\tHEAD\n")).toThrow("symbolic HEAD");
+  expect(() => parseRemoteHead("ref: refs/tags/v1\tHEAD\n")).toThrow(
+    "symbolic HEAD",
+  );
+  expect(() =>
+    parseRemoteHead(
+      "ref: refs/heads/main\tHEAD\nref: refs/heads/trunk\tHEAD\n",
+    ),
+  ).toThrow("exactly one");
+});
+
+test("reconciliation accepts equivalent evidence and refuses conflicts", () => {
+  expect(
+    reconcileProviderEvidence([
+      {
+        identity: "acme/service",
+        remoteBranch: "develop",
+        uuid: "{same}",
+        providerBranch: "develop",
+      },
+      {
+        identity: "acme/service",
+        remoteBranch: "develop",
+        uuid: "{same}",
+        providerBranch: "develop",
+      },
+    ]),
+  ).toBe("develop");
+  expect(() =>
+    reconcileProviderEvidence([
+      {
+        identity: "acme/service",
+        remoteBranch: "develop",
+        uuid: "{a}",
+        providerBranch: "develop",
+      },
+      {
+        identity: "acme/other",
+        remoteBranch: "develop",
+        uuid: "{b}",
+        providerBranch: "develop",
+      },
+    ]),
+  ).toThrow("same repository");
+  expect(() =>
+    reconcileProviderEvidence([
+      {
+        identity: "acme/service",
+        remoteBranch: "develop",
+        uuid: "{a}",
+        providerBranch: "main",
+      },
+    ]),
+  ).toThrow("disagrees");
+});

--- a/tooling/git-main-branch-core.ts
+++ b/tooling/git-main-branch-core.ts
@@ -15,31 +15,31 @@ const componentPattern = /^[A-Za-z0-9._-]+$/;
 const uuidPattern =
   /^\{[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}\}$/;
 
-function identityFromPath(path: string, source: string): BitbucketIdentity {
+function identityFromPath(path: string): BitbucketIdentity {
   const normalized = path.replace(/^\//, "").replace(/\.git$/, "");
   const components = normalized.split("/");
   if (
     components.length !== 2 ||
     components.some((value) => !componentPattern.test(value))
   ) {
-    throw new Error(`unsupported Bitbucket Cloud fetch URL: ${source}`);
+    throw new Error("unsupported Bitbucket Cloud fetch URL");
   }
   const [workspace, slug] = components;
   if (workspace === undefined || slug === undefined) {
-    throw new Error(`unsupported Bitbucket Cloud fetch URL: ${source}`);
+    throw new Error("unsupported Bitbucket Cloud fetch URL");
   }
   return { identity: `${workspace}/${slug}`, workspace, slug };
 }
 
 export function parseBitbucketIdentity(source: string): BitbucketIdentity {
   const scp = /^git@bitbucket\.org:(.+)$/i.exec(source);
-  if (scp?.[1]) return identityFromPath(scp[1], source);
+  if (scp?.[1]) return identityFromPath(scp[1]);
 
   let url: URL;
   try {
     url = new URL(source);
   } catch {
-    throw new Error(`unsupported Bitbucket Cloud fetch URL: ${source}`);
+    throw new Error("unsupported Bitbucket Cloud fetch URL");
   }
   const validHttps = url.protocol === "https:";
   const validSsh =
@@ -52,9 +52,9 @@ export function parseBitbucketIdentity(source: string): BitbucketIdentity {
     url.hash !== "" ||
     url.pathname.includes("%")
   ) {
-    throw new Error(`unsupported Bitbucket Cloud fetch URL: ${source}`);
+    throw new Error("unsupported Bitbucket Cloud fetch URL");
   }
-  return identityFromPath(url.pathname, source);
+  return identityFromPath(url.pathname);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/tooling/git-main-branch-core.ts
+++ b/tooling/git-main-branch-core.ts
@@ -1,0 +1,170 @@
+export type BitbucketIdentity = Readonly<{
+  identity: string;
+  workspace: string;
+  slug: string;
+}>;
+
+export type RepositoryEvidence = Readonly<{
+  identity: string;
+  remoteBranch: string;
+  uuid: string;
+  providerBranch: string;
+}>;
+
+const componentPattern = /^[A-Za-z0-9._-]+$/;
+const uuidPattern =
+  /^\{[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}\}$/;
+
+function identityFromPath(path: string, source: string): BitbucketIdentity {
+  const normalized = path.replace(/^\//, "").replace(/\.git$/, "");
+  const components = normalized.split("/");
+  if (
+    components.length !== 2 ||
+    components.some((value) => !componentPattern.test(value))
+  ) {
+    throw new Error(`unsupported Bitbucket Cloud fetch URL: ${source}`);
+  }
+  const [workspace, slug] = components;
+  if (workspace === undefined || slug === undefined) {
+    throw new Error(`unsupported Bitbucket Cloud fetch URL: ${source}`);
+  }
+  return { identity: `${workspace}/${slug}`, workspace, slug };
+}
+
+export function parseBitbucketIdentity(source: string): BitbucketIdentity {
+  const scp = /^git@bitbucket\.org:(.+)$/i.exec(source);
+  if (scp?.[1]) return identityFromPath(scp[1], source);
+
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    throw new Error(`unsupported Bitbucket Cloud fetch URL: ${source}`);
+  }
+  const validHttps = url.protocol === "https:";
+  const validSsh =
+    url.protocol === "ssh:" && url.username === "git" && url.password === "";
+  if (
+    url.hostname !== "bitbucket.org" ||
+    (!validHttps && !validSsh) ||
+    url.port !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    url.pathname.includes("%")
+  ) {
+    throw new Error(`unsupported Bitbucket Cloud fetch URL: ${source}`);
+  }
+  return identityFromPath(url.pathname, source);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseCloudContexts(input: string): string {
+  let value: unknown;
+  try {
+    value = JSON.parse(input);
+  } catch {
+    throw new Error("Bitbucket context list is not valid JSON");
+  }
+  if (!isRecord(value) || !Array.isArray(value.contexts))
+    throw new Error("Bitbucket context list has an invalid shape");
+  const contexts = value.contexts.filter(
+    (context): context is { name: string; host: string } =>
+      isRecord(context) &&
+      typeof context.name === "string" &&
+      context.name.length > 0 &&
+      typeof context.host === "string" &&
+      context.host.length > 0,
+  );
+  if (contexts.length !== value.contexts.length)
+    throw new Error("Bitbucket context list has an invalid shape");
+  const cloudContexts = contexts.filter(
+    ({ host }) => host === "api.bitbucket.org",
+  );
+  if (cloudContexts.length !== 1) {
+    throw new Error(
+      `expected exactly one Bitbucket Cloud context, found ${cloudContexts.length}`,
+    );
+  }
+  const context = cloudContexts[0];
+  if (context === undefined)
+    throw new Error("Bitbucket Cloud context is unavailable");
+  return context.name;
+}
+
+export function parseProviderRepository(
+  input: string,
+  expectedIdentity: string,
+) {
+  let value: unknown;
+  try {
+    value = JSON.parse(input);
+  } catch {
+    throw new Error(
+      `Bitbucket repository response for ${expectedIdentity} is not valid JSON`,
+    );
+  }
+  if (
+    !isRecord(value) ||
+    typeof value.uuid !== "string" ||
+    !uuidPattern.test(value.uuid) ||
+    value.full_name !== expectedIdentity ||
+    !isRecord(value.mainbranch) ||
+    typeof value.mainbranch.name !== "string" ||
+    value.mainbranch.name.length === 0
+  ) {
+    throw new Error(
+      `invalid Bitbucket repository response for ${expectedIdentity}`,
+    );
+  }
+  return {
+    uuid: value.uuid,
+    branch: value.mainbranch.name,
+  } as const;
+}
+
+export function parseRemoteHead(input: string): string {
+  const branches = input
+    .split("\n")
+    .map((line) => /^ref: refs\/heads\/(.+)\s+HEAD$/.exec(line)?.[1])
+    .filter((branch): branch is string => branch !== undefined);
+  if (branches.length === 0)
+    throw new Error("remote did not publish a symbolic HEAD branch");
+  if (branches.length !== 1)
+    throw new Error(
+      `remote published exactly one symbolic HEAD is required, found ${branches.length}`,
+    );
+  const branch = branches[0];
+  if (branch === undefined)
+    throw new Error("remote symbolic HEAD branch is unavailable");
+  return branch;
+}
+
+export function reconcileProviderEvidence(
+  evidence: readonly RepositoryEvidence[],
+): string {
+  if (evidence.length === 0)
+    throw new Error("no Bitbucket Cloud repository evidence was found");
+  const uuids = new Set(evidence.map(({ uuid }) => uuid));
+  if (uuids.size !== 1)
+    throw new Error("Bitbucket remotes do not identify the same repository");
+  const providerBranches = new Set(
+    evidence.map(({ providerBranch }) => providerBranch),
+  );
+  const remoteBranches = new Set(
+    evidence.map(({ remoteBranch }) => remoteBranch),
+  );
+  if (providerBranches.size !== 1 || remoteBranches.size !== 1) {
+    throw new Error("Bitbucket remotes do not agree on one primary branch");
+  }
+  const providerBranch = evidence[0]?.providerBranch;
+  const remoteBranch = evidence[0]?.remoteBranch;
+  if (providerBranch === undefined || providerBranch !== remoteBranch) {
+    throw new Error(
+      `provider primary branch ${providerBranch ?? "<missing>"} disagrees with remote HEAD ${remoteBranch ?? "<missing>"}`,
+    );
+  }
+  return providerBranch;
+}

--- a/tooling/git-main-branch-entry.test.ts
+++ b/tooling/git-main-branch-entry.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, run } from "./git-main-branch.test-support/harness.ts";
+
+afterEach(cleanup);
+
+const repository = {
+  uuid: "{11111111-1111-1111-1111-111111111111}",
+  full_name: "acme/service",
+  mainbranch: { name: "develop" },
+};
+
+describe("generic entrypoint compatibility", () => {
+  test.each([["main"], ["master"], ["trunk"]])(
+    "selects local %s",
+    async (branch) => {
+      const result = await run(
+        { localBranches: [branch] },
+        "-C",
+        "/repository",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.toString()).toBe(`${branch}\n`);
+    },
+  );
+
+  test("keeps permissive fallback outside a repository", async () => {
+    const result = await run({ repository: false }, "-C", "/missing");
+    expect([
+      result.exitCode,
+      result.stdout.toString(),
+      result.stderr.toString(),
+    ]).toEqual([0, "main\n", ""]);
+  });
+
+  test("strict mode exposes repository and branch-probe failures", async () => {
+    const outside = await run(
+      {
+        repository: false,
+        failures: {
+          "git rev-parse --git-dir": { status: 128, stderr: "fatal: absent\n" },
+        },
+      },
+      "--strict",
+    );
+    expect([
+      outside.exitCode,
+      outside.stdout.toString(),
+      outside.stderr.toString(),
+    ]).toEqual([1, "", "fatal: absent\n"]);
+    const probe = await run({ showRefStatus: 42 }, "--strict");
+    expect([probe.exitCode, probe.stdout.toString()]).toEqual([42, ""]);
+  });
+
+  test("permissive fallback preserves branch-probe diagnostics", async () => {
+    const result = await run({
+      showRefStatus: 42,
+      showRefStderr: "fatal: probe\n",
+    });
+    expect([
+      result.exitCode,
+      result.stdout.toString(),
+      result.stderr.toString(),
+    ]).toEqual([0, "main\n", "fatal: probe\nfatal: probe\nfatal: probe\n"]);
+  });
+});
+
+describe("Bitbucket Cloud entrypoint", () => {
+  test("resolves a nonstandard branch despite stale local metadata", async () => {
+    const result = await run(
+      {
+        localBranches: ["main"],
+        remotes: {
+          origin: {
+            urls: ["git@bitbucket.org:acme/service.git"],
+            head: "develop",
+          },
+        },
+        repositories: { "acme/service": repository },
+      },
+      "--bitbucket-cloud",
+      "-C",
+      "/repository",
+    );
+    expect([
+      result.exitCode,
+      result.stdout.toString(),
+      result.stderr.toString(),
+    ]).toEqual([0, "develop\n", ""]);
+  });
+
+  test("accepts equivalent remotes and URL forms", async () => {
+    const result = await run(
+      {
+        remotes: {
+          origin: {
+            urls: ["https://user@bitbucket.org/acme/service.git"],
+            head: "develop",
+          },
+          mirror: {
+            urls: ["ssh://git@bitbucket.org/acme/service.git"],
+            head: "develop",
+          },
+        },
+        repositories: { "acme/service": repository },
+      },
+      "--strict",
+      "--bitbucket-cloud",
+    );
+    expect([result.exitCode, result.stdout.toString()]).toEqual([
+      0,
+      "develop\n",
+    ]);
+  });
+
+  test.each([
+    ["no remote", { remotes: {} }],
+    [
+      "non-Bitbucket URL",
+      {
+        remotes: {
+          origin: {
+            urls: ["git@github.com:acme/service.git"],
+            head: "develop",
+          },
+        },
+      },
+    ],
+    [
+      "multiple contexts",
+      {
+        remotes: {
+          origin: {
+            urls: ["git@bitbucket.org:acme/service.git"],
+            head: "develop",
+          },
+        },
+        contexts: {
+          contexts: [
+            { name: "a", host: "api.bitbucket.org" },
+            { name: "b", host: "api.bitbucket.org" },
+          ],
+        },
+      },
+    ],
+    [
+      "missing remote HEAD",
+      { remotes: { origin: { urls: ["git@bitbucket.org:acme/service.git"] } } },
+    ],
+    [
+      "conflicting remotes",
+      {
+        remotes: {
+          origin: {
+            urls: ["git@bitbucket.org:acme/service.git"],
+            head: "develop",
+          },
+          mirror: {
+            urls: ["git@bitbucket.org:acme/other.git"],
+            head: "develop",
+          },
+        },
+        repositories: {
+          "acme/service": repository,
+          "acme/other": {
+            ...repository,
+            uuid: "{22222222-2222-2222-2222-222222222222}",
+            full_name: "acme/other",
+          },
+        },
+      },
+    ],
+    [
+      "provider disagreement",
+      {
+        remotes: {
+          origin: {
+            urls: ["git@bitbucket.org:acme/service.git"],
+            head: "develop",
+          },
+        },
+        repositories: {
+          "acme/service": { ...repository, mainbranch: { name: "main" } },
+        },
+      },
+    ],
+    [
+      "remote branch disagreement",
+      {
+        remotes: {
+          origin: {
+            urls: ["git@bitbucket.org:acme/service.git"],
+            head: "develop",
+          },
+          mirror: {
+            urls: ["git@bitbucket.org:acme/service.git"],
+            head: "main",
+          },
+        },
+        repositories: { "acme/service": repository },
+      },
+    ],
+    [
+      "malformed provider response",
+      {
+        remotes: {
+          origin: {
+            urls: ["git@bitbucket.org:acme/service.git"],
+            head: "develop",
+          },
+        },
+        repositories: { "acme/service": { full_name: "acme/service" } },
+      },
+    ],
+  ] as const)("fails closed on %s", async (_name, fixture) => {
+    const result = await run(fixture, "--bitbucket-cloud");
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout.toString()).toBe("");
+    expect(result.stderr.toString().trim().length).toBeGreaterThan(0);
+  });
+
+  test("reports unavailable dependencies", async () => {
+    const gitMissing = await run(
+      {
+        failures: {
+          "git rev-parse --git-dir": { status: 127, stderr: "git missing\n" },
+        },
+      },
+      "--bitbucket-cloud",
+    );
+    expect([gitMissing.exitCode, gitMissing.stdout.toString()]).toEqual([
+      1,
+      "",
+    ]);
+    expect(gitMissing.stderr.toString()).toContain("git missing");
+
+    const result = await run(
+      {
+        remotes: {
+          origin: {
+            urls: ["git@bitbucket.org:acme/service.git"],
+            head: "develop",
+          },
+        },
+        failures: {
+          "bkt context list --json": { status: 127, stderr: "bkt missing\n" },
+        },
+      },
+      "--bitbucket-cloud",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.toString()).toBe("");
+    expect(result.stderr.toString()).toContain("bkt missing");
+  });
+});

--- a/tooling/git-main-branch-entry.test.ts
+++ b/tooling/git-main-branch-entry.test.ts
@@ -251,4 +251,23 @@ describe("Bitbucket Cloud entrypoint", () => {
     expect(result.stdout.toString()).toBe("");
     expect(result.stderr.toString()).toContain("bkt missing");
   });
+
+  test("redacts credentials from rejected fetch URLs", async () => {
+    const secret = "example-secret";
+    const result = await run(
+      {
+        remotes: {
+          origin: {
+            urls: [`https://user:${secret}@bitbucket.org/acme/service/extra`],
+            head: "develop",
+          },
+        },
+      },
+      "--bitbucket-cloud",
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout.toString()).toBe("");
+    expect(result.stderr.toString()).not.toContain(secret);
+    expect(result.stderr.toString()).toContain("fetch URL");
+  });
 });

--- a/tooling/git-main-branch.test-support/fake-command.ts
+++ b/tooling/git-main-branch.test-support/fake-command.ts
@@ -1,0 +1,100 @@
+type Fixture = {
+  repository?: boolean;
+  localBranches?: string[];
+  showRefStatus?: number;
+  showRefStderr?: string;
+  remotes?: Record<
+    string,
+    { urls: string[]; head?: string; headOutput?: string }
+  >;
+  contexts?: unknown;
+  repositories?: Record<string, unknown>;
+  failures?: Record<string, { status: number; stderr: string }>;
+};
+
+const fixture = (await Bun.file(
+  process.env.FIXTURE_PATH ?? "",
+).json()) as Fixture;
+const command = process.argv[2];
+const arguments_ = process.argv.slice(3);
+const failure = fixture.failures?.[`${command} ${arguments_.join(" ")}`];
+
+if (failure) {
+  process.stderr.write(failure.stderr);
+  process.exit(failure.status);
+}
+
+if (command === "git") {
+  const operation = arguments_.findIndex((value) =>
+    [
+      "rev-parse",
+      "show-ref",
+      "remote",
+      "ls-remote",
+      "check-ref-format",
+    ].includes(value),
+  );
+  const tail = arguments_.slice(operation);
+  if (tail[0] === "rev-parse")
+    process.exit(fixture.repository === false ? 128 : 0);
+  if (tail[0] === "show-ref") {
+    if (fixture.showRefStatus) {
+      if (fixture.showRefStderr) process.stderr.write(fixture.showRefStderr);
+      process.exit(fixture.showRefStatus);
+    }
+    const branch = tail.at(-1)?.replace("refs/heads/", "");
+    process.exit(branch && fixture.localBranches?.includes(branch) ? 0 : 1);
+  }
+  if (tail[0] === "remote" && tail.length === 1) {
+    process.stdout.write(`${Object.keys(fixture.remotes ?? {}).join("\n")}\n`);
+    process.exit(0);
+  }
+  if (tail[0] === "remote" && tail[1] === "get-url") {
+    const remote = fixture.remotes?.[tail.at(-1) ?? ""];
+    if (!remote) process.exit(2);
+    process.stdout.write(`${remote.urls.join("\n")}\n`);
+    process.exit(0);
+  }
+  if (tail[0] === "ls-remote") {
+    const remote = fixture.remotes?.[tail.at(-2) ?? ""];
+    if (!remote) process.exit(2);
+    process.stdout.write(
+      remote.headOutput ??
+        (remote.head
+          ? `ref: refs/heads/${remote.head}\tHEAD\nabc\tHEAD\n`
+          : ""),
+    );
+    process.exit(0);
+  }
+  if (tail[0] === "check-ref-format") {
+    const branch = tail.at(-1);
+    process.exit(
+      branch && !branch.startsWith("-") && !branch.includes("..") ? 0 : 1,
+    );
+  }
+}
+
+if (command === "bkt" && arguments_.includes("context")) {
+  process.stdout.write(
+    JSON.stringify(
+      fixture.contexts ?? {
+        contexts: [{ name: "cloud", host: "api.bitbucket.org" }],
+      },
+    ),
+  );
+  process.exit(0);
+}
+
+if (command === "bkt" && arguments_.includes("api")) {
+  if (arguments_[0] !== "--context" || arguments_[1] !== "cloud")
+    process.exit(3);
+  const identity = arguments_
+    .find((value) => value.startsWith("/repositories/"))
+    ?.replace("/repositories/", "");
+  const response = fixture.repositories?.[identity ?? ""];
+  if (!response) process.exit(2);
+  process.stdout.write(JSON.stringify(response));
+  process.exit(0);
+}
+
+process.exit(127);

--- a/tooling/git-main-branch.test-support/harness.ts
+++ b/tooling/git-main-branch.test-support/harness.ts
@@ -1,0 +1,55 @@
+import { chmod, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+export type Fixture = {
+  repository?: boolean;
+  localBranches?: readonly string[];
+  showRefStatus?: number;
+  showRefStderr?: string;
+  remotes?: Readonly<
+    Record<
+      string,
+      { urls: readonly string[]; head?: string; headOutput?: string }
+    >
+  >;
+  contexts?: unknown;
+  repositories?: Readonly<Record<string, unknown>>;
+  failures?: Readonly<Record<string, { status: number; stderr: string }>>;
+};
+
+const entrypoint = join(import.meta.dir, "..", "git-main-branch");
+const fakeCommand = join(import.meta.dir, "fake-command.ts");
+const temporaryDirectories: string[] = [];
+
+export async function cleanup(): Promise<void> {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })),
+  );
+}
+
+export async function run(fixture: Fixture, ...arguments_: string[]) {
+  const root = await mkdtemp(join(tmpdir(), "git-main-branch-"));
+  temporaryDirectories.push(root);
+  const bin = join(root, "bin");
+  await Bun.$`mkdir -p ${bin}`.quiet();
+  await Bun.write(join(root, "fixture.json"), JSON.stringify(fixture));
+  for (const command of ["git", "bkt"] as const) {
+    const executable = join(bin, command);
+    await Bun.write(
+      executable,
+      `#!/bin/sh\nexec "${process.execPath}" "${fakeCommand}" ${command} "$@"\n`,
+    );
+    await chmod(executable, 0o755);
+  }
+  return Bun.spawnSync([entrypoint, ...arguments_], {
+    cwd: root,
+    env: {
+      ...process.env,
+      FIXTURE_PATH: join(root, "fixture.json"),
+      PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}

--- a/tooling/upgrade-test
+++ b/tooling/upgrade-test
@@ -4,6 +4,8 @@ set -euo pipefail
 tooling_dir=$(cd "$(dirname "$0")" && pwd)
 upgrade=$tooling_dir/upgrade
 main_branch_helper=$tooling_dir/git-main-branch
+main_branch_cli=$tooling_dir/git-main-branch-cli.ts
+main_branch_core=$tooling_dir/git-main-branch-core.ts
 test_root=$(mktemp -d "${TMPDIR:-/tmp}/upgrade-test.XXXXXX")
 trap 'rm -rf "$test_root"' EXIT
 
@@ -17,6 +19,7 @@ assert_equal() {
 }
 
 real_git=$(command -v git)
+real_bun=$(command -v bun)
 test_home=$test_root/home
 repository=$test_home/.dotfiles
 remote=$test_root/remote.git
@@ -24,7 +27,7 @@ mock_bin=$test_root/bin
 git_log=$test_root/git.log
 command_log=$test_root/command.log
 mkdir -p "$repository/tooling" "$repository/home/.config/nvim" "$mock_bin"
-cp "$upgrade" "$main_branch_helper" "$repository/tooling/"
+cp "$upgrade" "$main_branch_helper" "$main_branch_cli" "$main_branch_core" "$repository/tooling/"
 printf 'base\n' >"$repository/home/.config/nvim/lazy-lock.json"
 
 "$real_git" init --bare -q "$remote"
@@ -64,6 +67,7 @@ printf '%s\n' \
   'done' \
   'exec "$REAL_GIT" "$@"' >"$mock_bin/git"
 chmod +x "$mock_bin"/*
+ln -s "$real_bun" "$mock_bin/bun"
 
 run_upgrade() {
   output=$test_root/$1.out


### PR DESCRIPTION
## Summary

- preserve the generic `main` / `master` / `trunk` resolution contract through the existing `tooling/git-main-branch` entrypoint, including strict statuses and permissive diagnostics
- add strict Bitbucket Cloud resolution from effective fetch URLs, live remote `HEAD`, one explicit Cloud context, and validated provider evidence
- exercise the real entrypoint plus the Fish rebase, Fish cleanup, and upgrade consumers; make the Fish install target reuse the pinned Homebrew Bun runtime

Closes #186
Part of #188

## Validation

Authenticated locally on macOS Darwin 25.5 arm64 with Bun 1.4.0:

- `bun test`: 127 passed / 128 run, 1 existing platform-dependent skip, 842 assertions
- `bun run typecheck`: 0 errors
- `tooling/upgrade-test`: passed
- `fish --no-config home/.config/fish/tests/git_cleanup_test.fish`: passed
- `fish --no-config home/.config/fish/tests/git_main_branch_test.fish`: passed
- `tooling/makefile-test`: passed
- `make -n -B fish`: includes the canonical `brew install bun` target
- `actionlint`, changed ShellCheck, Fish formatting, Prettier, and `git diff --check`: passed

Linux and GitHub-hosted macOS remain CI evidence, not locally reproduced evidence. Provider/network behavior is exercised through deterministic process boundaries; no live personal Bitbucket repository is used.



## Structure

`tooling/git-main-branch-entry.test.ts` exceeds the 250-line review trigger because it keeps one data-driven observable CLI contract together; command fakes and fixture lifecycle are already split into `git-main-branch.test-support/`, and splitting the behavior table would separate success/failure comparisons without creating another responsibility.
