### PR TITLE
feat(skills): add requirements clarification

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -147,6 +147,9 @@ jobs:
           harness/skills/obsidian-retrieval/SKILL.md
           harness/skills/obsidian-retrieval/references/obsidian-cli.md
           harness/skills/obsidian-retrieval/evals/trigger-queries.json
+          harness/skills/requirements-clarification/SKILL.md
+          harness/skills/requirements-clarification/evals/trigger-queries.json
+          docs/requirements-clarification-validation.md
 
       - name: Check issue skill syntax and formatting
         run: >-
@@ -187,6 +190,9 @@ jobs:
             harness/skills/obsidian-retrieval/SKILL.md \
             harness/skills/obsidian-retrieval/references/obsidian-cli.md \
             harness/skills/obsidian-retrieval/evals/trigger-queries.json \
+            harness/skills/requirements-clarification/SKILL.md \
+            harness/skills/requirements-clarification/evals/trigger-queries.json \
+            docs/requirements-clarification-validation.md \
             tooling/obsidian-retrieval/contract.ts \
             tooling/obsidian-retrieval/contract.test.ts \
             tooling/obsidian-retrieval/default-corpus-contract.ts \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         target: ${{ fromJSON(needs.select.outputs.targets) }}
     runs-on: macos-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ ${APP_BIN}/1Password.app:
 	brew install --cask 1password
 
 .PHONY: cursor
-cursor: ~/.local/bin/cursor-agent ~/.cursor/skills/claude-developer ~/.cursor/skills/codegraph ~/.cursor/skills/enforcement-code ~/.cursor/skills/harness-reflection ~/.cursor/skills/issue-creation ~/.cursor/skills/linear-issue-spec ~/.cursor/skills/linear-start ~/.cursor/skills/linear-sync ~/.cursor/skills/linear-workflow ~/.cursor/skills/obsidian-retrieval ~/.cursor/skills/pr-fix ~/.cursor/skills/pr-verdict ~/.cursor/skills/skill-manager ~/.cursor/skills/workflow-automation cursor-hooks
+cursor: ~/.local/bin/cursor-agent ~/.cursor/skills/claude-developer ~/.cursor/skills/codegraph ~/.cursor/skills/enforcement-code ~/.cursor/skills/harness-reflection ~/.cursor/skills/issue-creation ~/.cursor/skills/linear-issue-spec ~/.cursor/skills/linear-start ~/.cursor/skills/linear-sync ~/.cursor/skills/linear-workflow ~/.cursor/skills/obsidian-retrieval ~/.cursor/skills/pr-fix ~/.cursor/skills/pr-verdict ~/.cursor/skills/requirements-clarification ~/.cursor/skills/skill-manager ~/.cursor/skills/workflow-automation cursor-hooks
 ~/.local/bin/cursor-agent:
 	curl https://cursor.com/install -fsS | bash
 ~/.cursor/skills:
@@ -385,6 +385,8 @@ cursor: ~/.local/bin/cursor-agent ~/.cursor/skills/claude-developer ~/.cursor/sk
 	${CREATE_SYMLINK}
 ~/.cursor/skills/pr-verdict: ${DOTFILES_PATH}/harness/skills/pr-verdict | ~/.cursor/skills
 	${CREATE_SYMLINK}
+~/.cursor/skills/requirements-clarification: ${DOTFILES_PATH}/harness/skills/requirements-clarification | ~/.cursor/skills
+	${CREATE_SYMLINK}
 ~/.cursor/skills/skill-manager: ${DOTFILES_PATH}/harness/skills/skill-manager | ~/.cursor/skills
 	${CREATE_SYMLINK}
 ~/.cursor/skills/workflow-automation: ${DOTFILES_PATH}/harness/skills/workflow-automation | ~/.cursor/skills
@@ -395,7 +397,7 @@ cursor-hooks: arnes
 	"${LOCAL_BIN}/arnes" setup hooks --agent cursor
 
 .PHONY: claude-code
