### PR TITLE
Migrate Scrapling lifecycle to Bun and TypeScript

### DIFF
--- a/.github/workflows/test-typescript.yml
+++ b/.github/workflows/test-typescript.yml
@@ -13,6 +13,8 @@ jobs:
           bun-version-file: package.json
       - run: bun install --frozen-lockfile
       - run: bun test
+        env:
+          SCRAPLING_DOCKER_SMOKE: "1"
 
   typecheck:
     name: TypeScript types

--- a/tooling/scrapling-container.ts
+++ b/tooling/scrapling-container.ts
@@ -1,0 +1,236 @@
+import { z } from "zod";
+
+const containerSchema = z.object({
+  Name: z.string(),
+  Config: z.object({
+    Image: z.string(),
+    Entrypoint: z.array(z.string()).nullable(),
+    Cmd: z.array(z.string()).nullable(),
+  }),
+  HostConfig: z.object({ ExtraHosts: z.array(z.string()).nullable() }),
+  Mounts: z.array(
+    z.object({
+      Type: z.string(),
+      Name: z.string().optional(),
+      Destination: z.string(),
+      RW: z.boolean(),
+    }),
+  ),
+  State: z.object({ Running: z.boolean() }),
+});
+
+type CommandResult = Readonly<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}>;
+
+export type Configuration = Readonly<{
+  container: string;
+  image: string;
+  timeoutMilliseconds: number;
+}>;
+
+const profileVolume = "scrapling-profiles";
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+export async function prepareScraplingContainer(
+  environment: NodeJS.ProcessEnv,
+): Promise<Configuration> {
+  const configuration = readConfiguration(environment);
+  await requireDocker(configuration.timeoutMilliseconds);
+  const existing = await findContainer(configuration);
+  if (existing) await reuseContainer(existing, configuration);
+  else await createContainer(configuration);
+  return configuration;
+}
+
+function readConfiguration(environment: NodeJS.ProcessEnv): Configuration {
+  const container = environment.SCRAPLING_CONTAINER ?? "scrapling-mcp";
+  const image = environment.SCRAPLING_IMAGE ?? "pyd4vinci/scrapling";
+  const timeout = environment.SCRAPLING_DOCKER_TIMEOUT_MS ?? "10000";
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(container)) {
+    throw new LifecycleError(64, `invalid container name: ${container}`);
+  }
+  if (!image || image.startsWith("-") || /[\x00-\x20\x7f]/.test(image)) {
+    throw new LifecycleError(64, `invalid image reference: ${image}`);
+  }
+  if (
+    !/^[1-9]\d*$/.test(timeout) ||
+    !Number.isSafeInteger(Number(timeout)) ||
+    Number(timeout) > 300_000
+  ) {
+    throw new LifecycleError(64, `invalid Docker timeout: ${timeout}`);
+  }
+  return { container, image, timeoutMilliseconds: Number(timeout) };
+}
+
+async function requireDocker(timeoutMilliseconds: number): Promise<void> {
+  const result = await runDocker(["info"], timeoutMilliseconds);
+  if (result.exitCode !== 0)
+    throw commandError(69, "Docker daemon unavailable", result);
+}
+
+async function findContainer(configuration: Configuration) {
+  const listed = await runDocker(
+    ["container", "ls", "--all", "--format", "{{.Names}}"],
+    configuration.timeoutMilliseconds,
+  );
+  requireSuccess(listed, "cannot list Docker containers");
+  const names = listed.stdout.split("\n").filter(Boolean);
+  if (!names.includes(configuration.container)) return undefined;
+  const inspected = await runDocker(
+    ["container", "inspect", "--format", "{{json .}}", configuration.container],
+    configuration.timeoutMilliseconds,
+  );
+  requireSuccess(
+    inspected,
+    `cannot inspect container ${configuration.container}`,
+  );
+  try {
+    return containerSchema.parse(JSON.parse(inspected.stdout));
+  } catch {
+    throw new LifecycleError(
+      78,
+      `container ${configuration.container} returned invalid inspection data`,
+    );
+  }
+}
+
+async function reuseContainer(
+  container: z.infer<typeof containerSchema>,
+  configuration: Configuration,
+): Promise<void> {
+  if (!isCompatible(container, configuration)) {
+    throw new LifecycleError(
+      78,
+      `container ${configuration.container} is incompatible with the required Scrapling configuration`,
+    );
+  }
+  if (container.State.Running) return;
+  const started = await runDocker(
+    ["start", configuration.container],
+    configuration.timeoutMilliseconds,
+  );
+  requireSuccess(started, `cannot start container ${configuration.container}`);
+}
+
+function isCompatible(
+  container: z.infer<typeof containerSchema>,
+  configuration: Configuration,
+): boolean {
+  const profile = container.Mounts.find(
+    (mount) => mount.Destination === "/profiles",
+  );
+  return (
+    container.Name === `/${configuration.container}` &&
+    container.Config.Image === configuration.image &&
+    arraysEqual(container.Config.Entrypoint, ["sleep"]) &&
+    arraysEqual(container.Config.Cmd, ["infinity"]) &&
+    (container.HostConfig.ExtraHosts ?? []).includes(
+      "host.docker.internal:host-gateway",
+    ) &&
+    profile?.Type === "volume" &&
+    profile.Name === profileVolume &&
+    profile.RW
+  );
+}
+
+async function createContainer(configuration: Configuration): Promise<void> {
+  const created = await runDocker(
+    [
+      "run",
+      "--detach",
+      "--name",
+      configuration.container,
+      "--add-host=host.docker.internal:host-gateway",
+      "--volume",
+      `${profileVolume}:/profiles`,
+      "--entrypoint",
+      "sleep",
+      configuration.image,
+      "infinity",
+    ],
+    configuration.timeoutMilliseconds,
+  );
+  if (created.exitCode === 0) return;
+  const racedContainer = await findContainer(configuration);
+  if (!racedContainer)
+    throw commandError(
+      1,
+      `cannot create container ${configuration.container}`,
+      created,
+    );
+  await reuseContainer(racedContainer, configuration);
+}
+
+async function runDocker(
+  arguments_: readonly string[],
+  timeoutMilliseconds: number,
+): Promise<CommandResult> {
+  const child = Bun.spawn(["docker", ...arguments_], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGKILL");
+  }, timeoutMilliseconds);
+  const [exitCode, stdoutBytes, stderrBytes] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).arrayBuffer(),
+    new Response(child.stderr).arrayBuffer(),
+  ]);
+  clearTimeout(timeout);
+  try {
+    return {
+      exitCode,
+      stdout: decoder.decode(stdoutBytes),
+      stderr: decoder.decode(stderrBytes),
+      timedOut,
+    };
+  } catch {
+    throw new LifecycleError(
+      65,
+      `Docker ${arguments_[0] ?? "command"} returned invalid UTF-8`,
+    );
+  }
+}
+
+function requireSuccess(result: CommandResult, action: string): void {
+  if (result.exitCode !== 0) throw commandError(1, action, result);
+}
+
+function commandError(
+  exitCode: number,
+  action: string,
+  result: CommandResult,
+): LifecycleError {
+  if (result.timedOut) return new LifecycleError(75, `${action} timed out`);
+  const detail = result.stderr.trim();
+  return new LifecycleError(
+    exitCode,
+    detail ? `${action}: ${detail}` : `${action} (status ${result.exitCode})`,
+  );
+}
+
+function arraysEqual(
+  actual: readonly string[] | null,
+  expected: readonly string[],
+): boolean {
+  return (
+    actual?.length === expected.length &&
+    actual.every((value, index) => value === expected[index])
+  );
+}
+
+export class LifecycleError extends Error {
+  constructor(
+    readonly exitCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}

--- a/tooling/scrapling-mcp
+++ b/tooling/scrapling-mcp
@@ -1,30 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bun
 
-# Scrapling MCP server backed by a single reusable container. Registering
-# `docker run … scrapling mcp` directly leaks one container per agent session,
-# which never exits when the session dies; here every session execs into the
-# same named container instead.
+import { runScraplingMcp } from "./scrapling-mcp.ts";
 
-set -euo pipefail
-
-CONTAINER="${SCRAPLING_CONTAINER:-scrapling-mcp}"
-IMAGE="${SCRAPLING_IMAGE:-pyd4vinci/scrapling}"
-
-if ! docker info >/dev/null 2>&1; then
-  echo "Error: Docker daemon unavailable" >&2
-  exit 69
-fi
-
-# `docker start` also succeeds on an already running container, so this both
-# reuses and restarts. The trailing start covers the race where a concurrent
-# session created the container between our two commands.
-if ! docker start "${CONTAINER}" >/dev/null 2>&1; then
-  docker run --detach --name "${CONTAINER}" \
-    --add-host=host.docker.internal:host-gateway \
-    --volume scrapling-profiles:/profiles \
-    --entrypoint sleep \
-    "${IMAGE}" infinity >/dev/null 2>&1 ||
-    docker start "${CONTAINER}" >/dev/null
-fi
-
-exec docker exec --interactive "${CONTAINER}" uv run scrapling mcp
+process.exit(await runScraplingMcp(process.env));

--- a/tooling/scrapling-mcp-test-provider.ts
+++ b/tooling/scrapling-mcp-test-provider.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env bun
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+
+const arguments_ = process.argv.slice(2);
+const realDocker = process.env.SCRAPLING_REAL_DOCKER_BIN;
+if (realDocker) {
+  if (arguments_[0] === "exec") finish(0, "mcp smoke\n");
+  const realArguments = arguments_.map((argument) =>
+    argument === "scrapling-profiles:/profiles"
+      ? `${process.env.SCRAPLING_REAL_PROFILE_VOLUME}:/profiles`
+      : argument,
+  );
+  if (realArguments[0] === "run") {
+    realArguments.splice(
+      1,
+      0,
+      "--label",
+      `${process.env.SCRAPLING_REAL_OWNER_LABEL}=${process.env.SCRAPLING_REAL_OWNER}`,
+    );
+  }
+  const result = Bun.spawnSync([realDocker, ...realArguments]);
+  if (
+    realArguments.includes("container") &&
+    realArguments.includes("inspect")
+  ) {
+    const inspection = result.stdout
+      .toString()
+      .replaceAll(
+        `\"Name\":\"${process.env.SCRAPLING_REAL_PROFILE_VOLUME}\"`,
+        '\"Name\":\"scrapling-profiles\"',
+      );
+    finish(result.exitCode, inspection, result.stderr.toString());
+  }
+  finish(result.exitCode, result.stdout.toString(), result.stderr.toString());
+}
+
+const state = process.env.SCRAPLING_TEST_STATE;
+if (!state) throw new Error("SCRAPLING_TEST_STATE is required");
+const scenario = JSON.parse(readFileSync(join(state, "scenario.json"), "utf8"));
+appendFileSync(join(state, "calls"), `${JSON.stringify(arguments_)}\n`);
+const command = arguments_.join(" ");
+
+if (scenario.hang && command.includes(scenario.hang)) {
+  await Bun.sleep(60_000);
+}
+
+if (scenario.invalidUtf8 && command.includes(scenario.invalidUtf8)) {
+  process.stdout.write(new Uint8Array([0xff]));
+  process.exit(0);
+}
+
+if (arguments_[0] === "info")
+  finish(scenario.infoFailure ? 1 : 0, "", "daemon failed\n");
+
+if (command.includes("container ls")) {
+  if (scenario.listFailure) finish(1, "", "list failed\n");
+  if (scenario.concurrent) {
+    writeFileSync(join(state, `list-${process.pid}`), "");
+    while (
+      readdirSync(state).filter((name) => name.startsWith("list-")).length < 2
+    ) {
+      Bun.sleepSync(2);
+    }
+  }
+  finish(0, existsSync(join(state, "container")) ? "scrapling-mcp\n" : "");
+}
+
+if (command.includes("container inspect")) {
+  if (scenario.inspectFailure) finish(1, "", "inspect failed\n");
+  if (scenario.invalidInspect) finish(0, "not-json\n");
+  const compatible = scenario.compatible !== false;
+  finish(
+    0,
+    `${JSON.stringify({
+      Name: "/scrapling-mcp",
+      Config: {
+        Image: compatible ? "pyd4vinci/scrapling" : "other/image",
+        Entrypoint: ["sleep"],
+        Cmd: ["infinity"],
+      },
+      HostConfig: { ExtraHosts: ["host.docker.internal:host-gateway"] },
+      Mounts: [
+        {
+          Type: "volume",
+          Name: "scrapling-profiles",
+          Destination: "/profiles",
+          RW: true,
+        },
+      ],
+      State: { Running: existsSync(join(state, "running")) },
+    })}\n`,
+  );
+}
+
+if (arguments_[0] === "start") {
+  if (scenario.startFailure) finish(1, "", "start failed\n");
+  writeFileSync(join(state, "running"), "");
+  finish(0);
+}
+
+if (arguments_[0] === "run") {
+  if (scenario.runFailure) finish(125, "", "create failed\n");
+  try {
+    mkdirSync(join(state, "container"));
+    writeFileSync(join(state, "running"), "");
+    finish(0);
+  } catch {
+    finish(125, "", "name conflict\n");
+  }
+}
+
+if (arguments_[0] === "exec") {
+  finish(
+    scenario.execExit ?? 0,
+    scenario.execStdout ?? "",
+    scenario.execStderr ?? "",
+  );
+}
+
+finish(
+  64,
+  "",
+  `unexpected docker call from ${basename(process.argv[1] ?? "")}: ${command}\n`,
+);
+
+function finish(exitCode: number, stdout = "", stderr = ""): never {
+  if (stdout) process.stdout.write(stdout);
+  if (stderr && exitCode !== 0) process.stderr.write(stderr);
+  process.exit(exitCode);
+}

--- a/tooling/scrapling-mcp-test-support.ts
+++ b/tooling/scrapling-mcp-test-support.ts
@@ -1,0 +1,123 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const entryPoint = join(import.meta.dir, "scrapling-mcp");
+const provider = join(import.meta.dir, "scrapling-mcp-test-provider.ts");
+const fixtures: Fixture[] = [];
+
+type Scenario = Readonly<{
+  present?: boolean;
+  running?: boolean;
+  compatible?: boolean;
+  infoFailure?: boolean;
+  listFailure?: boolean;
+  inspectFailure?: boolean;
+  startFailure?: boolean;
+  runFailure?: boolean;
+  concurrent?: boolean;
+  execExit?: number;
+  execStdout?: string;
+  execStderr?: string;
+  invalidInspect?: boolean;
+  invalidUtf8?: string;
+  hang?: string;
+}>;
+
+export type Fixture = Readonly<{
+  root: string;
+  entryPoint: string;
+  environment: NodeJS.ProcessEnv;
+  state: string;
+}>;
+
+export function createFixture(
+  scenario: Scenario = {},
+  environment: Record<string, string> = {},
+): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "scrapling-mcp-"));
+  const binaries = join(root, "bin");
+  const state = join(root, "state");
+  mkdirSync(binaries);
+  mkdirSync(state);
+  symlinkSync(process.execPath, join(binaries, "bun"));
+  symlinkSync(provider, join(binaries, "docker"));
+  const installedEntryPoint = join(binaries, "scrapling_mcp");
+  symlinkSync(entryPoint, installedEntryPoint);
+  chmodSync(provider, 0o755);
+  writeFileSync(join(state, "scenario.json"), JSON.stringify(scenario));
+  if (scenario.present) mkdirSync(join(state, "container"));
+  if (scenario.running) writeFileSync(join(state, "running"), "");
+  const fixture = {
+    root,
+    entryPoint: installedEntryPoint,
+    state,
+    environment: {
+      ...process.env,
+      PATH: `${binaries}:${process.env.PATH ?? ""}`,
+      SCRAPLING_TEST_STATE: state,
+      SCRAPLING_DOCKER_TIMEOUT_MS: "5000",
+      ...environment,
+    },
+  };
+  fixtures.push(fixture);
+  return fixture;
+}
+
+export function run(fixture: Fixture) {
+  const result = Bun.spawnSync([fixture.entryPoint], {
+    env: fixture.environment,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}
+
+export function start(fixture: Fixture) {
+  return Bun.spawn([fixture.entryPoint], {
+    env: fixture.environment,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+export async function result(process: ReturnType<typeof start>) {
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+export function calls(fixture: Fixture): string[][] {
+  try {
+    return readFileSync(join(fixture.state, "calls"), "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+  } catch {
+    return [];
+  }
+}
+
+export function cleanupFixtures(): void {
+  for (const fixture of fixtures.splice(0)) {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}

--- a/tooling/scrapling-mcp.test.ts
+++ b/tooling/scrapling-mcp.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  calls,
+  cleanupFixtures,
+  createFixture,
+  result,
+  run,
+  start,
+} from "./scrapling-mcp-test-support.ts";
+
+afterEach(cleanupFixtures);
+
+describe("scrapling-mcp entry point", () => {
+  test("reuses a compatible running container and preserves MCP output", () => {
+    const fixture = createFixture({
+      present: true,
+      running: true,
+      execStdout: "mcp response\n",
+    });
+
+    expect(run(fixture)).toEqual({
+      exitCode: 0,
+      stdout: "mcp response\n",
+      stderr: "",
+    });
+    expect(calls(fixture).map((call) => call[0])).toEqual([
+      "info",
+      "container",
+      "container",
+      "exec",
+    ]);
+  });
+
+  test("starts a compatible stopped container", () => {
+    const fixture = createFixture({ present: true });
+
+    expect(run(fixture).exitCode).toBe(0);
+    expect(calls(fixture).map((call) => call[0])).toEqual([
+      "info",
+      "container",
+      "container",
+      "start",
+      "exec",
+    ]);
+  });
+
+  test("creates the established container when absent", () => {
+    const fixture = createFixture();
+
+    expect(run(fixture).exitCode).toBe(0);
+    expect(calls(fixture)).toContainEqual([
+      "run",
+      "--detach",
+      "--name",
+      "scrapling-mcp",
+      "--add-host=host.docker.internal:host-gateway",
+      "--volume",
+      "scrapling-profiles:/profiles",
+      "--entrypoint",
+      "sleep",
+      "pyd4vinci/scrapling",
+      "infinity",
+    ]);
+  });
+
+  test("concurrent entry points converge on one named container", async () => {
+    const fixture = createFixture({ concurrent: true });
+
+    const outcomes = await Promise.all([
+      result(start(fixture)),
+      result(start(fixture)),
+    ]);
+
+    expect(outcomes.map(({ exitCode }) => exitCode)).toEqual([0, 0]);
+    expect(calls(fixture).filter((call) => call[0] === "exec")).toHaveLength(2);
+  });
+
+  test("refuses an incompatible existing container", () => {
+    const fixture = createFixture({ present: true, compatible: false });
+
+    const outcome = run(fixture);
+
+    expect(outcome.exitCode).toBe(78);
+    expect(outcome.stderr).toContain("incompatible");
+    expect(calls(fixture).some((call) => call[0] === "exec")).toBeFalse();
+  });
+
+  test.each([
+    ["Docker daemon unavailable", { infoFailure: true }],
+    ["cannot list", { listFailure: true }],
+    ["cannot inspect", { present: true, inspectFailure: true }],
+    ["cannot start", { present: true, startFailure: true }],
+    ["cannot create", { runFailure: true }],
+  ])("reports %s", (_label, scenario) => {
+    const outcome = run(createFixture(scenario));
+
+    expect(outcome.exitCode).not.toBe(0);
+    expect(outcome.stderr).not.toBe("");
+  });
+
+  test("propagates the MCP process status and stderr", () => {
+    const fixture = createFixture({
+      present: true,
+      running: true,
+      execExit: 42,
+      execStderr: "mcp failed\n",
+    });
+
+    expect(run(fixture)).toEqual({
+      exitCode: 42,
+      stdout: "",
+      stderr: "mcp failed\n",
+    });
+  });
+
+  test("rejects malformed and non-UTF-8 Docker evidence", () => {
+    for (const scenario of [
+      { present: true, invalidInspect: true },
+      { invalidUtf8: "container ls" },
+    ]) {
+      const outcome = run(createFixture(scenario));
+      expect(outcome.exitCode).not.toBe(0);
+      expect(outcome.stdout).toBe("");
+      expect(outcome.stderr).toMatch(/invalid (inspection data|UTF-8)/);
+    }
+  });
+
+  test("rejects unsafe environment overrides before Docker runs", () => {
+    for (const environment of [
+      { SCRAPLING_CONTAINER: "--privileged" },
+      { SCRAPLING_IMAGE: "-v /:/host" },
+      { SCRAPLING_DOCKER_TIMEOUT_MS: "0" },
+    ]) {
+      const fixture = createFixture({}, environment);
+      expect(run(fixture).exitCode).toBe(64);
+      expect(calls(fixture)).toEqual([]);
+    }
+  });
+
+  test("times out a blocked lifecycle command", () => {
+    const fixture = createFixture(
+      { hang: "container ls" },
+      { SCRAPLING_DOCKER_TIMEOUT_MS: "100" },
+    );
+
+    const outcome = run(fixture);
+
+    expect(outcome.exitCode).toBe(75);
+    expect(outcome.stderr).toContain("timed out");
+  });
+
+  test.skipIf(process.env.SCRAPLING_DOCKER_SMOKE !== "1")(
+    "uses an isolated real Docker lifecycle when explicitly enabled",
+    () => {
+      const docker = Bun.which("docker");
+      expect(docker).not.toBeNull();
+      const container = `scrapling-mcp-smoke-${crypto.randomUUID()}`;
+      const volume = `scrapling-profiles-smoke-${crypto.randomUUID()}`;
+      const volumeOwner = crypto.randomUUID();
+      const volumeLabel = "dotfiles.scrapling-smoke";
+      const fixture = createFixture(
+        {},
+        {
+          SCRAPLING_CONTAINER: container,
+          SCRAPLING_IMAGE: "alpine:3.22",
+          SCRAPLING_REAL_DOCKER_BIN: docker!,
+          SCRAPLING_REAL_PROFILE_VOLUME: volume,
+          SCRAPLING_REAL_OWNER: volumeOwner,
+          SCRAPLING_REAL_OWNER_LABEL: volumeLabel,
+          SCRAPLING_DOCKER_TIMEOUT_MS: "60000",
+        },
+      );
+      try {
+        const existingContainer = Bun.spawnSync([
+          docker!,
+          "container",
+          "inspect",
+          container,
+        ]);
+        expect(existingContainer.exitCode).not.toBe(0);
+        const existingVolume = Bun.spawnSync([
+          docker!,
+          "volume",
+          "inspect",
+          volume,
+        ]);
+        expect(existingVolume.exitCode).not.toBe(0);
+        const createdVolume = Bun.spawnSync([
+          docker!,
+          "volume",
+          "create",
+          "--label",
+          `${volumeLabel}=${volumeOwner}`,
+          volume,
+        ]);
+        expect(createdVolume.exitCode).toBe(0);
+        const owner = Bun.spawnSync([
+          docker!,
+          "volume",
+          "inspect",
+          "--format",
+          `{{ index .Labels "${volumeLabel}" }}`,
+          volume,
+        ]);
+        expect(owner.stdout.toString().trim()).toBe(volumeOwner);
+        expect(run(fixture)).toEqual({
+          exitCode: 0,
+          stdout: "mcp smoke\n",
+          stderr: "",
+        });
+        expect(run(fixture)).toEqual({
+          exitCode: 0,
+          stdout: "mcp smoke\n",
+          stderr: "",
+        });
+        const inspection = Bun.spawnSync([docker!, "inspect", container]);
+        expect(inspection.exitCode).toBe(0);
+      } finally {
+        const ownedContainer = Bun.spawnSync([
+          docker!,
+          "container",
+          "inspect",
+          "--format",
+          `{{.Id}} {{ index .Config.Labels "${volumeLabel}" }}`,
+          container,
+        ]);
+        const [containerId, containerOwner] = ownedContainer.stdout
+          .toString()
+          .trim()
+          .split(" ");
+        if (ownedContainer.exitCode === 0 && containerOwner === volumeOwner) {
+          Bun.spawnSync([docker!, "rm", "--force", containerId!]);
+        }
+      }
+    },
+    90_000,
+  );
+});

--- a/tooling/scrapling-mcp.ts
+++ b/tooling/scrapling-mcp.ts
@@ -1,0 +1,44 @@
+import {
+  LifecycleError,
+  prepareScraplingContainer,
+  type Configuration,
+} from "./scrapling-container.ts";
+
+export async function runScraplingMcp(
+  environment: NodeJS.ProcessEnv,
+): Promise<number> {
+  try {
+    return await runMcp(await prepareScraplingContainer(environment));
+  } catch (error) {
+    process.stderr.write(
+      `Error: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return error instanceof LifecycleError ? error.exitCode : 1;
+  }
+}
+
+async function runMcp(configuration: Configuration): Promise<number> {
+  const child = Bun.spawn(
+    [
+      "docker",
+      "exec",
+      "--interactive",
+      configuration.container,
+      "uv",
+      "run",
+      "scrapling",
+      "mcp",
+    ],
+    { stdin: "inherit", stdout: "inherit", stderr: "inherit" },
+  );
+  const forwardInterrupt = () => child.kill("SIGINT");
+  const forwardTermination = () => child.kill("SIGTERM");
+  process.on("SIGINT", forwardInterrupt);
+  process.on("SIGTERM", forwardTermination);
+  try {
+    return await child.exited;
+  } finally {
+    process.off("SIGINT", forwardInterrupt);
+    process.off("SIGTERM", forwardTermination);
+  }
+}


### PR DESCRIPTION
## Summary

- replace the Scrapling MCP Shell wrapper with a Bun/TypeScript lifecycle while preserving the deployed command, image, named container, host mapping, profile volume, sleep command, and stdio MCP invocation
- validate an existing container before reuse, start only compatible stopped state, and converge safely after concurrent named creation
- fail visibly on Docker, inspection, configuration, start, creation, timeout, malformed evidence, and MCP process failures
- retain the repository-wide pinned Bun 1.4.0 / TypeScript 7 toolchain and add an isolated real-Docker lifecycle smoke to its Bun CI gate

## Verification

- `bun test` — 181 pass, 2 explicit skips, 1022 assertions on Darwin 25.5 arm64; Scrapling targeted: 14 pass, 1 real-Docker skip because the local daemon did not answer
- `bun run typecheck`
- `tooling/makefile-test`
- Prettier and actionlint
- `git diff --check`
- real Docker lifecycle is exercised by the Ubuntu TypeScript CI job with a unique container, immutable-ID container cleanup, and a disposable UUID volume

## Scope

CloakBrowser remains unchanged: its `127.0.0.1:9222` binding and `--idle-timeout=300` are a separate manual lifecycle in the agent instructions, not behavior of the migrated `tooling/scrapling-mcp` entry point. No other Shell migration is included.

The explicit local Docker smoke leaves its uniquely named, labeled volume behind: Docker volumes have no immutable ID for race-safe conditional deletion. GitHub-hosted Ubuntu destroys its disposable runner after the gate.

Comments added: none.

Closes #197
Parent: #188


