### PR TITLE
Keep Bun packages current with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       day: monday
       time: "05:00"
       timezone: Europe/Paris
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Europe/Paris

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -141,7 +141,8 @@ jobs:
 
       - name: Check text syntax and formatting
         run: >-
-          prettier --check .github/ISSUE_TEMPLATE/change.yml package.json tsconfig.json
+          prettier --check .github/ISSUE_TEMPLATE/change.yml .github/dependabot.yml
+          package.json tsconfig.json
           docs/AGENTS.md docs/ARCHITECTURE.md
           harness/skills/obsidian-retrieval/SKILL.md
           harness/skills/obsidian-retrieval/references/obsidian-cli.md

--- a/docs/adr/008-lockfile-plugins-versionne.md
+++ b/docs/adr/008-lockfile-plugins-versionne.md
@@ -21,10 +21,10 @@ commit précis, et les mises à jour produisent un commit dédié
 Dependabot propose chaque semaine les mises à jour des dépendances directes du
 projet Bun racine. Sa configuration ne porte aucune liste de paquets : les
 dépendances directes présentes et futures restent éligibles. Les propositions
-restent des pull requests sans fusion automatique et passent l'installation
-gelée, les tests Bun et la vérification TypeScript communes aux autres pull
-requests. Cette décision ne couvre aucun autre écosystème ni les mises à jour
-du runtime Bun.
+restent des pull requests sans fusion automatique et déclenchent
+l'installation gelée, les tests Bun et la vérification TypeScript communes
+aux autres pull requests. Cette décision ne couvre aucun autre écosystème ni
+les mises à jour du runtime Bun.
 
 ## Conséquences
 
@@ -44,5 +44,6 @@ du runtime Bun.
   arrière.
 - Mises à jour manuelles plugin par plugin : coût sans bénéfice, puisque le
   lockfile permet déjà l'annulation.
-- Renovate pour les dépendances Bun : aucun service ni configuration Renovate
-  n'est actif dans le dépôt ; Dependabot fournit l'intégration GitHub retenue.
+- Renovate pour les dépendances Bun : cette intégration n'est pas retenue ; la
+  cible d'installation du CLI local n'en fait pas le gestionnaire de mises à
+  jour du dépôt.

--- a/docs/adr/008-lockfile-plugins-versionne.md
+++ b/docs/adr/008-lockfile-plugins-versionne.md
@@ -20,11 +20,12 @@ commit précis, et les mises à jour produisent un commit dédié
 
 Dependabot propose chaque semaine les mises à jour des dépendances directes du
 projet Bun racine. Sa configuration ne porte aucune liste de paquets : les
-dépendances directes présentes et futures restent éligibles. Les propositions
-restent des pull requests sans fusion automatique et déclenchent
-l'installation gelée, les tests Bun et la vérification TypeScript communes
-aux autres pull requests. Cette décision ne couvre aucun autre écosystème ni
-les mises à jour du runtime Bun.
+dépendances directes présentes et futures restent éligibles après une fenêtre
+de refroidissement explicite d'au moins trois jours suivant la publication
+d'une version. Les propositions restent des pull requests sans fusion
+automatique et déclenchent l'installation gelée, les tests Bun et la
+vérification TypeScript communes aux autres pull requests. Cette décision ne
+couvre aucun autre écosystème ni les mises à jour du runtime Bun.
 
 ## Conséquences
 
@@ -33,6 +34,9 @@ les mises à jour du runtime Bun.
   trois cents sur douze ans — ce qui nuit à sa lisibilité.
 - Un poste neuf installe exactement les versions validées sur le poste
   courant.
+- Une nouvelle version attend au moins trois jours avant de devenir éligible à
+  une proposition, ce qui laisse apparaître les compromissions détectées
+  rapidement au lieu de suivre immédiatement la publication.
 - Le service Dependabot ne devient observable qu'après intégration de sa
   configuration dans la branche par défaut ; une validation YAML locale ne
   prouve ni son exécution ni la production conjointe du manifeste et du

--- a/docs/adr/008-lockfile-plugins-versionne.md
+++ b/docs/adr/008-lockfile-plugins-versionne.md
@@ -1,21 +1,30 @@
-# ADR-008 — `lazy-lock.json` versionné et Renovate
+# ADR-008 — Lockfiles versionnés et Dependabot pour Bun
 
 - **Statut** : accepté
-- **Date** : 2024-10
+- **Dates** : 2024-10, 2026-08
 - **Commits** : `bef7198`
 
 ## Contexte
 
 Un plugin Neovim suivi sur sa branche par défaut peut casser l'éditeur à la
 première mise à jour, sans possibilité de revenir à un état connu. Le reste
-des dépendances du dépôt souffre du même problème à une échelle plus lente.
+des dépendances du dépôt souffre du même problème à une échelle plus lente. Le
+projet Bun racine dispose également d'un manifeste et d'un lockfile texte
+versionnés, exécutés par une CI qui refuse leur désynchronisation.
 
 ## Décision
 
 Committer `home/.config/nvim/lazy-lock.json` : chaque plugin est épinglé à un
 commit précis, et les mises à jour produisent un commit dédié