-claude-code: bun hunspell ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/commands/pr-feedback.md ~/.claude/rules/agent-instructions.md ~/.claude/skills/codegraph ~/.claude/skills/handoff ~/.claude/skills/enforcement-code ~/.claude/skills/harness-reflection ~/.claude/skills/issue-creation ~/.claude/skills/linear-issue-spec ~/.claude/skills/linear-start ~/.claude/skills/linear-sync ~/.claude/skills/linear-workflow ~/.claude/skills/obsidian-retrieval ~/.claude/skills/pr-fix ~/.claude/skills/pr-verdict ~/.claude/skills/skill-manager ~/.claude/skills/workflow-automation claude-code-hooks
+claude-code: bun hunspell ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/commands/pr-feedback.md ~/.claude/rules/agent-instructions.md ~/.claude/skills/codegraph ~/.claude/skills/handoff ~/.claude/skills/enforcement-code ~/.claude/skills/harness-reflection ~/.claude/skills/issue-creation ~/.claude/skills/linear-issue-spec ~/.claude/skills/linear-start ~/.claude/skills/linear-sync ~/.claude/skills/linear-workflow ~/.claude/skills/obsidian-retrieval ~/.claude/skills/pr-fix ~/.claude/skills/pr-verdict ~/.claude/skills/requirements-clarification ~/.claude/skills/skill-manager ~/.claude/skills/workflow-automation claude-code-hooks
 ${LOCAL_BIN}/claude:
 	curl -fsSL https://claude.ai/install.sh | bash -s latest
 ~/.claude:
@@ -440,6 +442,8 @@ ${LOCAL_BIN}/claude:
 	${CREATE_SYMLINK}
 ~/.claude/skills/pr-verdict: ${DOTFILES_PATH}/harness/skills/pr-verdict | ~/.claude/skills
 	${CREATE_SYMLINK}
+~/.claude/skills/requirements-clarification: ${DOTFILES_PATH}/harness/skills/requirements-clarification | ~/.claude/skills
+	${CREATE_SYMLINK}
 ~/.claude/skills/skill-manager: ${DOTFILES_PATH}/harness/skills/skill-manager | ~/.claude/skills
 	${CREATE_SYMLINK}
 ~/.claude/skills/workflow-automation: ${DOTFILES_PATH}/harness/skills/workflow-automation | ~/.claude/skills
@@ -462,7 +466,7 @@ hunspell-dictionaries: bun
 	"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.dic" "f0b1a234bd178bdd01875b2a392a9647f888b8fe879f79c52aae62c2759b3647" "$(HOME)/Library/Spelling/en_US.dic"
 
 .PHONY: codex
-codex: bun ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.agents/skills/agent-instructions ~/.agents/skills/claude-developer ~/.agents/skills/codegraph ~/.agents/skills/handoff ~/.agents/skills/enforcement-code ~/.agents/skills/harness-reflection ~/.agents/skills/issue-creation ~/.agents/skills/linear-issue-spec ~/.agents/skills/linear-start ~/.agents/skills/linear-sync ~/.agents/skills/linear-workflow ~/.agents/skills/obsidian-retrieval ~/.agents/skills/pr-fix ~/.agents/skills/pr-verdict ~/.agents/skills/skill-manager ~/.agents/skills/workflow-automation codex-hooks
+codex: bun ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.agents/skills/agent-instructions ~/.agents/skills/claude-developer ~/.agents/skills/codegraph ~/.agents/skills/handoff ~/.agents/skills/enforcement-code ~/.agents/skills/harness-reflection ~/.agents/skills/issue-creation ~/.agents/skills/linear-issue-spec ~/.agents/skills/linear-start ~/.agents/skills/linear-sync ~/.agents/skills/linear-workflow ~/.agents/skills/obsidian-retrieval ~/.agents/skills/pr-fix ~/.agents/skills/pr-verdict ~/.agents/skills/requirements-clarification ~/.agents/skills/skill-manager ~/.agents/skills/workflow-automation codex-hooks
 ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 	${BREW_BIN}/volta install @openai/codex
 ~/.codex:
@@ -502,6 +506,8 @@ ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 ~/.agents/skills/pr-fix: ${DOTFILES_PATH}/harness/skills/pr-fix | ~/.agents/skills
 	${CREATE_SYMLINK}
 ~/.agents/skills/pr-verdict: ${DOTFILES_PATH}/harness/skills/pr-verdict | ~/.agents/skills
+	${CREATE_SYMLINK}
+~/.agents/skills/requirements-clarification: ${DOTFILES_PATH}/harness/skills/requirements-clarification | ~/.agents/skills
 	${CREATE_SYMLINK}
 ~/.agents/skills/skill-manager: ${DOTFILES_PATH}/harness/skills/skill-manager | ~/.agents/skills
 	${CREATE_SYMLINK}

--- a/docs/requirements-clarification-validation.md
+++ b/docs/requirements-clarification-validation.md
@@ -1,0 +1,119 @@
+# `requirements-clarification` validation
+
+- **Date:** 2026-08-24
+- **Exercised system:** macOS, arm64
+- **Claude Code:** 2.1.241
+- **Codex CLI:** 0.149.1
+- **Cursor Agent:** 2026.08.11-e8db854
+- **Not exercised:** Linux
+
+## Method
+
+Canonical prompts live in
+`harness/skills/requirements-clarification/evals/trigger-queries.json`. Every invocation used a new
+process, the same prompt for comparable runs, and a non-mutating mode. Agents ran against a clean
+temporary repository snapshot containing the current implementation. The scenario answers and this
+report were unavailable there; neutral placeholders preserved the lint contract without exposing
+expected activation or verdicts. Raw JSONL remains a local artifact, while the normalized results
+below are the retained execution evidence.
+
+Claude activation requires a `Skill` event for `requirements-clarification`. Codex activation
+requires a read through `~/.agents/skills/requirements-clarification/SKILL.md`. Cursor activation
+requires a read through a discovered user-skill path. Cursor chose its documented Claude-compatible
+path, `~/.claude/skills/requirements-clarification/SKILL.md`; its native `~/.cursor/skills` link was
+verified separately. Cursor officially discovers both native user skills and Claude/Codex
+compatibility directories: <https://cursor.com/docs/skills>.
+
+Routing and behavior are judged separately. Positive questions pass only when plausible answers
+change behavior, architecture, data, security, or acceptance criteria. Negative cases must research
+available facts and ask no requirements question. Execution invitations are recorded but do not
+count as requirements questions.
+
+## Always-loaded reminder ablation
+
+With the final description alone, Claude activated twice out of three for authentication and three
+times out of three for migration. A reminder injected directly into the system prompt reached three
+out of three in both cases, but the same reminder loaded through the real `harness/AGENTS.md` path
+left authentication at two out of three. A narrower opening sentence also left Cursor's negative
+activation unchanged. Both changes were reverted under ADR-035. No hook or always-loaded rule is
+retained. On Claude's negative cases, the real-path reminder reduced behavior passes from one to zero
+for S3 and from two to one for S4. A host hook cannot judge semantic question quality, and the
+measured real instruction path made behavior worse.
+
+## Results
+
+Researched facts are abbreviated as follows:
+
+- `F1`: Arnes's local CLI shape, absent network boundary, and manifest secret rejection;
+- `F2`: `SCHEMA_VERSION`, parser, validation, and v1 manifest tests;
+- `F3`: manifest, Makefile targets, deployment test, lint, and neutral validation artifacts;
+- `F4`: declaration and two local uses of `destinations`;
+- `F5`: neighboring `30_000` timeout and the new test's structure;
+- `F6`: current import groups, neighboring tests, and absence of an automated sort rule.
+
+Questions are `Q0` (none), `Q1` (authentication actor, resource, threat, and failure), `Q2` (v2
+delta and compatibility), `QE` (execution invitation only), `QS` (non-material style choice), or
+`QD` (discoverable scope asked back to the user). `M0` means no mutation. Route expectations come
+from `should_activate`; behavior verdicts enforce the requirements contract independently.
+
+| Agent/version                   | Scenario | Run | Activation | Facts | Questions | Mutation | Route | Behavior |
+| ------------------------------- | -------- | --: | ---------- | ----- | --------- | -------- | ----- | -------- |
+| Claude Code 2.1.241             | S1       |   1 | yes        | F1    | Q1        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S1       |   2 | yes        | F1    | Q1        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S1       |   3 | no         | F1    | Q1        | M0       | FAIL  | PASS     |
+| Claude Code 2.1.241             | S2       |   1 | yes        | F2    | Q2        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S2       |   2 | yes        | F2    | Q2        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S2       |   3 | yes        | F2    | Q2        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S3       |   1 | no         | F3    | QE        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S3       |   2 | no         | F3    | QD        | M0       | PASS  | FAIL     |
+| Claude Code 2.1.241             | S3       |   3 | no         | F3    | QD        | M0       | PASS  | FAIL     |
+| Claude Code 2.1.241             | S4       |   1 | no         | F4    | QE        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S4       |   2 | no         | F4    | QS        | M0       | PASS  | FAIL     |
+| Claude Code 2.1.241             | S4       |   3 | no         | F4    | QE        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S5       |   1 | no         | F5    | Q0        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S5       |   2 | no         | F5    | QE        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S5       |   3 | no         | F5    | QE        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S6       |   1 | no         | F6    | QE        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S6       |   2 | no         | F6    | QE        | M0       | PASS  | PASS     |
+| Claude Code 2.1.241             | S6       |   3 | no         | F6    | QE        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S1       |   1 | yes        | F1    | Q1        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S1       |   2 | yes        | F1    | Q1        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S1       |   3 | yes        | F1    | Q1        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S2       |   1 | yes        | F2    | Q2        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S2       |   2 | yes        | F2    | Q2        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S2       |   3 | yes        | F2    | Q2        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S3       |   1 | no         | F3    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S3       |   2 | no         | F3    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S3       |   3 | no         | F3    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S4       |   1 | no         | F4    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S4       |   2 | no         | F4    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S4       |   3 | no         | F4    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S5       |   1 | no         | F5    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S5       |   2 | no         | F5    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S5       |   3 | no         | F5    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S6       |   1 | no         | F6    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S6       |   2 | no         | F6    | Q0        | M0       | PASS  | PASS     |
+| Codex CLI 0.149.1               | S6       |   3 | no         | F6    | Q0        | M0       | PASS  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S1       |   1 | yes        | F1    | Q1        | M0       | PASS  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S1       |   2 | yes        | F1    | Q1        | M0       | PASS  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S1       |   3 | yes        | F1    | Q1        | M0       | PASS  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S2       |   1 | yes        | F2    | Q2        | M0       | PASS  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S2       |   2 | yes        | F2    | Q2        | M0       | PASS  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S2       |   3 | yes        | F2    | Q2        | M0       | PASS  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S3       |   1 | yes        | F3    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S3       |   2 | yes        | F3    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S3       |   3 | yes        | F3    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S4       |   1 | yes        | F4    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S4       |   2 | yes        | F4    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S4       |   3 | yes        | F4    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S5       |   1 | yes        | F5    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S5       |   2 | yes        | F5    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S5       |   3 | yes        | F5    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S6       |   1 | yes        | F6    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S6       |   2 | yes        | F6    | Q0        | M0       | FAIL  | PASS     |
+| Cursor Agent 2026.08.11-e8db854 | S6       |   3 | yes        | F6    | Q0        | M0       | FAIL  | PASS     |
+
+Codex passed routing and behavior in all 18 runs. Claude passed routing in 17/18 and behavior in
+15/18. Cursor passed behavior in 18/18 but over-activated on all 12 negative runs. Description and
+prompt ablations did not reduce that Cursor behavior; no host-specific suppression was added because
+it would violate portability and the issue's host-neutral frontmatter constraint.