-(`chore(nvim): update plugins`) généré par le script d'upgrade. Renovate prend
-en charge les dépendances restantes du dépôt.
+(`chore(nvim): update plugins`) généré par le script d'upgrade.
+
+Dependabot propose chaque semaine les mises à jour des dépendances directes du
+projet Bun racine. Sa configuration ne porte aucune liste de paquets : les
+dépendances directes présentes et futures restent éligibles. Les propositions
+restent des pull requests sans fusion automatique et passent l'installation
+gelée, les tests Bun et la vérification TypeScript communes aux autres pull
+requests. Cette décision ne couvre aucun autre écosystème ni les mises à jour
+du runtime Bun.
 
 ## Conséquences
 
@@ -24,6 +33,10 @@ en charge les dépendances restantes du dépôt.
   trois cents sur douze ans — ce qui nuit à sa lisibilité.
 - Un poste neuf installe exactement les versions validées sur le poste
   courant.
+- Le service Dependabot ne devient observable qu'après intégration de sa
+  configuration dans la branche par défaut ; une validation YAML locale ne
+  prouve ni son exécution ni la production conjointe du manifeste et du
+  lockfile.
 
 ## Alternatives écartées
 
@@ -31,3 +44,5 @@ en charge les dépendances restantes du dépôt.
   arrière.
 - Mises à jour manuelles plugin par plugin : coût sans bénéfice, puisque le
   lockfile permet déjà l'annulation.
+- Renovate pour les dépendances Bun : aucun service ni configuration Renovate
+  n'est actif dans le dépôt ; Dependabot fournit l'intégration GitHub retenue.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,7 +44,7 @@ ici sont les dates d'auteur.
 | [005](005-elagage-des-cibles.md)                       | Élagage périodique des cibles inutilisées                        | 2025-12 |
 | [006](006-neovim-editeur-par-defaut.md)                | Neovim comme éditeur par défaut                                  | 2019-11 |
 | [007](007-lazyvim-comme-distribution.md)               | LazyVim comme distribution Neovim                                | 2023-12 |
-| [008](008-lockfile-plugins-versionne.md)               | `lazy-lock.json` versionné et Renovate                           | 2024-10 |
+| [008](008-lockfile-plugins-versionne.md)               | Lockfiles versionnés et Dependabot pour Bun                      | 2024-10 |
 | [009](009-lsp-natif-et-conform.md)                     | Lint et format par LSP natif et conform                          | 2026-07 |
 | [010](010-fish-shell-par-defaut.md)                    | Fish comme shell par défaut                                      | 2025-01 |
 | [011](011-starship-comme-prompt.md)                    | Starship comme prompt unique                                     | 2025-01 |

--- a/tooling/dependabot-config.test.ts
+++ b/tooling/dependabot-config.test.ts
@@ -12,6 +12,9 @@ const rootBunUpdate = {
     time: "05:00",
     timezone: "Europe/Paris",
   },
+  cooldown: {
+    "default-days": 3,
+  },
 } as const;
 
 const rootBunUpdateSchema = z
@@ -24,6 +27,11 @@ const rootBunUpdateSchema = z
         day: z.literal("monday"),
         time: z.literal("05:00"),
         timezone: z.literal("Europe/Paris"),
+      })
+      .strict(),
+    cooldown: z
+      .object({
+        "default-days": z.number().int().min(3),
       })
       .strict(),
   })
@@ -43,15 +51,17 @@ test("keeps every root Bun dependency eligible for weekly updates", () => {
   );
   const config = dependabotConfigSchema.parse(Bun.YAML.parse(contents));
 
-  expect(config.updates).toEqual([rootBunUpdate]);
+  expect(config.updates[0]?.cooldown["default-days"]).toBeGreaterThanOrEqual(3);
 });
 
 test.each([
   ["a disabled pull request queue", { "open-pull-requests-limit": 0 }],
   ["an allow filter", { allow: [] }],
   ["an ignore filter", { ignore: [] }],
-])("rejects %s", (_, excludedOption) => {
+  ["a cooldown shorter than three days", { cooldown: { "default-days": 2 } }],
+  ["a cooldown exclusion", { cooldown: { "default-days": 3, exclude: ["*"] } }],
+])("rejects %s", (_, contractOverride) => {
   expect(() =>
-    rootBunUpdateSchema.parse({ ...rootBunUpdate, ...excludedOption }),
+    rootBunUpdateSchema.parse({ ...rootBunUpdate, ...contractOverride }),
   ).toThrow();
 });

--- a/tooling/dependabot-config.test.ts
+++ b/tooling/dependabot-config.test.ts
@@ -3,25 +3,38 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
 