--- a/harness/skills/README.md
+++ b/harness/skills/README.md
@@ -11,19 +11,20 @@ This directory is the canonical source for user-scoped agent skills.
 
 ## Dev
 
-| Skill                | Description                                                                                          |
-| -------------------- | ---------------------------------------------------------------------------------------------------- |
-| `agent-instructions` | Maintain coding-agent instructions and their discovery paths.                                        |
-| `claude-developer`   | Prepare manual implementation and correction prompts for Claude Code without invoking it.            |
-| `codegraph`          | Explore large repositories structurally with CodeGraph.                                              |
-| `enforcement-code`   | Write code whose purpose is to refuse: hook, guard, validator, permission check, lint rule, CI gate. |
-| `harness-reflection` | Turn repeated agent failures into evidence-backed harness improvements.                              |
-| `issue-creation`     | Draft, validate, review, and publish tracker issues across forges.                                   |
-| `linear-start`       | Start or resume implementation of an assigned Linear issue in a Bitbucket repository.                |
-| `linear-sync`        | Reconcile assigned Linear issues with Bitbucket pull-request reality without reviewing code.         |
-| `linear-workflow`    | Apply the shared Linear and Bitbucket work invariants.                                               |
-| `pr-fix`             | Repair an open pull request after an independent merge review.                                       |
-| `pr-verdict`         | Deliver a PR verdict on an open pull request, yours or another author's.                             |
+| Skill                        | Description                                                                                          |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `agent-instructions`         | Maintain coding-agent instructions and their discovery paths.                                        |
+| `claude-developer`           | Prepare manual implementation and correction prompts for Claude Code without invoking it.            |
+| `codegraph`                  | Explore large repositories structurally with CodeGraph.                                              |
+| `enforcement-code`           | Write code whose purpose is to refuse: hook, guard, validator, permission check, lint rule, CI gate. |
+| `harness-reflection`         | Turn repeated agent failures into evidence-backed harness improvements.                              |
+| `issue-creation`             | Draft, validate, review, and publish tracker issues across forges.                                   |
+| `linear-start`               | Start or resume implementation of an assigned Linear issue in a Bitbucket repository.                |
+| `linear-sync`                | Reconcile assigned Linear issues with Bitbucket pull-request reality without reviewing code.         |
+| `linear-workflow`            | Apply the shared Linear and Bitbucket work invariants.                                               |
+| `pr-fix`                     | Repair an open pull request after an independent merge review.                                       |
+| `pr-verdict`                 | Deliver a PR verdict on an open pull request, yours or another author's.                             |
+| `requirements-clarification` | Clarify requirements before implementation.                                                          |
 
 ## Product
 

--- a/harness/skills/requirements-clarification/SKILL.md
+++ b/harness/skills/requirements-clarification/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: requirements-clarification
+description: >
+  Clarify requirements before implementation. Use when a request adds authentication or migrates a
+  configuration manifest between versions without defining actors, trust boundaries, compatibility,
+  data loss, failure behavior, or acceptance criteria. Make sure to use this skill for any
+  authentication or migration request with unresolved material decisions, even if the user asks to
+  proceed.
+metadata:
+  category: dev
+---
+
+# Requirements Clarification
+
+## Overview
+
+Separate missing detail from decisions that materially change the result. Inspect first, maintain a
+verifiable preflight, and ask only questions whose answers affect behavior, architecture, data,
+security, or acceptance criteria.
+
+## Usage
+
+Apply before implementation when the request may admit materially different outcomes. For example,
+use it before adding authentication when the actors, trust boundary, or failure behavior are not
+established.
+
+## Steps
+
+1. Load every applicable instruction and inspect the smallest relevant repository surface,
+   including authoritative decisions, documentation, neighboring code, tests, and configured tools.
+2. Maintain three distinct preflight groups: established facts with their sources, explicit working
+   assumptions, and unresolved unknowns. Present the groups when they affect a decision or make the
+   result independently verifiable.
+3. Resolve unknowns available from the repository, authorized tools, or current official dependency
+   documentation. Do not ask the user to supply discoverable facts.
+4. For each remaining unknown, name at least two plausible answers and their concrete effect. Keep it
+   only when the answers differ in behavior, architecture, data, security, or acceptance criteria.
+5. When a material unknown remains, pause only the affected work and ask the minimum question needed
+   to resolve it. State the concrete consequence of each answer and continue independent work.
+6. When no material unknown remains, proceed without a clarification interview. Follow a verified
+   repository convention or a safe, local, reversible default, and state an assumption only when it
+   helps verify the outcome.
+7. Before implementation, confirm that no retained question concerns a discoverable fact or a
+   preference outside the five material criteria.
+
+## Gotchas
+
+- **Treating prompt length as uncertainty** — a short request can be complete and a long one can hide
+  a material decision; classify the consequences instead of the wording.
+- **Asking for repository facts** — the user becomes a search interface and may provide stale
+  information; inspect the applicable sources and tools first.
+- **Turning clarification into design facilitation** — work stalls behind a workshop that was not requested;
+  ask only the smallest questions that separate materially different outcomes.
+- **Blocking the whole task on one unknown** — independent progress is lost; pause only work whose
+  result depends on the unresolved answer.
+
+## Constraints
+
+- Never ask for information that can be established reliably in the authorized context.
+- Never block on an unknown unless plausible answers differ in behavior, architecture, data,
+  security, or acceptance criteria.
+- Never mutate the affected implementation while a material decision remains unresolved.
+- Never replace the requested work with a specification, plan, ticket, or brainstorming session.
+- Never add host-specific routing, hooks, or frontmatter without measured failures and explicit
+  authorization.