-const dependabotConfigSchema = z.object({
-  version: z.literal(2),
-  updates: z
-    .array(
-      z
-        .object({
-          "package-ecosystem": z.literal("bun"),
-          directory: z.literal("/"),
-          schedule: z.object({
-            interval: z.literal("weekly"),
-            day: z.literal("monday"),
-            time: z.literal("05:00"),
-            timezone: z.literal("Europe/Paris"),
-          }),
-        })
-        .passthrough(),
-    )
-    .length(1),
-});
+const rootBunUpdate = {
+  "package-ecosystem": "bun",
+  directory: "/",
+  schedule: {
+    interval: "weekly",
+    day: "monday",
+    time: "05:00",
+    timezone: "Europe/Paris",
+  },
+} as const;
+
+const rootBunUpdateSchema = z
+  .object({
+    "package-ecosystem": z.literal("bun"),
+    directory: z.literal("/"),
+    schedule: z
+      .object({
+        interval: z.literal("weekly"),
+        day: z.literal("monday"),
+        time: z.literal("05:00"),
+        timezone: z.literal("Europe/Paris"),
+      })
+      .strict(),
+  })
+  .strict();
+
+const dependabotConfigSchema = z
+  .object({
+    version: z.literal(2),
+    updates: z.array(rootBunUpdateSchema).length(1),
+  })
+  .strict();
 
 test("keeps every root Bun dependency eligible for weekly updates", () => {
   const contents = readFileSync(
@@ -29,8 +42,16 @@ test("keeps every root Bun dependency eligible for weekly updates", () => {
     "utf8",
   );
   const config = dependabotConfigSchema.parse(Bun.YAML.parse(contents));
-  const rootBunUpdate = config.updates[0];
 
-  expect(rootBunUpdate).not.toHaveProperty("allow");
-  expect(rootBunUpdate).not.toHaveProperty("ignore");
+  expect(config.updates).toEqual([rootBunUpdate]);
+});
+
+test.each([
+  ["a disabled pull request queue", { "open-pull-requests-limit": 0 }],
+  ["an allow filter", { allow: [] }],
+  ["an ignore filter", { ignore: [] }],
+])("rejects %s", (_, excludedOption) => {
+  expect(() =>
+    rootBunUpdateSchema.parse({ ...rootBunUpdate, ...excludedOption }),
+  ).toThrow();
 });

--- a/tooling/dependabot-config.test.ts
+++ b/tooling/dependabot-config.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+
+const dependabotConfigSchema = z.object({
+  version: z.literal(2),
+  updates: z
+    .array(
+      z
+        .object({
+          "package-ecosystem": z.literal("bun"),
+          directory: z.literal("/"),
+          schedule: z.object({
+            interval: z.literal("weekly"),
+            day: z.literal("monday"),
+            time: z.literal("05:00"),
+            timezone: z.literal("Europe/Paris"),
+          }),
+        })
+        .passthrough(),
+    )
+    .length(1),
+});
+
+test("keeps every root Bun dependency eligible for weekly updates", () => {
+  const contents = readFileSync(
+    join(import.meta.dir, "../.github/dependabot.yml"),
+    "utf8",
+  );
+  const config = dependabotConfigSchema.parse(Bun.YAML.parse(contents));
+  const rootBunUpdate = config.updates[0];
+
+  expect(rootBunUpdate).not.toHaveProperty("allow");
+  expect(rootBunUpdate).not.toHaveProperty("ignore");
+});


### PR DESCRIPTION
## Summary

- schedule weekly Dependabot version updates for every direct dependency in the root Bun project
- quarantine every newly published version for at least three days before it becomes eligible
- keep the configuration closed to package filters, cooldown exclusions, and options that could disable updates
- supersede ADR-008's inactive Renovate direction for the root Bun project
- validate the configuration contract in the existing Bun test and formatting gates

## Validation

Local environment: macOS 26.6.2 arm64, Bun 1.4.0.

- `bun install --frozen-lockfile`
- `prettier --check` for the changed YAML, workflow, and ADR files
- `actionlint` 1.7.12 for `.github/workflows/lint.yml`
- `bun run format:typescript:check` (82 files)
- `bun test` (241 passed, 4 integration tests skipped, 0 failed)
- `bun run typecheck`

GitHub: the native `.github/dependabot.yml` check passed; GitHub Actions on Ubuntu and macOS reported 15 passed checks, 1 smoke installation job skipped by its target selector, and 0 failures.

## Evidence limits

- The native Dependabot check proves that GitHub accepts this configuration; it does not prove a successful scheduled update job or a generated Bun update.
- A real generated PR is still required to prove that `package.json` and `bun.lock` update together and pass the Ubuntu Bun CI. Issue #217 must remain open until those post-merge criteria are observed.
- Repository configuration, history, hooks, workflows, branches, and checks show no active Renovate overlap. The current token cannot enumerate installed GitHub Apps, so that final Settings inventory was not reproduced through the API.

Implements the pre-merge configuration for #217 without enabling auto-merge, Bun runtime updates, security updates, or another dependency ecosystem.