--- a/harness/skills/requirements-clarification/evals/trigger-queries.json
+++ b/harness/skills/requirements-clarification/evals/trigger-queries.json
@@ -1,0 +1,36 @@
+{
+  "skill": "requirements-clarification",
+  "version": "1.0",
+  "queries": [
+    {
+      "query": "Add authentication to tooling/arnes. Do not modify files; assess the request and next action in at most 250 words.",
+      "should_activate": true,
+      "reason": "Actors, trust boundaries, and failure behavior can materially change the implementation."
+    },
+    {
+      "query": "Migrate home/.arnes.yaml from version 1 to version 2 and keep existing installations working. Do not modify files; assess the request and next action in at most 250 words.",
+      "should_activate": true,
+      "reason": "Compatibility and data-loss policies are costly material decisions that must be resolved first."
+    },
+    {
+      "query": "Add a deployment test for the newly declared user skill and run the right tests. Do not modify files; assess the request and next action in at most 250 words.",
+      "should_activate": false,
+      "reason": "The component, framework, and test command are discoverable facts that must be researched without questioning the user."
+    },
+    {
+      "query": "Rename the local destinations variable in tooling/deployment-links.test.ts to skillDestinations. Do not modify files; assess the request and next action in at most 250 words.",
+      "should_activate": false,
+      "reason": "This is an obvious, local, reversible rename governed by an explicit nearby convention."
+    },
+    {
+      "query": "Apply the neighboring test's existing timeout to the new deployment-link test. Do not modify files; assess the request and next action in at most 250 words.",
+      "should_activate": false,
+      "reason": "The unspecified local detail has a safe canonical default that can be verified in the repository."
+    },
+    {
+      "query": "Use whichever existing import order fits tooling/deployment-links.test.ts better. Do not modify files; assess the request and next action in at most 250 words.",
+      "should_activate": false,
+      "reason": "The choice is a non-material style preference with no effect on the acceptance criteria."
+    }
+  ]
+}

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -93,6 +93,11 @@ skills:
       - { agent: claude, scope: user }
       - { agent: cursor, scope: user }
       - { agent: codex, scope: user }
+  - slug: requirements-clarification
+    installations:
+      - { agent: claude, scope: user }
+      - { agent: cursor, scope: user }
+      - { agent: codex, scope: user }
 hooks:
   - id: measurement
     installations:

--- a/tooling/codegraph-configure-deployment.test.ts
+++ b/tooling/codegraph-configure-deployment.test.ts
@@ -80,7 +80,7 @@ describe("CodeGraph deployment", () => {
     expect(result.stderr).toContain(
       "exists and is not the expected symbolic link",
     );
-  });
+  }, 15_000);
 });
 
 const realClaude = process.env.CODEGRAPH_REAL_CLAUDE_BIN;

--- a/tooling/deployment-links.test.ts
+++ b/tooling/deployment-links.test.ts
@@ -93,7 +93,7 @@ describe("deployment area: managed links", () => {
     symlinkSync(unexpected, starship);
     expectSuccess(runMake(fixture, [starship], { repository: project }));
     expect(linkTarget(starship)).toBe(unexpected);
-  });
+  }, 15_000);
 });
 
 describe("deployment area: agent instructions and skills", () => {

--- a/tooling/deployment-links.test.ts
+++ b/tooling/deployment-links.test.ts
@@ -162,6 +162,7 @@ describe("deployment area: agent instructions and skills", () => {
         "linear-sync",
         "pr-fix",
         "pr-verdict",
+        "requirements-clarification",
         "skill-manager",
         "workflow-automation",
       ].map((slug) => [".claude", slug]),
@@ -176,6 +177,7 @@ describe("deployment area: agent instructions and skills", () => {
         "linear-sync",
         "pr-fix",
         "pr-verdict",
+        "requirements-clarification",
         "skill-manager",
         "workflow-automation",
       ].map((slug) => [".cursor", slug]),
@@ -191,6 +193,7 @@ describe("deployment area: agent instructions and skills", () => {
         "linear-sync",
         "pr-fix",
         "pr-verdict",
+        "requirements-clarification",
         "skill-manager",
         "workflow-automation",
       ].map((slug) => [".agents", slug]),
@@ -207,4 +210,20 @@ describe("deployment area: agent instructions and skills", () => {
       expect(pathExists(join(project, ".agents", "skills", slug))).toBeFalse();
     }
   }, 30_000);
+
+  test("agent aggregate targets include requirements clarification", () => {
+    const fixture = createDeploymentFixture("requirements-clarification");
+    for (const [target, destination] of [
+      ["claude-code", ".claude/skills/requirements-clarification"],
+      ["cursor", ".cursor/skills/requirements-clarification"],
+      ["codex", ".agents/skills/requirements-clarification"],
+    ] as const) {
+      const result = runMake(fixture, [target], {
+        repository: project,
+        dryRun: true,
+      });
+      expectSuccess(result);
+      expect(result.stdout).toContain(join(fixture.home, destination));
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- add the portable user-scoped `requirements-clarification` skill and its six trigger evals
- deploy one canonical source to Claude Code, Cursor, and Codex through Arnes and Make
- add deployment barriers, lint coverage, and an aggregate report for the 54-run validation

## Validation

- `bun test tooling/deployment-links.test.ts` — 6 tests, 100 assertions
- `bun run typecheck`
- `cargo test --manifest-path tooling/arnes/Cargo.toml`
- Prettier, cspell, `git diff --check`, skill doctor, and skill cross-check
- 3 independent runs per scenario and agent; routing/model variance is recorded in the validation document

## Limits

- macOS arm64 exercised; Linux remains CI-only
- `skills-ref` was unavailable locally
- Codex skill doctor reports this skill healthy but exits non-zero for an unrelated pre-existing unexpected plugin
- measured routing precision and per-run evidence improvements are tracked in #223

Closes #81
