### PR TITLE
feat(tooling): enforce strict type-aware Oxlint

### DIFF
--- a/.agents/skills/apple-notes/scripts/notes-applescript.ts
+++ b/.agents/skills/apple-notes/scripts/notes-applescript.ts
@@ -1,40 +1,46 @@
-export function quoteAppleScript(value: string): string {
-  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+function quoteAppleScript(value: string): string {
+  return value
+    .replaceAll("\\", String.raw`\\\\`)
+    .replaceAll('"', String.raw`\"`);
 }
 
-export function folderSpecifier(path: string): string {
-  const parts = path.split("/");
-  if (parts.some((part) => part === ""))
-    throw new Error(`invalid folder path: ${path}`);
-  return parts.reduce(
-    (specifier, part) =>
-      specifier === ""
-        ? `folder "${quoteAppleScript(part)}"`
-        : `folder "${quoteAppleScript(part)}" of ${specifier}`,
-    "",
-  );
-}
-
-export function folderCreation(path: string): string {
+function folderCreation(path: string): string {
   let specifier = "";
   return path
     .split("/")
     .map((part) => {
-      const quoted = quoteAppleScript(part);
       const parent = specifier;
-      specifier =
-        parent === ""
-          ? `folder "${quoted}"`
-          : `folder "${quoted}" of ${parent}`;
-      return parent === ""
-        ? `if not (exists ${specifier}) then make new folder with properties {name:"${quoted}"}`
-        : `if not (exists ${specifier}) then make new folder at ${parent} with properties {name:"${quoted}"}`;
+      const quoted = quoteAppleScript(part);
+      if (parent === "") {
+        specifier = `folder "${quoted}"`;
+        return `if not (exists ${specifier}) then make new folder with properties {name:"${quoted}"}`;
+      }
+      specifier = `folder "${quoted}" of ${parent}`;
+      return `if not (exists ${specifier}) then make new folder at ${parent} with properties {name:"${quoted}"}`;
     })
     .join("\n");
 }
 
-export function replaceTitle(body: string, title: string): string {
-  const block = `<div><b><span style="font-size: 24px">${title}</span></b><br></div>`;
-  const replaced = body.replace(/^\s*<div>.*?<\/div>/s, block);
-  return replaced === body ? `${block}${body}` : replaced;
+function folderSpecifier(path: string): string {
+  const parts = path.split("/");
+  if (parts.some((part) => part === "")) {
+    throw new Error(`invalid folder path: ${path}`);
+  }
+  let specifier = "";
+  for (const part of parts) {
+    const folder = `folder "${quoteAppleScript(part)}"`;
+    specifier = specifier === "" ? folder : `${folder} of ${specifier}`;
+  }
+  return specifier;
 }
+
+function replaceTitle(body: string, title: string): string {
+  const block = `<div><b><span style="font-size: 24px">${title}</span></b><br></div>`;
+  const replaced = body.replace(/^\s*<div>.*?<\/div>/su, block);
+  if (replaced === body) {
+    return `${block}${body}`;
+  }
+  return replaced;
+}
+
+export { folderCreation, folderSpecifier, quoteAppleScript, replaceTitle };

--- a/.agents/skills/apple-notes/scripts/notes-arguments.ts
+++ b/.agents/skills/apple-notes/scripts/notes-arguments.ts
@@ -1,0 +1,40 @@
+import { quoteAppleScript } from "./notes-applescript.ts";
+
+function optionalArgument(
+  arguments_: readonly string[],
+  index: number,
+): string | undefined {
+  const value = arguments_.at(index);
+  return typeof value === "string" ? value : undefined;
+}
+
+function optionalNonemptyArgument(
+  arguments_: readonly string[],
+  index: number,
+): string | undefined {
+  const value = optionalArgument(arguments_, index);
+  return value === "" ? undefined : value;
+}
+
+function requiredArgument(
+  arguments_: readonly string[],
+  index: number,
+  usage: string,
+): string {
+  const value = optionalArgument(arguments_, index);
+  if (value === undefined || value === "") {
+    throw new Error(usage);
+  }
+  return value;
+}
+
+function selectedAccount(arguments_: readonly string[], index: number): string {
+  return quoteAppleScript(optionalArgument(arguments_, index) ?? "iCloud");
+}
+
+export {
+  optionalArgument,
+  optionalNonemptyArgument,
+  requiredArgument,
+  selectedAccount,
+};

--- a/.agents/skills/apple-notes/scripts/notes-attachments.ts
+++ b/.agents/skills/apple-notes/scripts/notes-attachments.ts
@@ -1,73 +1,113 @@
-import { lstat, mkdtemp, readdir, rm } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { folderSpecifier, quoteAppleScript } from "./notes-applescript.ts";
-import { runAppleScript } from "./notes-process.ts";
+import { lstat, mkdtemp, readdir, rm } from "node:fs/promises";
 import { publishDirectoryExclusively } from "./notes-publish.ts";
+import { runAppleScript } from "./notes-process.ts";
 
-async function pathIsAbsent(path: string): Promise<boolean> {
+const accountIndex = 4;
+const destinationIndex = 3;
+const folderIndex = 1;
+const noItems = 0;
+const titleIndex = 2;
+const pathIsAbsent = async (candidatePath: string): Promise<boolean> => {
   try {
-    await lstat(path);
+    await lstat(candidatePath);
     return false;
   } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT")
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return true;
+    }
     throw error;
   }
-}
-
-async function createExportStaging(
-  path: string,
-): Promise<Readonly<{ destination: string; temporary: string }>> {
-  const destination = resolve(path);
+};
+const createExportStaging = async (
+  candidatePath: string,
+): Promise<Readonly<{ destination: string; temporary: string }>> => {
+  const destination = resolve(candidatePath);
   const parentPath = dirname(destination);
   const parent = await lstat(parentPath);
-  if (!parent.isDirectory() || parent.isSymbolicLink())
+  if (!parent.isDirectory() || parent.isSymbolicLink()) {
     throw new Error(
       `attachment destination parent is not a physical directory`,
     );
-  if (!(await pathIsAbsent(destination)))
+  }
+  if (!(await pathIsAbsent(destination))) {
     throw new Error(`refusing existing attachment destination: ${destination}`);
+  }
   return {
     destination,
     temporary: await mkdtemp(
       join(parentPath, `.${basename(destination)}.notes-export-`),
     ),
   };
-}
-
-export async function exportAttachments(
-  arguments_: readonly string[],
-): Promise<void> {
-  const account = quoteAppleScript(arguments_[4] ?? "iCloud");
-  const source = folderSpecifier(arguments_[1]!);
-  const title = quoteAppleScript(arguments_[2]!);
-  const { destination, temporary } = await createExportStaging(arguments_[3]!);
-  let published = false;
-  try {
-    runAppleScript(`tell application "Notes"
-set sourceFolder to ${source} of account "${account}"
-set matches to every note of sourceFolder whose name is "${title}"
+};
+const exportScript = (
+  input: Readonly<{
+    account: string;
+    source: string;
+    temporary: string;
+    title: string;
+  }>,
+): string => `tell application "Notes"
+set sourceFolder to ${input.source} of account "${input.account}"
+set matches to every note of sourceFolder whose name is "${input.title}"
 if (count of matches) is not 1 then error "expected exactly one source note"
 set n to item 1 of matches
 repeat with i from 1 to (count of attachments of n)
 set a to attachment i of n
 set nm to (get name of a)
 if nm is missing value then set nm to "attachment"
-set exportPath to "${quoteAppleScript(temporary)}/" & i & "-" & nm
+set exportPath to "${quoteAppleScript(input.temporary)}/" & i & "-" & nm
 save a in file ((POSIX file exportPath) as string)
 log exportPath
 end repeat
-end tell\n`);
-    const exported = await readdir(temporary);
-    if (exported.length === 0)
-      throw new Error(
-        `nothing was exported from "${arguments_[2]}" — do not treat its attachments as backed up`,
-      );
-    if (!(await pathIsAbsent(destination)))
-      throw new Error(`attachment destination appeared during export`);
-    publishDirectoryExclusively(temporary, destination);
+end tell\n`;
+const publishExport = async (
+  destination: string,
+  temporary: string,
+  title: string,
+): Promise<void> => {
+  const exported = await readdir(temporary);
+  if (exported.length === noItems) {
+    throw new Error(
+      `nothing was exported from "${title}" — do not treat its attachments as backed up`,
+    );
+  }
+  if (!(await pathIsAbsent(destination))) {
+    throw new Error(`attachment destination appeared during export`);
+  }
+  publishDirectoryExclusively(temporary, destination);
+};
+const requiredArgument = (
+  arguments_: readonly string[],
+  index: number,
+): string => {
+  const value = arguments_.at(index);
+  if (typeof value !== "string") {
+    throw new TypeError(`missing attachment export argument`);
+  }
+  return value;
+};
+
+export const exportAttachments = async (
+  arguments_: readonly string[],
+): Promise<void> => {
+  const account = quoteAppleScript(arguments_.at(accountIndex) ?? "iCloud");
+  const folder = requiredArgument(arguments_, folderIndex);
+  const titleValue = requiredArgument(arguments_, titleIndex);
+  const source = folderSpecifier(folder);
+  const title = quoteAppleScript(titleValue);
+  const { destination, temporary } = await createExportStaging(
+    requiredArgument(arguments_, destinationIndex),
+  );
+  let published = false;
+  try {
+    runAppleScript(exportScript({ account, source, temporary, title }));
+    await publishExport(destination, temporary, titleValue);
     published = true;
   } finally {
-    if (!published) await rm(temporary, { recursive: true, force: true });
+    if (!published) {
+      await rm(temporary, { force: true, recursive: true });
+    }
   }
-}
+};

--- a/.agents/skills/apple-notes/scripts/notes-command.ts
+++ b/.agents/skills/apple-notes/scripts/notes-command.ts
@@ -1,60 +1,96 @@
+import { CommandFailureError, runAppleScript as run } from "./notes-process.ts";
 import {
   folderCreation,
   folderSpecifier,
   quoteAppleScript,
   replaceTitle,
 } from "./notes-applescript.ts";
+import {
+  optionalArgument,
+  optionalNonemptyArgument,
+  requiredArgument,
+  selectedAccount,
+} from "./notes-arguments.ts";
 import { exportAttachments } from "./notes-attachments.ts";
-import { CommandFailure, runAppleScript as run } from "./notes-process.ts";
 
+type MoveInput = Readonly<{
+  destination: string;
+  destinationPath: string;
+  expectedBody: string | undefined;
+  newTitle: string | undefined;
+  source: string;
+  title: string;
+}>;
+
+const accountIndex = 5;
+const attachmentCountIndex = 2;
+const commandIndex = 0;
+const destinationIndex = 3;
+const expectedMoveFactCount = 3;
+const folderIndex = 1;
+const genericFailureExitCode = 1;
+const matchCountIndex = 1;
+const noAttachments = 0;
+const sharedIndex = 0;
+const successfulExitCode = 0;
+const titleIndex = 2;
+const renamedTitleIndex = 4;
+const usageExitCode = 64;
 const usage = `usage:
   notes.sh folder <name> [account]
   notes.sh note <folder> <title> [account]
   notes.sh move <src/path> <title> <dst/path> [new-title] [account]
   notes.sh attachments <folder/path> <title> <dir> [account]`;
-
-function selectedAccount(arguments_: readonly string[], index: number): string {
-  return quoteAppleScript(arguments_[index] ?? "iCloud");
-}
-
-function parseMoveFacts(output: string): Readonly<{
-  shared: boolean;
-  matchCount: number;
+const parseMoveFacts = (
+  output: string,
+): Readonly<{
   attachmentCount: number;
-}> {
-  const [shared, matches, attachments, extra] = output.split("\t");
-  const matchCount = Number(matches);
+  matchCount: number;
+  shared: boolean;
+}> => {
+  const parts = output.split("\t");
+  if (parts.length !== expectedMoveFactCount) {
+    throw new Error(`unexpected AppleScript move evidence: ${output}`);
+  }
+  const attachments = parts.at(attachmentCountIndex) ?? "";
+  const matches = parts.at(matchCountIndex) ?? "";
+  const shared = parts.at(sharedIndex) ?? "";
   const attachmentCount = Number(attachments);
+  const matchCount = Number(matches);
   if (
     (shared !== "true" && shared !== "false") ||
-    extra !== undefined ||
     !Number.isSafeInteger(matchCount) ||
-    matchCount < 0 ||
+    matchCount < successfulExitCode ||
     !Number.isSafeInteger(attachmentCount) ||
-    attachmentCount < 0
-  )
+    attachmentCount < noAttachments
+  ) {
     throw new Error(`unexpected AppleScript move evidence: ${output}`);
-  return { shared: shared === "true", matchCount, attachmentCount };
-}
-
-function createFolder(arguments_: readonly string[]): void {
-  if (!arguments_[1]) throw new Error(usage);
-  const name = quoteAppleScript(arguments_[1]);
-  const account = selectedAccount(arguments_, 2);
+  }
+  return { attachmentCount, matchCount, shared: shared === "true" };
+};
+const createFolder = (arguments_: readonly string[]): void => {
+  const account = selectedAccount(arguments_, titleIndex);
+  const name = quoteAppleScript(
+    requiredArgument(arguments_, folderIndex, usage),
+  );
   process.stdout.write(
     `${run(`tell application "Notes" to tell account "${account}"
 if not (exists folder "${name}") then make new folder with properties {name:"${name}"}
 return name of folder "${name}"
 end tell\n`)}\n`,
   );
-}
-
-function createNote(arguments_: readonly string[], body: string): void {
-  if (!arguments_[1] || !arguments_[2]) throw new Error(usage);
-  if (body === "") throw new Error("refusing empty note body");
-  const account = selectedAccount(arguments_, 3);
-  const folder = quoteAppleScript(arguments_[1]);
-  const title = quoteAppleScript(arguments_[2]);
+};
+const createNote = (arguments_: readonly string[], body: string): void => {
+  const account = selectedAccount(arguments_, destinationIndex);
+  const folder = quoteAppleScript(
+    requiredArgument(arguments_, folderIndex, usage),
+  );
+  const title = quoteAppleScript(
+    requiredArgument(arguments_, titleIndex, usage),
+  );
+  if (body === "") {
+    throw new Error("refusing empty note body");
+  }
   const content = quoteAppleScript(body.replaceAll("\n", ""));
   process.stdout.write(
     `${run(`tell application "Notes" to tell account "${account}"
@@ -63,72 +99,71 @@ set n to make new note at folder "${folder}" with properties {body:"<div><h1>${t
 return name of n
 end tell\n`)}\n`,
   );
-}
-
-function buildMoveMutation(
-  input: Readonly<{
-    source: string;
-    destination: string;
-    destinationPath: string;
-    title: string;
-    newTitle: string | undefined;
-    expectedBody: string | undefined;
-  }>,
-): string {
+};
+const appendMoveRetitle = (mutation: string, input: MoveInput): string => {
+  if (input.newTitle === undefined) {
+    return mutation;
+  }
+  if (input.expectedBody === undefined) {
+    return `${mutation}\nset name of n to "${quoteAppleScript(input.newTitle)}"`;
+  }
+  const rewritten = quoteAppleScript(
+    replaceTitle(input.expectedBody, input.newTitle).replaceAll("\n", ""),
+  );
+  return `${mutation}\nset body of n to "${rewritten}"`;
+};
+const buildMoveMutation = (input: MoveInput): string => {
   let mutation = `if (get shared of ${input.source}) then error "source folder became shared before the move"
 set sourceMatches to every note of ${input.source} whose name is "${input.title}"
 if (count of sourceMatches) is not 1 then error "source note cardinality changed before the move"
 set n to item 1 of sourceMatches`;
-  if (input.expectedBody !== undefined)
+  if (input.expectedBody !== undefined) {
     mutation += `\nif (count of attachments of n) is not 0 then error "source note gained attachments before the move"
 if (get body of n) is not "${quoteAppleScript(input.expectedBody)}" then error "source note changed before the move"`;
+  }
   mutation += `\nset moveCompleted to false
 try
 ${folderCreation(input.destinationPath)}
 move n to ${input.destination}
 set moveCompleted to true`;
-  if (input.newTitle && input.expectedBody === undefined)
-    mutation += `\nset name of n to "${quoteAppleScript(input.newTitle)}"`;
-  if (input.newTitle && input.expectedBody !== undefined) {
-    const rewritten = quoteAppleScript(
-      replaceTitle(input.expectedBody, input.newTitle).replaceAll("\n", ""),
-    );
-    mutation += `\nset body of n to "${rewritten}"`;
+  mutation = appendMoveRetitle(mutation, input);
+  if (input.newTitle !== undefined) {
+    mutation += "\nreturn name of n";
   }
-  if (input.newTitle) mutation += "\nreturn name of n";
   return `${mutation}
 on error errorMessage number errorNumber
 if moveCompleted then error "note moved but its post-move update failed; inspect the destination: " & errorMessage number errorNumber
 error errorMessage number errorNumber
 end try`;
-}
-
-function readExpectedBody(
-  newTitle: string | undefined,
-  attachmentCount: number,
-  account: string,
-  title: string,
-  source: string,
-): string | undefined {
-  if (!newTitle || attachmentCount !== 0) return undefined;
+};
+const readExpectedBody = (
+  input: Readonly<{
+    account: string;
+    attachmentCount: number;
+    newTitle: string | undefined;
+    source: string;
+    title: string;
+  }>,
+): string | undefined => {
+  if (input.newTitle === undefined || input.attachmentCount !== noAttachments) {
+    return undefined;
+  }
   const body = run(
-    `tell application "Notes" to tell account "${account}" to get body of note "${quoteAppleScript(title)}" of ${source}\n`,
+    `tell application "Notes" to tell account "${input.account}" to get body of note "${quoteAppleScript(input.title)}" of ${input.source}\n`,
   );
-  if (body === "")
+  if (body === "") {
     throw new Error(
-      `refusing to retitle "${title}": rewritten body came back empty — the note is unchanged`,
+      `refusing to retitle "${input.title}": rewritten body came back empty — the note is unchanged`,
     );
+  }
   return body;
-}
-
-function moveNote(arguments_: readonly string[]): void {
-  if (!arguments_[1] || !arguments_[2] || !arguments_[3])
-    throw new Error(usage);
-  const account = selectedAccount(arguments_, 5);
-  const source = folderSpecifier(arguments_[1]);
-  const destination = folderSpecifier(arguments_[3]);
-  const title = quoteAppleScript(arguments_[2]);
-  const facts = parseMoveFacts(
+};
+const readMoveFacts = (
+  account: string,
+  source: string,
+  title: string,
+): ReturnType<typeof parseMoveFacts> =>
+  parseMoveFacts(
     run(`tell application "Notes" to tell account "${account}"
 set matches to every note of ${source} whose name is "${title}"
 set matchCount to count of matches
@@ -136,58 +171,112 @@ if matchCount is not 1 then return ((get shared of ${source}) as text) & tab & m
 return ((get shared of ${source}) as text) & tab & matchCount & tab & (count of attachments of item 1 of matches)
 end tell\n`),
   );
-  if (facts.shared)
+const assertMoveAllowed = (facts: ReturnType<typeof parseMoveFacts>): void => {
+  if (facts.shared) {
     throw new Error(
       "refusing to move a note out of a shared folder — sharing cannot be restored by script",
     );
-  if (facts.matchCount !== 1)
+  }
+  if (facts.matchCount !== genericFailureExitCode) {
     throw new Error(
       `expected exactly one source note, found ${facts.matchCount}`,
     );
-  const newTitle = arguments_[4];
-  const expectedBody = readExpectedBody(
-    newTitle,
-    facts.attachmentCount,
+  }
+};
+const writeAttachmentRenameWarning = (
+  attachmentCount: number,
+  newTitle: string | undefined,
+): void => {
+  if (newTitle !== undefined && attachmentCount > noAttachments) {
+    process.stderr.write(
+      `renamed via 'set name' (${attachmentCount} attachment(s) preserved); the body's first line still shows the old title\n`,
+    );
+  }
+};
+const moveNote = (arguments_: readonly string[]): void => {
+  const account = selectedAccount(arguments_, accountIndex);
+  const destinationPath = requiredArgument(arguments_, destinationIndex, usage);
+  const newTitle = optionalNonemptyArgument(arguments_, renamedTitleIndex);
+  const sourcePath = requiredArgument(arguments_, folderIndex, usage);
+  const titleValue = requiredArgument(arguments_, titleIndex, usage);
+  const destination = folderSpecifier(destinationPath);
+  const source = folderSpecifier(sourcePath);
+  const title = quoteAppleScript(titleValue);
+  const facts = readMoveFacts(account, source, title);
+  assertMoveAllowed(facts);
+  const expectedBody = readExpectedBody({
     account,
-    arguments_[2],
-    source,
-  );
-  const mutation = buildMoveMutation({
-    source,
-    destination,
-    destinationPath: arguments_[3],
-    title,
+    attachmentCount: facts.attachmentCount,
     newTitle,
+    source,
+    title: titleValue,
+  });
+  const mutation = buildMoveMutation({
+    destination,
+    destinationPath,
     expectedBody,
+    newTitle,
+    source,
+    title,
   });
   const output = run(`tell application "Notes" to tell account "${account}"
 ${mutation}
 end tell\n`);
-  if (output !== "") process.stdout.write(`${output}\n`);
-  if (newTitle && facts.attachmentCount > 0)
-    process.stderr.write(
-      `renamed via 'set name' (${facts.attachmentCount} attachment(s) preserved); the body's first line still shows the old title\n`,
-    );
-}
-
-export async function runNotesCommand(
+  if (output !== "") {
+    process.stdout.write(`${output}\n`);
+  }
+  writeAttachmentRenameWarning(facts.attachmentCount, newTitle);
+};
+const runSelectedCommand = async (
   arguments_: readonly string[],
   body: string,
-): Promise<number> {
-  try {
-    if (arguments_[0] === "folder") createFolder(arguments_);
-    else if (arguments_[0] === "note") createNote(arguments_, body);
-    else if (arguments_[0] === "move") moveNote(arguments_);
-    else if (arguments_[0] === "attachments") {
-      if (!arguments_[1] || !arguments_[2] || !arguments_[3])
-        throw new Error(usage);
-      await exportAttachments(arguments_);
-    } else throw new Error(usage);
-    return 0;
-  } catch (error) {
-    if (error instanceof CommandFailure) return error.status;
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`${message}\n`);
-    return message === usage ? 64 : 1;
+): Promise<void> => {
+  const command = optionalArgument(arguments_, commandIndex);
+  if (command === "folder") {
+    createFolder(arguments_);
+    return;
   }
-}
+  if (command === "note") {
+    createNote(arguments_, body);
+    return;
+  }
+  if (command === "move") {
+    moveNote(arguments_);
+    return;
+  }
+  if (command === "attachments") {
+    requiredArgument(arguments_, folderIndex, usage);
+    requiredArgument(arguments_, titleIndex, usage);
+    requiredArgument(arguments_, destinationIndex, usage);
+    await exportAttachments(arguments_);
+    return;
+  }
+  throw new Error(usage);
+};
+const reportFailure = (error: unknown): number => {
+  if (error instanceof CommandFailureError) {
+    return error.status;
+  }
+  let message = String(error);
+  if (error instanceof Error) {
+    ({ message } = error);
+  }
+  process.stderr.write(`${message}\n`);
+  if (message === usage) {
+    return usageExitCode;
+  }
+  return genericFailureExitCode;
+};
+const runNotesCommand = async (
+  arguments_: readonly string[],
+  body: string,
+): Promise<number> => {
+  try {
+    await runSelectedCommand(arguments_, body);
+    return successfulExitCode;
+  } catch (error) {
+    return reportFailure(error);
+  }
+};
+
+export { runNotesCommand };

--- a/.agents/skills/apple-notes/scripts/notes-process.ts
+++ b/.agents/skills/apple-notes/scripts/notes-process.ts
@@ -1,31 +1,45 @@
-export class CommandFailure extends Error {
-  constructor(readonly status: number) {
+const successfulExitCode = 0;
+
+class CommandFailureError extends Error {
+  public readonly status: number;
+
+  public constructor(status: number) {
     super("");
+    this.name = "CommandFailureError";
+    this.status = status;
   }
 }
 
-const decoder = new TextDecoder("utf-8", { fatal: true });
-
-function decode(bytes: Uint8Array): string {
+function decodeOutput(output: readonly number[]): string {
   try {
-    return decoder.decode(bytes);
+    return new TextDecoder("utf-8", { fatal: true }).decode(
+      new Uint8Array(output),
+    );
   } catch {
     throw new Error(`AppleScript returned invalid UTF-8`);
   }
 }
 
-export function runAppleScript(script: string): string {
+const runAppleScript = (script: string): string => {
   const result = Bun.spawnSync(["osascript"], {
+    stderr: "pipe",
     stdin: Buffer.from(script),
     stdout: "pipe",
-    stderr: "pipe",
   });
-  if (result.exitCode !== 0) {
-    if (result.stdout.length > 0) process.stdout.write(result.stdout);
-    if (result.stderr.length > 0) process.stderr.write(result.stderr);
-    throw new CommandFailure(result.exitCode);
+  if (result.exitCode !== successfulExitCode) {
+    if (result.stdout.length > successfulExitCode) {
+      process.stdout.write(result.stdout);
+    }
+    if (result.stderr.length > successfulExitCode) {
+      process.stderr.write(result.stderr);
+    }
+    throw new CommandFailureError(result.exitCode);
   }
-  const stdout = decode(result.stdout);
-  if (result.stderr.length > 0) process.stderr.write(result.stderr);
+  const stdout = decodeOutput([...result.stdout]);
+  if (result.stderr.length > successfulExitCode) {
+    process.stderr.write(result.stderr);
+  }
   return stdout.trimEnd();
-}
+};
+
+export { CommandFailureError, runAppleScript };

--- a/.agents/skills/apple-notes/scripts/notes-publish.ts
+++ b/.agents/skills/apple-notes/scripts/notes-publish.ts
@@ -1,50 +1,58 @@
 import { dlopen } from "bun:ffi";
 
+const currentWorkingDirectory = -100;
 const renameExclusive = 4;
 const renameNoReplace = 1;
-const currentWorkingDirectory = -100;
+const successfulExitCode = 0;
+const publishOnDarwin = (source: string, destination: string): boolean => {
+  const library = dlopen("/usr/lib/libSystem.B.dylib", {
+    renamex_np: { args: ["cstring", "cstring", "u32"], returns: "i32" },
+  });
+  try {
+    return (
+      library.symbols.renamex_np(source, destination, renameExclusive) ===
+      successfulExitCode
+    );
+  } finally {
+    library.close();
+  }
+};
+const publishOnLinux = (source: string, destination: string): boolean => {
+  const library = dlopen("libc.so.6", {
+    renameat2: {
+      args: ["i32", "cstring", "i32", "cstring", "u32"],
+      returns: "i32",
+    },
+  });
+  try {
+    return (
+      library.symbols.renameat2(
+        currentWorkingDirectory,
+        source,
+        currentWorkingDirectory,
+        destination,
+        renameNoReplace,
+      ) === successfulExitCode
+    );
+  } finally {
+    library.close();
+  }
+};
 
-export function publishDirectoryExclusively(
+export const publishDirectoryExclusively = (
   source: string,
   destination: string,
-): void {
-  if (process.platform === "darwin") {
-    const library = dlopen("/usr/lib/libSystem.B.dylib", {
-      renamex_np: { args: ["cstring", "cstring", "u32"], returns: "i32" },
-    });
-    try {
-      if (
-        library.symbols.renamex_np(source, destination, renameExclusive) === 0
-      )
-        return;
-    } finally {
-      library.close();
-    }
-  } else if (process.platform === "linux") {
-    const library = dlopen("libc.so.6", {
-      renameat2: {
-        args: ["i32", "cstring", "i32", "cstring", "u32"],
-        returns: "i32",
-      },
-    });
-    try {
-      if (
-        library.symbols.renameat2(
-          currentWorkingDirectory,
-          source,
-          currentWorkingDirectory,
-          destination,
-          renameNoReplace,
-        ) === 0
-      )
-        return;
-    } finally {
-      library.close();
-    }
-  } else {
+): void => {
+  if (process.platform === "darwin" && publishOnDarwin(source, destination)) {
+    return;
+  }
+  if (process.platform === "linux" && publishOnLinux(source, destination)) {
+    return;
+  }
+  if (process.platform !== "darwin" && process.platform !== "linux") {
     throw new Error(`unsupported platform for exclusive publication`);
   }
   throw new Error(
     `attachment destination already exists or cannot be published`,
   );
-}
+};

--- a/.agents/skills/apple-notes/scripts/notes.ts
+++ b/.agents/skills/apple-notes/scripts/notes.ts
@@ -2,6 +2,9 @@
 
 import { runNotesCommand } from "./notes-command.ts";
 
-process.exit(
-  await runNotesCommand(process.argv.slice(2), await Bun.stdin.text()),
-);
+const argumentOffset = 2;
+const commandArguments = process.argv.slice(argumentOffset);
+const body = await Bun.stdin.text();
+const exitCode = await runNotesCommand(commandArguments, body);
+
+process.exit(exitCode);

--- a/.github/workflows/test-typescript.yml
+++ b/.github/workflows/test-typescript.yml
@@ -3,6 +3,17 @@ name: TypeScript
 on: [push, pull_request]
 
 jobs:
+  lint:
+    name: TypeScript lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+      - run: bun --config=/dev/null --no-env-file install --frozen-lockfile --ignore-scripts
+      - run: bun --config=/dev/null --no-env-file tooling/lint-typescript.ts
+
   test:
     name: Bun tests
     runs-on: ubuntu-latest
@@ -11,8 +22,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: package.json
-      - run: bun install --frozen-lockfile
-      - run: bun test
+      - run: bun --config=/dev/null --no-env-file install --frozen-lockfile --ignore-scripts
+      - run: bun --config=/dev/null --no-env-file test
         env:
           SCRAPLING_DOCKER_SMOKE: "1"
 
@@ -24,5 +35,5 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: package.json
-      - run: bun install --frozen-lockfile
-      - run: bun run typecheck
+      - run: bun --config=/dev/null --no-env-file install --frozen-lockfile --ignore-scripts
+      - run: bun --config=/dev/null --no-env-file run typecheck

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": [
+    "eslint",
+    "import",
+    "node",
+    "promise",
+    "typescript",
+    "unicorn",
+    "oxc"
+  ],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "error",
+    "pedantic": "error",
+    "perf": "error",
+    "style": "error",
+    "restriction": "error"
+  },
+  "options": {
+    "typeAware": true,
+    "maxWarnings": 0
+  },
+  "rules": {
+    "eslint/func-style": [
+      "error",
+      "declaration",
+      { "allowArrowFunctions": true }
+    ],
+    "eslint/max-statements": ["error", 20],
+    "eslint/no-await-in-loop": "off",
+    "eslint/no-bitwise": "off",
+    "eslint/no-magic-numbers": [
+      "error",
+      {
+        "enforceConst": true,
+        "ignore": [-1, 0, 1],
+        "ignoreArrayIndexes": true,
+        "ignoreNumericLiteralTypes": true,
+        "ignoreTypeIndexes": true
+      }
+    ],
+    "eslint/no-duplicate-imports": [
+      "error",
+      { "allowSeparateTypeImports": true }
+    ],
+    "eslint/no-ternary": "off",
+    "eslint/no-undefined": "off",
+    "eslint/no-use-before-define": [
+      "error",
+      { "classes": true, "functions": false, "variables": true }
+    ],
+    "eslint/one-var": ["error", "never"],
+    "eslint/sort-keys": "off",
+    "import/consistent-type-specifier-style": [
+      "error",
+      "prefer-top-level-if-only-type-imports"
+    ],
+    "import/no-named-export": "off",
+    "import/no-nodejs-modules": "off",
+    "import/no-relative-parent-imports": "off",
+    "import/prefer-default-export": "off",
+    "node/no-process-env": "off",
+    "node/no-sync": "off",
+    "node/no-top-level-await": "off",
+    "oxc/no-async-await": "off",
+    "oxc/no-optional-chaining": "off",
+    "oxc/no-rest-spread-properties": "off",
+    "typescript/parameter-properties": [
+      "error",
+      { "prefer": "parameter-property" }
+    ],
+    "typescript/promise-function-async": "off",
+    "promise/avoid-new": "off",
+    "unicorn/consistent-function-scoping": [
+      "error",
+      { "checkArrowFunctions": false }
+    ],
+    "unicorn/import-style": [
+      "error",
+      {
+        "styles": { "node:path": { "default": false, "named": true } }
+      }
+    ],
+    "unicorn/max-nested-calls": ["error", { "max": 5 }],
+    "unicorn/no-array-reduce": "off",
+    "unicorn/no-null": "off",
+    "unicorn/no-process-exit": "off",
+    "unicorn/number-literal-case": "off"
+  },
+  "overrides": [
+    {
+      "files": ["tooling/scrapling-container.ts"],
+      "rules": {
+        "eslint/no-control-regex": "off"
+      }
+    },
+    {
+      "files": ["oxfmt.config.ts"],
+      "rules": {
+        "import/no-default-export": "off"
+      }
+    }
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,8 @@
       "devDependencies": {
         "@types/bun": "1.4.0",
         "oxfmt": "0.64.0",
+        "oxlint": "1.80.0",
+        "oxlint-tsgolint": "7.0.2001",
         "typescript": "7.0.2",
       },
     },
@@ -52,6 +54,56 @@
     "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.64.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-lNM6byTAQ881jugzFu8juJTbNRgsUTlswMA6pJmwi1XDvmIqnnb49lcUAs5gz94fCJLrVN+/X3s3jOKqx23WIQ=="],
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.64.0", "", { "os": "win32", "cpu": "x64" }, "sha512-BtmbtL/QjMtF1a6C3CqoDluH2IfB6fJt62E+B9RFfUPtFk4Iz9PFS6+y/SzzOvSxc7aUk2Kphwg7Dh8lMbwu6g=="],
+
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@7.0.2001", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w=="],
+
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@7.0.2001", "", { "os": "darwin", "cpu": "x64" }, "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw=="],
+
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@7.0.2001", "", { "os": "linux", "cpu": "arm64" }, "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A=="],
+
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@7.0.2001", "", { "os": "linux", "cpu": "x64" }, "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ=="],
+
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@7.0.2001", "", { "os": "win32", "cpu": "arm64" }, "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q=="],
+
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.80.0", "", { "os": "android", "cpu": "arm" }, "sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.80.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.80.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.80.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.80.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.80.0", "", { "os": "linux", "cpu": "arm" }, "sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.80.0", "", { "os": "linux", "cpu": "arm" }, "sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.80.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.80.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.80.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.80.0", "", { "os": "linux", "cpu": "none" }, "sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.80.0", "", { "os": "linux", "cpu": "none" }, "sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.80.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.80.0", "", { "os": "linux", "cpu": "x64" }, "sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.80.0", "", { "os": "linux", "cpu": "x64" }, "sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.80.0", "", { "os": "none", "cpu": "arm64" }, "sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.80.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.80.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.80.0", "", { "os": "win32", "cpu": "x64" }, "sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q=="],
 
     "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
@@ -100,6 +152,10 @@
     "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "oxfmt": ["oxfmt@0.64.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.64.0", "@oxfmt/binding-android-arm64": "0.64.0", "@oxfmt/binding-darwin-arm64": "0.64.0", "@oxfmt/binding-darwin-x64": "0.64.0", "@oxfmt/binding-freebsd-x64": "0.64.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.64.0", "@oxfmt/binding-linux-arm-musleabihf": "0.64.0", "@oxfmt/binding-linux-arm64-gnu": "0.64.0", "@oxfmt/binding-linux-arm64-musl": "0.64.0", "@oxfmt/binding-linux-ppc64-gnu": "0.64.0", "@oxfmt/binding-linux-riscv64-gnu": "0.64.0", "@oxfmt/binding-linux-riscv64-musl": "0.64.0", "@oxfmt/binding-linux-s390x-gnu": "0.64.0", "@oxfmt/binding-linux-x64-gnu": "0.64.0", "@oxfmt/binding-linux-x64-musl": "0.64.0", "@oxfmt/binding-openharmony-arm64": "0.64.0", "@oxfmt/binding-win32-arm64-msvc": "0.64.0", "@oxfmt/binding-win32-ia32-msvc": "0.64.0", "@oxfmt/binding-win32-x64-msvc": "0.64.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-XZ4GFBN/PLbXKq+0zrgpQfPKYuJlUuj+nzZJY7UpIbFMNyefNLCdN9EwViycNqnYcv0wrn0jXcQLlqJp8RCKBg=="],
+
+    "oxlint": ["oxlint@1.80.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.80.0", "@oxlint/binding-android-arm64": "1.80.0", "@oxlint/binding-darwin-arm64": "1.80.0", "@oxlint/binding-darwin-x64": "1.80.0", "@oxlint/binding-freebsd-x64": "1.80.0", "@oxlint/binding-linux-arm-gnueabihf": "1.80.0", "@oxlint/binding-linux-arm-musleabihf": "1.80.0", "@oxlint/binding-linux-arm64-gnu": "1.80.0", "@oxlint/binding-linux-arm64-musl": "1.80.0", "@oxlint/binding-linux-ppc64-gnu": "1.80.0", "@oxlint/binding-linux-riscv64-gnu": "1.80.0", "@oxlint/binding-linux-riscv64-musl": "1.80.0", "@oxlint/binding-linux-s390x-gnu": "1.80.0", "@oxlint/binding-linux-x64-gnu": "1.80.0", "@oxlint/binding-linux-x64-musl": "1.80.0", "@oxlint/binding-openharmony-arm64": "1.80.0", "@oxlint/binding-win32-arm64-msvc": "1.80.0", "@oxlint/binding-win32-ia32-msvc": "1.80.0", "@oxlint/binding-win32-x64-msvc": "1.80.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA=="],
+
+    "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "format:typescript": "bun tooling/format-typescript.ts",
     "format:typescript:check": "bun tooling/format-typescript.ts --check",
+    "lint": "bun tooling/lint-typescript.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
@@ -15,6 +16,8 @@
   "devDependencies": {
     "@types/bun": "1.4.0",
     "oxfmt": "0.64.0",
+    "oxlint": "1.80.0",
+    "oxlint-tsgolint": "7.0.2001",
     "typescript": "7.0.2"
   }
 }

--- a/tooling/agent-handoff-error.ts
+++ b/tooling/agent-handoff-error.ts
@@ -1,8 +1,9 @@
 export class HandoffError extends Error {
-  constructor(
-    message: string,
-    readonly exitCode: number,
-  ) {
+  public readonly exitCode: number;
+
+  public constructor(message: string, exitCode: number) {
     super(message);
+    this.exitCode = exitCode;
+    this.name = "HandoffError";
   }
 }

--- a/tooling/agent-handoff-failures.test.ts
+++ b/tooling/agent-handoff-failures.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  type HookResult,
+  claudeEvent,
+  claudeUsage,
+  codexUsage,
+  runEntryPoint,
+} from "./agent-handoff-test-support.ts";
+import { afterEach, beforeEach, expect, test } from "bun:test";
 import {
   chmodSync,
   mkdirSync,
@@ -6,24 +13,29 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  claudeEvent,
-  claudeUsage,
-  codexUsage,
-  type HookResult,
-  runEntryPoint,
-} from "./agent-handoff-test-support.ts";
+import { tmpdir } from "node:os";
 
-let testRoot: string;
+let testRoot = "";
+
+const highUsage = 90_000;
+const restrictedDirectoryMode = 0o500;
+const unexpectedFailureExitCode = 3;
+
+type FailureSetup = Readonly<{
+  environment?: Readonly<Record<string, string>>;
+  records?: readonly string[];
+}>;
 
 beforeEach(() => {
   testRoot = mkdtempSync(join(tmpdir(), "agent-handoff-failure-"));
 });
 
 afterEach(() => {
-  rmSync(testRoot, { force: true, recursive: true });
+  if (testRoot !== "") {
+    rmSync(testRoot, { force: true, recursive: true });
+    testRoot = "";
+  }
 });
 
 function writeTranscript(name: string, records: readonly string[]): string {
@@ -32,134 +44,142 @@ function writeTranscript(name: string, records: readonly string[]): string {
   return path;
 }
 
-async function runHook(
+function runHook(
   input: string,
   environment: Readonly<Record<string, string>> = {},
 ): Promise<HookResult> {
   return runEntryPoint(testRoot, input, environment);
 }
 
-describe("agent-handoff failures", () => {
-  test.each([
-    ["malformed event", "not-json", "invalid hook event"],
-    [
-      "missing session",
-      JSON.stringify({ hook_event_name: "Stop", transcript_path: "/tmp/x" }),
-      "missing session_id",
-    ],
-    [
-      "missing transcript",
-      JSON.stringify({ hook_event_name: "Stop", session_id: "x" }),
-      "missing transcript_path",
-    ],
-    [
-      "unsafe session",
-      JSON.stringify({
-        hook_event_name: "Stop",
-        session_id: "../escape",
-        transcript_path: "/tmp/x",
-      }),
-      "invalid session_id",
-    ],
-    [
-      "missing event name",
-      JSON.stringify({ session_id: "x", transcript_path: "/tmp/x" }),
-      "missing Stop event",
-    ],
-    [
-      "another Claude event",
-      JSON.stringify({
-        hook_event_name: "UserPromptSubmit",
-        session_id: "x",
-        transcript_path: "/tmp/x",
-      }),
-      "unsupported hook event",
-    ],
-    [
-      "another Codex event",
-      JSON.stringify({
-        event: "UserPromptSubmit",
-        session_id: "x",
-        transcript_path: "/tmp/x",
-      }),
-      "unsupported hook event",
-    ],
-    [
-      "conflicting event names",
-      JSON.stringify({
-        event: "Stop",
-        hook_event_name: "UserPromptSubmit",
-        session_id: "x",
-        transcript_path: "/tmp/x",
-      }),
-      "unsupported hook event",
-    ],
-  ])("fails visibly for %s", async (_name, input, diagnostic) => {
-    const result = await runHook(input);
+test.each([
+  ["malformed event", "not-json", "invalid hook event"],
+  [
+    "missing session",
+    JSON.stringify({ hook_event_name: "Stop", transcript_path: "/tmp/x" }),
+    "missing session_id",
+  ],
+  [
+    "missing transcript",
+    JSON.stringify({ hook_event_name: "Stop", session_id: "x" }),
+    "missing transcript_path",
+  ],
+  [
+    "unsafe session",
+    JSON.stringify({
+      hook_event_name: "Stop",
+      session_id: "../escape",
+      transcript_path: "/tmp/x",
+    }),
+    "invalid session_id",
+  ],
+  [
+    "missing event name",
+    JSON.stringify({ session_id: "x", transcript_path: "/tmp/x" }),
+    "missing Stop event",
+  ],
+  [
+    "another Claude event",
+    JSON.stringify({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "x",
+      transcript_path: "/tmp/x",
+    }),
+    "unsupported hook event",
+  ],
+  [
+    "another Codex event",
+    JSON.stringify({
+      event: "UserPromptSubmit",
+      session_id: "x",
+      transcript_path: "/tmp/x",
+    }),
+    "unsupported hook event",
+  ],
+  [
+    "conflicting event names",
+    JSON.stringify({
+      event: "Stop",
+      hook_event_name: "UserPromptSubmit",
+      session_id: "x",
+      transcript_path: "/tmp/x",
+    }),
+    "unsupported hook event",
+  ],
+])("fails visibly for %s", async (_name, input, diagnostic) => {
+  const result = await runHook(input);
 
-    expect(result.exitCode).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr).toContain(diagnostic);
-  });
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  expect(result.stderr).toContain(diagnostic);
+});
 
-  test.each([
-    [
-      "unreadable transcript",
-      "/missing/transcript",
-      {},
-      "cannot read transcript",
-    ],
-    [
-      "malformed transcript",
-      "malformed.jsonl",
-      { records: [claudeUsage(90_000), "not-json"] },
-      "malformed transcript JSON",
-    ],
-    [
-      "unsupported agent",
-      "unsupported.jsonl",
-      { records: [JSON.stringify({ type: "other" })] },
-      "no supported usage record",
-    ],
-    [
-      "invalid threshold",
-      "threshold.jsonl",
-      {
-        environment: { HANDOFF_TOKEN_THRESHOLD: "85k" },
-        records: [claudeUsage(90_000)],
-      },
-      "invalid HANDOFF_TOKEN_THRESHOLD",
-    ],
-    [
-      "missing Claude window",
-      "window.jsonl",
-      {
-        environment: { CLAUDE_CODE_AUTO_COMPACT_WINDOW: "" },
-        records: [claudeUsage(90_000)],
-      },
-      "missing context window",
-    ],
-    [
-      "invalid Claude sidechain marker",
-      "sidechain-marker.jsonl",
-      {
-        records: [
-          JSON.stringify({
-            type: "assistant",
-            isSidechain: "true",
-            message: { usage: { input_tokens: 90_000 } },
-          }),
-        ],
-      },
-      "invalid Claude isSidechain",
-    ],
-    [
-      "zero Codex context window",
-      "zero-window.jsonl",
-      { records: [codexUsage(90_000, 0)] },
-      "invalid Codex model_context_window",
-    ],
-  ])("fails visibly for %s", async (_name, filename, setup, diagnostic) => {
+test.each([
+  [
+    "unreadable transcript",
+    "/missing/transcript",
+    {},
+    "cannot read transcript",
+  ],
+  [
+    "malformed transcript",
+    "malformed.jsonl",
+    { records: [claudeUsage(highUsage), "not-json"] },
+    "malformed transcript JSON",
+  ],
+  [
+    "unsupported agent",
+    "unsupported.jsonl",
+    { records: [JSON.stringify({ type: "other" })] },
+    "no supported usage record",
+  ],
+  [
+    "invalid threshold",
+    "threshold.jsonl",
+    {
+      environment: { HANDOFF_TOKEN_THRESHOLD: "85k" },
+      records: [claudeUsage(highUsage)],
+    },
+    "invalid HANDOFF_TOKEN_THRESHOLD",
+  ],
+  [
+    "missing Claude window",
+    "window.jsonl",
+    {
+      environment: { CLAUDE_CODE_AUTO_COMPACT_WINDOW: "" },
+      records: [claudeUsage(highUsage)],
+    },
+    "missing context window",
+  ],
+  [
+    "invalid Claude sidechain marker",
+    "sidechain-marker.jsonl",
+    {
+      records: [
+        JSON.stringify({
+          isSidechain: "true",
+          message: { usage: { input_tokens: highUsage } },
+          type: "assistant",
+        }),
+      ],
+    },
+    "invalid Claude isSidechain",
+  ],
+  [
+    "zero Codex context window",
+    "zero-window.jsonl",
+    { records: [codexUsage(highUsage, 0)] },
+    "invalid Codex model_context_window",
+  ],
+])(
+  "fails visibly for %s",
+  async (
+    ...[_name, filename, setup, diagnostic]: readonly [
+      string,
+      string,
+      FailureSetup,
+      string,
+    ]
+  ) => {
     const records = "records" in setup ? setup.records : undefined;
     const transcript =
       records === undefined ? filename : writeTranscript(filename, records);
@@ -172,46 +192,48 @@ describe("agent-handoff failures", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain(diagnostic);
+  },
+);
+
+test("reports sentinel write failure without blocking", async () => {
+  const transcript = writeTranscript("write-failure.jsonl", [
+    claudeUsage(highUsage),
+  ]);
+  const stateDirectory = join(testRoot, "read-only-state");
+  mkdirSync(stateDirectory);
+  chmodSync(stateDirectory, restrictedDirectoryMode);
+  const result = await runHook(claudeEvent(transcript, "write-failure"), {
+    XDG_STATE_HOME: stateDirectory,
   });
 
-  test("reports sentinel write failure without blocking", async () => {
-    const transcript = writeTranscript("write-failure.jsonl", [
-      claudeUsage(90_000),
-    ]);
-    const stateDirectory = join(testRoot, "read-only-state");
-    mkdirSync(stateDirectory);
-    chmodSync(stateDirectory, 0o500);
-    const result = await runHook(claudeEvent(transcript, "write-failure"), {
-      XDG_STATE_HOME: stateDirectory,
-    });
+  expect(result.exitCode).toBe(unexpectedFailureExitCode);
+  expect(result.stdout).toBe("");
+  expect(result.stderr).toContain("cannot create handoff sentinel");
+});
 
-    expect(result.exitCode).toBe(3);
-    expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("cannot create handoff sentinel");
+test("retains exactly the latest 500 physical lines", async () => {
+  const boundary = writeTranscript("physical-window-boundary.jsonl", [
+    claudeUsage(highUsage),
+    ...Array.from({ length: 499 }, () => ""),
+  ]);
+  const boundaryResult = await runHook(
+    claudeEvent(boundary, "physical-window-boundary"),
+  );
+  expect(boundaryResult.stdout).not.toBe("");
+
+  const outside = writeTranscript("physical-window-outside.jsonl", [
+    claudeUsage(highUsage),
+    ...Array.from({ length: 500 }, () => ""),
+  ]);
+  const input = claudeEvent(outside, "physical-window-outside");
+
+  expect(await runHook(input)).toEqual({
+    exitCode: 1,
+    stderr: "agent-handoff: no supported usage record in transcript\n",
+    stdout: "",
   });
 
-  test("retains exactly the latest 500 physical lines", async () => {
-    const boundary = writeTranscript("physical-window-boundary.jsonl", [
-      claudeUsage(90_000),
-      ...Array.from({ length: 499 }, () => ""),
-    ]);
-    expect(
-      (await runHook(claudeEvent(boundary, "physical-window-boundary"))).stdout,
-    ).not.toBe("");
-
-    const outside = writeTranscript("physical-window-outside.jsonl", [
-      claudeUsage(90_000),
-      ...Array.from({ length: 500 }, () => ""),
-    ]);
-    const input = claudeEvent(outside, "physical-window-outside");
-
-    expect(await runHook(input)).toEqual({
-      exitCode: 1,
-      stderr: "agent-handoff: no supported usage record in transcript\n",
-      stdout: "",
-    });
-
-    writeFileSync(outside, `${claudeUsage(90_000)}\n`);
-    expect((await runHook(input)).stdout).not.toBe("");
-  });
+  writeFileSync(outside, `${claudeUsage(highUsage)}\n`);
+  const replay = await runHook(input);
+  expect(replay.stdout).not.toBe("");
 });

--- a/tooling/agent-handoff-test-support.ts
+++ b/tooling/agent-handoff-test-support.ts
@@ -1,47 +1,50 @@
 import { join } from "node:path";
 
 const entryPoint = join(import.meta.dir, "agent-handoff");
+const assistantMessageTokenCount = 2;
+const defaultContextWindow = 100_000;
 const inheritedEnvironment = Object.fromEntries(
   Object.entries(process.env).filter(
-    (entry): entry is [string, string] => entry[1] !== undefined,
+    (entry: readonly [string, string | undefined]): entry is [string, string] =>
+      entry[1] !== undefined,
   ),
 );
 
-export type HookResult = Readonly<{
+type HookResult = Readonly<{
   exitCode: number;
   stderr: string;
   stdout: string;
 }>;
 
-export function claudeUsage(used: number, sidechain = false): string {
+function claudeUsage(used: number, sidechain = false): string {
   return JSON.stringify({
-    type: "assistant",
     isSidechain: sidechain,
     message: {
       usage: {
-        input_tokens: 2,
-        cache_read_input_tokens: used - 2,
         cache_creation_input_tokens: 0,
+        cache_read_input_tokens: used - assistantMessageTokenCount,
+        input_tokens: assistantMessageTokenCount,
       },
     },
+    type: "assistant",
   });
 }
 
-export function codexUsage(used: number, window = 100_000): string {
+function codexUsage(used: number, window = defaultContextWindow): string {
   return JSON.stringify({
-    type: "event_msg",
     payload: {
-      type: "token_count",
       info: {
         last_token_usage: { input_tokens: used },
         model_context_window: window,
         total_token_usage: { input_tokens: 999_999 },
       },
+      type: "token_count",
     },
+    type: "event_msg",
   });
 }
 
-export function claudeEvent(
+function claudeEvent(
   transcriptPath: string,
   sessionId: string,
   stopHookActive = false,
@@ -54,7 +57,7 @@ export function claudeEvent(
   });
 }
 
-export function codexEvent(transcriptPath: string, sessionId: string): string {
+function codexEvent(transcriptPath: string, sessionId: string): string {
   return JSON.stringify({
     event: "Stop",
     session_id: sessionId,
@@ -62,7 +65,7 @@ export function codexEvent(transcriptPath: string, sessionId: string): string {
   });
 }
 
-export async function runEntryPoint(
+async function runEntryPoint(
   testRoot: string,
   input: string,
   environment: Readonly<Record<string, string>> = {},
@@ -91,3 +94,6 @@ export async function runEntryPoint(
 
   return { exitCode, stderr, stdout };
 }
+
+export { claudeEvent, claudeUsage, codexEvent, codexUsage, runEntryPoint };
+export type { HookResult };

--- a/tooling/agent-handoff-transcript.ts
+++ b/tooling/agent-handoff-transcript.ts
@@ -1,6 +1,6 @@
 import { HandoffError } from "./agent-handoff-error.ts";
 
-export type Usage = Readonly<{
+type Usage = Readonly<{
   agent: "Claude Code" | "Codex";
   used: number;
   window?: number;
@@ -15,25 +15,34 @@ function parseTokenCount(
   field: string,
   fallback?: number,
 ): number {
-  if (value === undefined && fallback !== undefined) return fallback;
+  if (value === undefined && fallback !== undefined) {
+    return fallback;
+  }
   if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
     throw new HandoffError(`invalid ${field}`, 1);
   }
   return value;
 }
 
-function parseClaudeUsage(record: Record<string, unknown>): Usage | undefined {
-  if (record.type !== "assistant") return undefined;
+function parseClaudeUsage(
+  record: Readonly<Record<string, unknown>>,
+): Usage | undefined {
+  if (record.type !== "assistant") {
+    return undefined;
+  }
   if (
     record.isSidechain !== undefined &&
     typeof record.isSidechain !== "boolean"
   ) {
     throw new HandoffError("invalid Claude isSidechain", 1);
   }
-  if (record.isSidechain === true) return undefined;
-  if (!isRecord(record.message) || !isRecord(record.message.usage))
+  if (record.isSidechain === true) {
     return undefined;
-  const usage = record.message.usage;
+  }
+  if (!isRecord(record.message) || !isRecord(record.message.usage)) {
+    return undefined;
+  }
+  const { usage } = record.message;
   const input = parseTokenCount(usage.input_tokens, "Claude input_tokens");
   const cacheRead = parseTokenCount(
     usage.cache_read_input_tokens,
@@ -46,24 +55,32 @@ function parseClaudeUsage(record: Record<string, unknown>): Usage | undefined {
     0,
   );
   const used = input + cacheRead + cacheCreation;
-  if (!Number.isSafeInteger(used))
+  if (!Number.isSafeInteger(used)) {
     throw new HandoffError("invalid Claude token total", 1);
+  }
   return { agent: "Claude Code", used };
 }
 
-function parseCodexUsage(record: Record<string, unknown>): Usage | undefined {
-  if (record.type !== "event_msg" || !isRecord(record.payload))
+function parseCodexUsage(
+  record: Readonly<Record<string, unknown>>,
+): Usage | undefined {
+  if (record.type !== "event_msg" || !isRecord(record.payload)) {
     return undefined;
-  if (record.payload.type !== "token_count" || !isRecord(record.payload.info))
+  }
+  if (record.payload.type !== "token_count" || !isRecord(record.payload.info)) {
     return undefined;
-  const info = record.payload.info;
-  if (!isRecord(info.last_token_usage)) return undefined;
+  }
+  const { info } = record.payload;
+  if (!isRecord(info.last_token_usage)) {
+    return undefined;
+  }
   const window = parseTokenCount(
     info.model_context_window,
     "Codex model_context_window",
   );
-  if (window === 0)
+  if (window === 0) {
     throw new HandoffError("invalid Codex model_context_window", 1);
+  }
   return {
     agent: "Codex",
     used: parseTokenCount(
@@ -74,27 +91,38 @@ function parseCodexUsage(record: Record<string, unknown>): Usage | undefined {
   };
 }
 
-export function findLatestUsage(transcript: string): Usage {
+const retainedTranscriptLineCount = 500;
+
+function parseTranscriptRecord(line: string, index: number): unknown {
+  try {
+    return JSON.parse(line);
+  } catch {
+    throw new HandoffError(
+      `malformed transcript JSON at retained line ${index + 1}`,
+      1,
+    );
+  }
+}
+
+function findLatestUsage(transcript: string): Usage {
   const splitLines = transcript.split("\n");
   const physicalLines =
     splitLines.at(-1) === "" ? splitLines.slice(0, -1) : splitLines;
-  const lines = physicalLines.slice(-500);
-  let latest: Usage | undefined;
+  const lines = physicalLines.slice(-retainedTranscriptLineCount);
+  let latest: Usage | undefined = undefined;
   for (const [index, line] of lines.entries()) {
-    if (line.trim() === "") continue;
-    let record: unknown;
-    try {
-      record = JSON.parse(line);
-    } catch {
-      throw new HandoffError(
-        `malformed transcript JSON at retained line ${index + 1}`,
-        1,
-      );
+    if (line.trim() !== "") {
+      const record = parseTranscriptRecord(line, index);
+      if (isRecord(record)) {
+        latest = parseClaudeUsage(record) ?? parseCodexUsage(record) ?? latest;
+      }
     }
-    if (!isRecord(record)) continue;
-    latest = parseClaudeUsage(record) ?? parseCodexUsage(record) ?? latest;
   }
-  if (latest === undefined)
+  if (latest === undefined) {
     throw new HandoffError("no supported usage record in transcript", 1);
+  }
   return latest;
 }
+
+export { findLatestUsage };
+export type { Usage };

--- a/tooling/agent-handoff.test.ts
+++ b/tooling/agent-handoff.test.ts
@@ -1,24 +1,35 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import {
-  claudeUsage,
+  type HookResult,
   claudeEvent,
+  claudeUsage,
   codexEvent,
   codexUsage,
-  type HookResult,
   runEntryPoint,
 } from "./agent-handoff-test-support.ts";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { z } from "zod";
 
-let testRoot: string;
+const handoffOutputSchema = z.object({ reason: z.string() });
+const belowDefaultThresholdUsage = 84_999;
+const defaultThresholdUsage = 85_000;
+const configuredThresholdUsage = 50_000;
+const highUsage = 90_000;
+const lowUsage = 40_000;
+
+let testRoot = "";
 
 beforeEach(() => {
   testRoot = mkdtempSync(join(tmpdir(), "agent-handoff-"));
 });
 
 afterEach(() => {
-  rmSync(testRoot, { force: true, recursive: true });
+  if (testRoot !== "") {
+    rmSync(testRoot, { force: true, recursive: true });
+    testRoot = "";
+  }
 });
 
 function writeTranscript(name: string, records: readonly string[]): string {
@@ -27,120 +38,124 @@ function writeTranscript(name: string, records: readonly string[]): string {
   return path;
 }
 
-async function runHook(
+function runHook(
   input: string,
   environment: Readonly<Record<string, string>> = {},
 ): Promise<HookResult> {
   return runEntryPoint(testRoot, input, environment);
 }
 
-describe("agent-handoff entry point", () => {
-  test("keeps Claude below the boundary and blocks at the boundary", async () => {
-    const below = writeTranscript("claude-below.jsonl", [claudeUsage(84_999)]);
-    const boundary = writeTranscript("claude-boundary.jsonl", [
-      claudeUsage(85_000),
-    ]);
+test("keeps Claude below the boundary and blocks at the boundary", async () => {
+  const below = writeTranscript("claude-below.jsonl", [
+    claudeUsage(belowDefaultThresholdUsage),
+  ]);
+  const boundary = writeTranscript("claude-boundary.jsonl", [
+    claudeUsage(defaultThresholdUsage),
+  ]);
 
-    expect(await runHook(claudeEvent(below, "claude-below"))).toEqual({
-      exitCode: 0,
-      stderr: "",
-      stdout: "",
-    });
-
-    const result = await runHook(claudeEvent(boundary, "claude-boundary"));
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(JSON.parse(result.stdout)).toEqual({
-      decision: "block",
-      reason:
-        "Context is at 85k tokens, past the 85k handoff threshold. Start no new work. Use /handoff to emit the resume prompt for a fresh session, then stop.",
-    });
+  expect(await runHook(claudeEvent(below, "claude-below"))).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout: "",
   });
 
-  test("uses the Codex window and invocation", async () => {
-    const transcript = writeTranscript("codex.jsonl", [codexUsage(90_000)]);
-    const result = await runHook(codexEvent(transcript, "codex"));
-
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(JSON.parse(result.stdout).reason).toContain("Use $handoff");
+  const result = await runHook(claudeEvent(boundary, "claude-boundary"));
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe("");
+  expect(JSON.parse(result.stdout)).toEqual({
+    decision: "block",
+    reason:
+      "Context is at 85k tokens, past the 85k handoff threshold. Start no new work. Use /handoff to emit the resume prompt for a fresh session, then stop.",
   });
+});
 
-  test("uses the configured threshold at its exact boundary", async () => {
-    const transcript = writeTranscript("configured-threshold.jsonl", [
-      claudeUsage(50_000),
-    ]);
-    const result = await runHook(
-      claudeEvent(transcript, "configured-threshold"),
-      {
-        HANDOFF_TOKEN_THRESHOLD: "50000",
-      },
-    );
+test("uses the Codex window and invocation", async () => {
+  const transcript = writeTranscript("codex.jsonl", [codexUsage(highUsage)]);
+  const result = await runHook(codexEvent(transcript, "codex"));
 
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(JSON.parse(result.stdout).reason).toContain(
-      "past the 50k handoff threshold",
-    );
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe("");
+  expect(handoffOutputSchema.parse(JSON.parse(result.stdout)).reason).toContain(
+    "Use $handoff",
+  );
+});
+
+test("uses the configured threshold at its exact boundary", async () => {
+  const transcript = writeTranscript("configured-threshold.jsonl", [
+    claudeUsage(configuredThresholdUsage),
+  ]);
+  const result = await runHook(
+    claudeEvent(transcript, "configured-threshold"),
+    {
+      HANDOFF_TOKEN_THRESHOLD: "50000",
+    },
+  );
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe("");
+  expect(handoffOutputSchema.parse(JSON.parse(result.stdout)).reason).toContain(
+    "past the 50k handoff threshold",
+  );
+});
+
+test("ignores sidechains and uses the latest main-chain usage", async () => {
+  const transcript = writeTranscript("sidechain.jsonl", [
+    claudeUsage(lowUsage),
+    claudeUsage(highUsage, true),
+  ]);
+
+  expect(await runHook(claudeEvent(transcript, "sidechain"))).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout: "",
   });
+});
 
-  test("ignores sidechains and uses the latest main-chain usage", async () => {
-    const transcript = writeTranscript("sidechain.jsonl", [
-      claudeUsage(40_000),
-      claudeUsage(90_000, true),
-    ]);
+test("retains only the latest 500 transcript lines", async () => {
+  const unrelated = Array.from({ length: 499 }, () =>
+    JSON.stringify({ type: "other" }),
+  );
+  const transcript = writeTranscript("retention.jsonl", [
+    claudeUsage(highUsage),
+    ...unrelated,
+    claudeUsage(lowUsage),
+  ]);
 
-    expect(await runHook(claudeEvent(transcript, "sidechain"))).toEqual({
-      exitCode: 0,
-      stderr: "",
-      stdout: "",
-    });
+  expect(await runHook(claudeEvent(transcript, "retention"))).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout: "",
   });
+});
 
-  test("retains only the latest 500 transcript lines", async () => {
-    const unrelated = Array.from({ length: 499 }, () =>
-      JSON.stringify({ type: "other" }),
-    );
-    const transcript = writeTranscript("retention.jsonl", [
-      claudeUsage(90_000),
-      ...unrelated,
-      claudeUsage(40_000),
-    ]);
-
-    expect(await runHook(claudeEvent(transcript, "retention"))).toEqual({
-      exitCode: 0,
-      stderr: "",
-      stdout: "",
-    });
+test("does not recurse when the stop hook is already active", async () => {
+  expect(
+    await runHook(claudeEvent("/missing/transcript", "active", true)),
+  ).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout: "",
   });
+});
 
-  test("does not recurse when the stop hook is already active", async () => {
-    expect(
-      await runHook(claudeEvent("/missing/transcript", "active", true)),
-    ).toEqual({
-      exitCode: 0,
-      stderr: "",
-      stdout: "",
-    });
-  });
+test("creates at most one handoff for repeated and concurrent events", async () => {
+  const transcript = writeTranscript("repeated.jsonl", [
+    claudeUsage(highUsage),
+  ]);
+  const input = claudeEvent(transcript, "same-session");
+  const results = await Promise.all([
+    runHook(input),
+    runHook(input),
+    runHook(input),
+  ]);
 
-  test("creates at most one handoff for repeated and concurrent events", async () => {
-    const transcript = writeTranscript("repeated.jsonl", [claudeUsage(90_000)]);
-    const input = claudeEvent(transcript, "same-session");
-    const results = await Promise.all([
-      runHook(input),
-      runHook(input),
-      runHook(input),
-    ]);
-
-    expect(results.filter((result) => result.stdout !== "")).toHaveLength(1);
-    expect(
-      results.every((result) => result.exitCode === 0 && result.stderr === ""),
-    ).toBe(true);
-    expect(await runHook(input)).toEqual({
-      exitCode: 0,
-      stderr: "",
-      stdout: "",
-    });
+  expect(results.filter((result) => result.stdout !== "")).toHaveLength(1);
+  expect(
+    results.every((result) => result.exitCode === 0 && result.stderr === ""),
+  ).toBe(true);
+  expect(await runHook(input)).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout: "",
   });
 });

--- a/tooling/agent-handoff.test.ts
+++ b/tooling/agent-handoff.test.ts
@@ -98,6 +98,19 @@ test("uses the configured threshold at its exact boundary", async () => {
   );
 });
 
+test("uses the HOME fallback when XDG_STATE_HOME is empty", async () => {
+  const transcript = writeTranscript("empty-xdg-state.jsonl", [
+    claudeUsage(highUsage),
+  ]);
+  const result = await runHook(claudeEvent(transcript, "empty-xdg-state"), {
+    XDG_STATE_HOME: "",
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe("");
+  expect(result.stdout).not.toBe("");
+});
+
 test("ignores sidechains and uses the latest main-chain usage", async () => {
   const transcript = writeTranscript("sidechain.jsonl", [
     claudeUsage(lowUsage),

--- a/tooling/agent-handoff.ts
+++ b/tooling/agent-handoff.ts
@@ -161,6 +161,19 @@ function handoffOutput(usage: Usage, threshold: number): string {
   );
 }
 
+function stateRootFromEnvironment(
+  environment: Readonly<NodeJS.ProcessEnv>,
+): string | undefined {
+  const xdgStateHome = environment.XDG_STATE_HOME;
+  if (xdgStateHome !== undefined && xdgStateHome !== "") {
+    return xdgStateHome;
+  }
+  if (environment.HOME === undefined) {
+    return undefined;
+  }
+  return join(environment.HOME, ".local", "state");
+}
+
 export async function runAgentHandoff(
   input: string,
   environment: Readonly<NodeJS.ProcessEnv>,
@@ -170,11 +183,7 @@ export async function runAgentHandoff(
     if (event.stopHookActive) {
       return 0;
     }
-    const stateRoot =
-      environment.XDG_STATE_HOME ??
-      (environment.HOME === undefined
-        ? undefined
-        : join(environment.HOME, ".local", "state"));
+    const stateRoot = stateRootFromEnvironment(environment);
     if (stateRoot === undefined || stateRoot === "") {
       throw new HandoffError("missing HOME and XDG_STATE_HOME", 1);
     }

--- a/tooling/agent-handoff.ts
+++ b/tooling/agent-handoff.ts
@@ -1,7 +1,7 @@
-import { mkdir, open, readFile, stat } from "node:fs/promises";
+import { type Usage, findLatestUsage } from "./agent-handoff-transcript.ts";
 import { dirname, join } from "node:path";
+import { mkdir, open, readFile, stat } from "node:fs/promises";
 import { HandoffError } from "./agent-handoff-error.ts";
-import { findLatestUsage, type Usage } from "./agent-handoff-transcript.ts";
 
 type HookEvent = Readonly<{
   sessionId: string;
@@ -9,19 +9,27 @@ type HookEvent = Readonly<{
   transcriptPath: string;
 }>;
 
+const unexpectedFailureExitCode = 3;
+const tokensPerThousand = 1000;
+const jsonIndentSpaces = 2;
+
+function parseHookEventValue(input: string): unknown {
+  try {
+    return JSON.parse(input);
+  } catch {
+    throw new HandoffError("invalid hook event: expected JSON", 1);
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseHookEvent(input: string): HookEvent {
-  let value: unknown;
-  try {
-    value = JSON.parse(input);
-  } catch {
-    throw new HandoffError("invalid hook event: expected JSON", 1);
-  }
-  if (!isRecord(value))
+  const value = parseHookEventValue(input);
+  if (!isRecord(value)) {
     throw new HandoffError("invalid hook event: expected an object", 1);
+  }
   const claudeEvent = value.hook_event_name;
   const codexEvent = value.event;
   if (claudeEvent === undefined && codexEvent === undefined) {
@@ -36,7 +44,7 @@ function parseHookEvent(input: string): HookEvent {
   if (typeof value.session_id !== "string" || value.session_id.length === 0) {
     throw new HandoffError("missing session_id", 1);
   }
-  if (!/^(?!\.{1,2}$)[A-Za-z0-9._-]+$/.test(value.session_id)) {
+  if (!/^(?!\.{1,2}$)[A-Za-z0-9._-]+$/u.test(value.session_id)) {
     throw new HandoffError("invalid session_id", 1);
   }
   if (
@@ -59,22 +67,27 @@ function parseHookEvent(input: string): HookEvent {
 }
 
 function parsePositiveInteger(value: string, name: string): number {
-  if (!/^[1-9][0-9]*$/.test(value))
+  if (!/^[1-9][0-9]*$/u.test(value)) {
     throw new HandoffError(`invalid ${name}`, 1);
+  }
   const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed))
+  if (!Number.isSafeInteger(parsed)) {
     throw new HandoffError(`invalid ${name}`, 1);
+  }
   return parsed;
 }
 
-function selectThreshold(usage: Usage, environment: NodeJS.ProcessEnv): number {
+function selectThreshold(
+  usage: Usage,
+  environment: Readonly<NodeJS.ProcessEnv>,
+): number {
   const configured = environment.HANDOFF_TOKEN_THRESHOLD;
   if (configured !== undefined && configured !== "") {
     return parsePositiveInteger(configured, "HANDOFF_TOKEN_THRESHOLD");
   }
   const window =
     usage.window ??
-    (() => {
+    ((): number => {
       const value = environment.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
       if (value === undefined || value === "") {
         throw new HandoffError("missing context window", 1);
@@ -91,12 +104,21 @@ function isFileSystemError(error: unknown, code: string): boolean {
 async function sentinelExists(path: string): Promise<boolean> {
   try {
     const metadata = await stat(path);
-    if (!metadata.isFile())
-      throw new HandoffError("invalid handoff sentinel", 3);
+    if (!metadata.isFile()) {
+      throw new HandoffError(
+        "invalid handoff sentinel",
+        unexpectedFailureExitCode,
+      );
+    }
     return true;
   } catch (error) {
-    if (isFileSystemError(error, "ENOENT")) return false;
-    throw new HandoffError("cannot inspect handoff sentinel", 3);
+    if (isFileSystemError(error, "ENOENT")) {
+      return false;
+    }
+    throw new HandoffError(
+      "cannot inspect handoff sentinel",
+      unexpectedFailureExitCode,
+    );
   }
 }
 
@@ -107,8 +129,13 @@ async function createSentinel(path: string): Promise<boolean> {
     await file.close();
     return true;
   } catch (error) {
-    if (isFileSystemError(error, "EEXIST")) return false;
-    throw new HandoffError("cannot create handoff sentinel", 3);
+    if (isFileSystemError(error, "EEXIST")) {
+      return false;
+    }
+    throw new HandoffError(
+      "cannot create handoff sentinel",
+      unexpectedFailureExitCode,
+    );
   }
 }
 
@@ -126,23 +153,25 @@ function handoffOutput(usage: Usage, threshold: number): string {
     {
       decision: "block",
       reason:
-        `Context is at ${Math.floor(usage.used / 1000)}k tokens, past the ${Math.floor(threshold / 1000)}k handoff threshold. ` +
+        `Context is at ${Math.floor(usage.used / tokensPerThousand)}k tokens, past the ${Math.floor(threshold / tokensPerThousand)}k handoff threshold. ` +
         `Start no new work. Use ${invocation} to emit the resume prompt for a fresh session, then stop.`,
     },
     null,
-    2,
+    jsonIndentSpaces,
   );
 }
 
 export async function runAgentHandoff(
   input: string,
-  environment: NodeJS.ProcessEnv,
+  environment: Readonly<NodeJS.ProcessEnv>,
 ): Promise<number> {
   try {
     const event = parseHookEvent(input);
-    if (event.stopHookActive) return 0;
+    if (event.stopHookActive) {
+      return 0;
+    }
     const stateRoot =
-      environment.XDG_STATE_HOME ||
+      environment.XDG_STATE_HOME ??
       (environment.HOME === undefined
         ? undefined
         : join(environment.HOME, ".local", "state"));
@@ -150,17 +179,21 @@ export async function runAgentHandoff(
       throw new HandoffError("missing HOME and XDG_STATE_HOME", 1);
     }
     const sentinel = join(stateRoot, "dotfiles", "handoff", event.sessionId);
-    if (await sentinelExists(sentinel)) return 0;
+    if (await sentinelExists(sentinel)) {
+      return 0;
+    }
     const usage = findLatestUsage(await readTranscript(event.transcriptPath));
     const threshold = selectThreshold(usage, environment);
-    if (usage.used < threshold || !(await createSentinel(sentinel))) return 0;
+    if (usage.used < threshold || !(await createSentinel(sentinel))) {
+      return 0;
+    }
     process.stdout.write(`${handoffOutput(usage, threshold)}\n`);
     return 0;
   } catch (error) {
     const failure =
       error instanceof HandoffError
         ? error
-        : new HandoffError("unexpected failure", 3);
+        : new HandoffError("unexpected failure", unexpectedFailureExitCode);
     process.stderr.write(`agent-handoff: ${failure.message}\n`);
     return failure.exitCode;
   }

--- a/tooling/apple-notes-attachments.test.ts
+++ b/tooling/apple-notes-attachments.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { cleanupNotesFixtures, runNotes } from "./apple-notes-test-support.ts";
 import {
   existsSync,
   lstatSync,
-  mkdtempSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -11,10 +12,9 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { publishDirectoryExclusively } from "../.agents/skills/apple-notes/scripts/notes-publish.ts";
-import { cleanupNotesFixtures, runNotes } from "./apple-notes-test-support.ts";
+import { tmpdir } from "node:os";
 
 afterEach(cleanupNotesFixtures);
 
@@ -49,9 +49,9 @@ describe("Apple Notes attachment export", () => {
       ["attachments", "Notes", "Photo", "exports"],
       [
         {
+          exportFile: "partial.jpg",
           status: 1,
           stderr: "unsupported attachment\n",
-          exportFile: "partial.jpg",
         },
       ],
     );
@@ -59,23 +59,26 @@ describe("Apple Notes attachment export", () => {
     expect(existsSync(join(result.root, "exports"))).toBe(false);
     expect(result.stderr).toContain("unsupported attachment");
   });
+});
 
+describe("Apple Notes attachment destination safety", () => {
   test("refuses an existing or symlinked destination before AppleScript", async () => {
     for (const kind of ["directory", "symlink"] as const) {
       let originalInode = 0;
       const result = await runNotes(
         ["attachments", "Notes", "Photo", "exports"],
         [],
-        "",
-        (root) => {
-          if (kind === "directory") {
-            mkdirSync(join(root, "exports"));
-            writeFileSync(join(root, "exports", "keep.txt"), "keep");
-          } else {
-            mkdirSync(join(root, "foreign"));
-            symlinkSync(join(root, "foreign"), join(root, "exports"));
-          }
-          originalInode = lstatSync(join(root, "exports")).ino;
+        {
+          prepare: (root) => {
+            if (kind === "directory") {
+              mkdirSync(join(root, "exports"));
+              writeFileSync(join(root, "exports", "keep.txt"), "keep");
+            } else {
+              mkdirSync(join(root, "foreign"));
+              symlinkSync(join(root, "foreign"), join(root, "exports"));
+            }
+            originalInode = lstatSync(join(root, "exports")).ino;
+          },
         },
       );
       expect([result.exitCode, result.calls.length]).toEqual([1, 0]);
@@ -96,7 +99,7 @@ describe("Apple Notes attachment export", () => {
   test("does not replace a destination that appears during export", async () => {
     const result = await runNotes(
       ["attachments", "Notes", "Photo", "exports"],
-      [{ exportFile: "partial.jpg", appearDirectory: "exports" }],
+      [{ appearDirectory: "exports", exportFile: "partial.jpg" }],
     );
     expect(result.exitCode).toBe(1);
     expect(
@@ -106,7 +109,9 @@ describe("Apple Notes attachment export", () => {
       readdirSync(result.root).some((name) => name.includes("notes-export")),
     ).toBeFalse();
   });
+});
 
+describe("Apple Notes attachment publication", () => {
   test("exclusive publication cannot replace an empty destination", () => {
     const root = mkdtempSync(join(tmpdir(), "notes-publish-test-"));
     try {
@@ -116,13 +121,15 @@ describe("Apple Notes attachment export", () => {
       mkdirSync(destination);
       writeFileSync(join(source, "attachment.jpg"), "attachment");
       const destinationInode = lstatSync(destination).ino;
-      expect(() => publishDirectoryExclusively(source, destination)).toThrow();
+      expect(() => {
+        publishDirectoryExclusively(source, destination);
+      }).toThrow();
       expect(lstatSync(destination).ino).toBe(destinationInode);
       expect(readFileSync(join(source, "attachment.jpg"), "utf8")).toBe(
         "attachment",
       );
     } finally {
-      rmSync(root, { recursive: true, force: true });
+      rmSync(root, { force: true, recursive: true });
     }
   });
 

--- a/tooling/apple-notes-test-support.ts
+++ b/tooling/apple-notes-test-support.ts
@@ -1,31 +1,48 @@
 import { chmod, mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
 
-export type Response = Readonly<{
+type Response = Readonly<{
   status?: number;
   stdout?: string;
-  stdoutBytes?: number[];
+  stdoutBytes?: readonly number[];
   stderr?: string;
   exportFile?: string;
   appearDirectory?: string;
 }>;
+type RunNotesResult = Readonly<{
+  calls: readonly string[];
+  exitCode: number;
+  root: string;
+  stderr: string;
+  stdout: string;
+  stdoutBytes: readonly number[];
+}>;
+type RunNotesOptions = Readonly<{
+  prepare?: (root: string) => void;
+  stdin?: string;
+}>;
+const executableMode = 0o755;
+const entrypoint = join(
+  import.meta.dir,
+  "..",
+  ".agents",
+  "skills",
+  "apple-notes",
+  "scripts",
+  "notes.sh",
+);
 const roots: string[] = [];
 
-export async function cleanupNotesFixtures(): Promise<void> {
+async function cleanupNotesFixtures(): Promise<void> {
   await Promise.all(
-    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    roots.splice(0).map(async (root) => {
+      await rm(root, { force: true, recursive: true });
+    }),
   );
 }
 
-export async function runNotes(
-  arguments_: readonly string[],
-  responses: readonly Response[],
-  stdin = "",
-  prepare?: (root: string) => void,
-) {
-  const root = await mkdtemp(join(tmpdir(), "apple-notes-test-"));
-  roots.push(root);
+async function prepareOsaScript(root: string): Promise<string> {
   const bin = join(root, "bin");
   await Bun.$`mkdir -p ${bin}`.quiet();
   const fake = join(root, "osascript.ts");
@@ -60,39 +77,54 @@ process.exit(response.status ?? 0);
     osascript,
     `#!/bin/sh\nexec "${process.execPath}" "${fake}"\n`,
   );
-  await chmod(osascript, 0o755);
-  const entrypoint = join(
-    import.meta.dir,
-    "..",
-    ".agents",
-    "skills",
-    "apple-notes",
-    "scripts",
-    "notes.sh",
-  );
-  prepare?.(root);
+  await chmod(osascript, executableMode);
+  return bin;
+}
+
+async function readCalls(root: string): Promise<readonly string[]> {
+  const logPath = join(root, "log");
+  const log = (await Bun.file(logPath).exists())
+    ? await readFile(logPath, "utf8")
+    : "";
+  return log.split("\0").filter(Boolean);
+}
+
+async function runNotes(
+  arguments_: readonly string[],
+  responses: readonly Response[],
+  options: RunNotesOptions = {},
+): Promise<RunNotesResult> {
+  const root = await mkdtemp(join(tmpdir(), "apple-notes-test-"));
+  roots.push(root);
+  const bin = await prepareOsaScript(root);
+  options.prepare?.(root);
   const result = Bun.spawnSync([entrypoint, ...arguments_], {
     cwd: root,
-    stdin: Buffer.from(stdin),
-    stdout: "pipe",
-    stderr: "pipe",
     env: {
       ...process.env,
-      PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
+      NOTES_LOG: join(root, "log"),
       NOTES_RESPONSES: JSON.stringify(responses),
       NOTES_STATE: join(root, "state"),
-      NOTES_LOG: join(root, "log"),
+      PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
     },
+    stderr: "pipe",
+    stdin: Buffer.from(options.stdin ?? ""),
+    stdout: "pipe",
   });
-  const log = (await Bun.file(join(root, "log")).exists())
-    ? await readFile(join(root, "log"), "utf8")
-    : "";
   return {
+    calls: await readCalls(root),
     exitCode: result.exitCode,
+    root,
+    stderr: result.stderr.toString(),
     stdout: result.stdout.toString(),
     stdoutBytes: [...result.stdout],
-    stderr: result.stderr.toString(),
-    calls: log.split("\0").filter(Boolean),
-    root,
   };
 }
+
+export {
+  cleanupNotesFixtures,
+  runNotes,
+  type Response,
+  type RunNotesOptions,
+  type RunNotesResult,
+};

--- a/tooling/apple-notes.test.ts
+++ b/tooling/apple-notes.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { cleanupNotesFixtures, runNotes } from "./apple-notes-test-support.ts";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+
+const commandFailureExitCode = 42;
+const invalidUtf8Byte = 0xff;
+const moveCallCount = 2;
+const rewrittenMoveCallCount = 3;
 
 afterEach(cleanupNotesFixtures);
 
@@ -17,14 +22,14 @@ describe("Apple Notes shipped entrypoint", () => {
       "",
     ]);
     expect(result.calls[0]).toContain('account "iCloud"');
-    expect(result.calls[0]).toContain('A \\"folder\\"');
+    expect(result.calls[0]).toContain(String.raw`A \"folder\"`);
   });
 
   test("creates a note with its title first and refuses an empty body before mutation", async () => {
     const created = await runNotes(
       ["note", "Inbox", "Title", "Work"],
       [{ stdout: "Title\n" }],
-      "<div>Body</div>\n",
+      { stdin: "<div>Body</div>\n" },
     );
     expect(created.exitCode).toBe(0);
     expect(created.calls[0]).toContain('account "Work"');
@@ -33,7 +38,9 @@ describe("Apple Notes shipped entrypoint", () => {
     expect([empty.exitCode, empty.calls.length]).toEqual([1, 0]);
     expect(empty.stderr).toContain("empty note body");
   });
+});
 
+describe("Apple Notes move validation", () => {
   test.each([
     ["true\t1\t0", "shared folder"],
     ["false\t0\t0", "exactly one"],
@@ -57,7 +64,7 @@ describe("Apple Notes shipped entrypoint", () => {
       [{ stdout: "false\t1\t2" }, { stdout: "New\n" }],
     );
     expect(result.exitCode).toBe(0);
-    expect(result.calls).toHaveLength(2);
+    expect(result.calls).toHaveLength(moveCallCount);
     expect(result.calls[1]).toContain("set name");
     expect(result.calls[1]).toContain("move n");
     expect(result.calls[1]).toContain("return name of n");
@@ -65,19 +72,33 @@ describe("Apple Notes shipped entrypoint", () => {
     expect(result.stderr).toContain("2 attachment(s) preserved");
   });
 
+  test("treats an empty optional move title as absent", async () => {
+    const result = await runNotes(
+      ["move", "Notes", "Old", "3 Resources/Test", ""],
+      [{ stdout: "false\t1\t0" }, { stdout: "" }],
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.calls).toHaveLength(moveCallCount);
+    expect(result.calls.join("\n")).not.toContain("get body");
+    expect(result.calls[1]).not.toContain("set name");
+    expect(result.calls[1]).not.toContain("set body");
+  });
+});
+
+describe("Apple Notes move transaction", () => {
   test("makes a post-move failure explicit when Notes cannot provide a transaction", async () => {
     const result = await runNotes(
       ["move", "Notes", "Old", "3 Resources/Test", "New"],
       [
         { stdout: "false\t1\t2" },
         {
-          status: 42,
+          status: commandFailureExitCode,
           stderr:
             "note moved but its post-move update failed; inspect the destination\n",
         },
       ],
     );
-    expect(result.exitCode).toBe(42);
+    expect(result.exitCode).toBe(commandFailureExitCode);
     expect(result.calls[1]).toContain("set moveCompleted to true");
     expect(result.calls[1]).toContain("if moveCompleted then error");
     expect(result.stderr).toContain("inspect the destination");
@@ -93,7 +114,7 @@ describe("Apple Notes shipped entrypoint", () => {
       ],
     );
     expect(result.exitCode).toBe(0);
-    expect(result.calls).toHaveLength(3);
+    expect(result.calls).toHaveLength(rewrittenMoveCallCount);
     const mutation = result.calls[2] ?? "";
     expect(mutation).toContain("move n");
     expect(mutation).toContain("set body");
@@ -103,13 +124,15 @@ describe("Apple Notes shipped entrypoint", () => {
       mutation.indexOf("make new folder"),
     );
   });
+});
 
+describe("Apple Notes move failures", () => {
   test("refuses an empty body read before moving the note", async () => {
     const result = await runNotes(
       ["move", "Notes", "Old", "3 Resources/Test", "New"],
       [{ stdout: "false\t1\t0" }, { stdout: "" }],
     );
-    expect([result.exitCode, result.calls.length]).toEqual([1, 2]);
+    expect([result.exitCode, result.calls.length]).toEqual([1, moveCallCount]);
     expect(result.stderr).toContain("note is unchanged");
     expect(result.calls.join("\n")).not.toContain("move note");
   });
@@ -117,36 +140,47 @@ describe("Apple Notes shipped entrypoint", () => {
   test("refuses invalid UTF-8 body evidence before mutation", async () => {
     const result = await runNotes(
       ["move", "Notes", "Old", "3 Resources/Test", "New"],
-      [{ stdout: "false\t1\t0" }, { stdoutBytes: [0xff] }],
+      [{ stdout: "false\t1\t0" }, { stdoutBytes: [invalidUtf8Byte] }],
     );
-    expect([result.exitCode, result.calls.length]).toEqual([1, 2]);
+    expect([result.exitCode, result.calls.length]).toEqual([1, moveCallCount]);
     expect(result.stderr).toContain("invalid UTF-8");
     expect(result.calls.join("\n")).not.toContain("move n");
   });
+});
 
+describe("Apple Notes process boundary", () => {
   test("propagates AppleScript errors without another mutation", async () => {
     const result = await runNotes(
       ["folder", "Test"],
       [
         {
-          status: 42,
-          stdout: "partial output\n",
+          status: commandFailureExitCode,
           stderr: "automation denied\n",
+          stdout: "partial output\n",
         },
       ],
     );
-    expect([result.exitCode, result.calls.length]).toEqual([42, 1]);
+    expect([result.exitCode, result.calls.length]).toEqual([
+      commandFailureExitCode,
+      1,
+    ]);
     expect([result.stdout, result.stderr]).toEqual([
       "partial output\n",
       "automation denied\n",
     ]);
     const binary = await runNotes(
       ["folder", "Test"],
-      [{ status: 42, stdoutBytes: [0xff], stderr: "automation denied\n" }],
+      [
+        {
+          status: commandFailureExitCode,
+          stderr: "automation denied\n",
+          stdoutBytes: [invalidUtf8Byte],
+        },
+      ],
     );
     expect([binary.exitCode, binary.stdoutBytes, binary.stderr]).toEqual([
-      42,
-      [0xff],
+      commandFailureExitCode,
+      [invalidUtf8Byte],
       "automation denied\n",
     ]);
   });

--- a/tooling/ci-smoke-git-error.ts
+++ b/tooling/ci-smoke-git-error.ts
@@ -1,0 +1,9 @@
+export class GitError extends Error {
+  public readonly details: string;
+
+  public constructor(details: string) {
+    super("Git command failed");
+    this.details = details;
+    this.name = "GitError";
+  }
+}

--- a/tooling/ci-smoke-selector-error.ts
+++ b/tooling/ci-smoke-selector-error.ts
@@ -1,0 +1,9 @@
+export class SelectorError extends Error {
+  public readonly details: string;
+
+  public constructor(message: string, details = "") {
+    super(message);
+    this.details = details;
+    this.name = "SelectorError";
+  }
+}

--- a/tooling/ci-smoke-targets-makefile.ts
+++ b/tooling/ci-smoke-targets-makefile.ts
@@ -1,8 +1,9 @@
-const targetPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const assignmentPattern =
-  /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_.-]*\s*[?:+!]?=/;
+  /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_.-]*\s*[?:+!]?=/u;
 const directivePattern =
-  /^\s*(?:-?include|sinclude|ifeq|ifneq|ifdef|ifndef|else|endif|define|endef|override|undefine|vpath)(?:[\s(]|$)/;
+  /^\s*(?:-?include|sinclude|ifeq|ifneq|ifdef|ifndef|else|endif|define|endef|override|undefine|vpath)(?:[\s(]|$)/u;
+const targetPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+const escapedBackslashPairLength = 2;
 
 type Range = Readonly<{ count: number; start: number }>;
 type Rule = Readonly<{ target: string | null }>;
@@ -14,14 +15,15 @@ function targetAtLine(
   return makefile
     .slice(0, line)
     .findLast((content) => content.startsWith(".PHONY: "))
-    ?.split(/\s+/)[1];
+    ?.split(/\s+/u)[1];
 }
 
 function parseRule(content: string): Rule | undefined {
-  if (/^\s|^#|^\.PHONY:/.test(content) || !content.includes(":")) {
+  if (/^\s|^#|^\.PHONY:/u.test(content) || !content.includes(":")) {
     return undefined;
   }
-  const target = /^([A-Za-z0-9][A-Za-z0-9._-]*):(?!:)/.exec(content)?.[1];
+  const target = /^(?<target>[A-Za-z0-9][A-Za-z0-9._-]*):(?!:)/u.exec(content)
+    ?.groups?.target;
   return { target: target ?? null };
 }
 
@@ -35,13 +37,13 @@ function ruleAtLine(
   );
   return throughLine
     .slice(declaration + 1)
-    .map(parseRule)
+    .map((content) => parseRule(content))
     .findLast((rule) => rule !== undefined);
 }
 
 function endsWithUnescapedBackslash(content: string): boolean {
-  const backslashes = /\\+$/.exec(content.trimEnd())?.[0].length ?? 0;
-  return backslashes % 2 === 1;
+  const backslashes = /\\+$/u.exec(content.trimEnd())?.[0].length ?? 0;
+  return backslashes % escapedBackslashPairLength === 1;
 }
 
 function logicalLineStart(makefile: readonly string[], line: number): number {
@@ -57,7 +59,7 @@ function isGlobalContinuation(
   line: number,
 ): boolean {
   const start = logicalLineStart(makefile, line);
-  return start < line - 1 && !makefile[start]?.startsWith("\t");
+  return start < line - 1 && makefile[start]?.startsWith("\t") !== true;
 }
 
 function isInsideDefine(makefile: readonly string[], line: number): boolean {
@@ -68,11 +70,11 @@ function isInsideDefine(makefile: readonly string[], line: number): boolean {
       if (!startsLogicalLine) {
         return depth;
       }
-      if (/^[ ]*endef[ ]*$/.test(content)) {
+      if (/^[ ]*endef[ ]*$/u.test(content)) {
         return Math.max(0, depth - 1);
       }
       if (
-        /^[ ]*(?:(?:export|override|private)\s+)*define(?:\s|$)/.test(content)
+        /^[ ]*(?:(?:export|override|private)\s+)*define(?:\s|$)/u.test(content)
       ) {
         return depth + 1;
       }
@@ -101,11 +103,9 @@ function classifyLine(makefile: readonly string[], line: number): string {
   if (endsWithUnescapedBackslash(content)) {
     return "all";
   }
-  if (/^\s*$/.test(content) || content.startsWith(".PHONY: ")) {
-    return target ?? "all";
-  }
-  if (/^\s*#/.test(content)) {
-    return target ?? "all";
+  const nonRuleTarget = targetForNonRuleLine(content, target);
+  if (nonRuleTarget !== undefined) {
+    return nonRuleTarget;
   }
   const declaredRule = parseRule(content);
   if (declaredRule?.target === target) {
@@ -114,8 +114,22 @@ function classifyLine(makefile: readonly string[], line: number): string {
   return "all";
 }
 
+function targetForNonRuleLine(
+  content: string,
+  target: string | undefined,
+): string | undefined {
+  if (
+    /^\s*$/u.test(content) ||
+    content.startsWith(".PHONY: ") ||
+    /^\s*#/u.test(content)
+  ) {
+    return target ?? "all";
+  }
+  return undefined;
+}
+
 function parseRange(start: string, count: string | undefined): Range {
-  if (!/^\d+$/.test(start) || (count !== undefined && !/^\d+$/.test(count))) {
+  if (!/^\d+$/u.test(start) || (count !== undefined && !/^\d+$/u.test(count))) {
     throw new Error(`invalid diff range: ${start},${count ?? "1"}`);
   }
   return { count: Number(count ?? "1"), start: Number(start) };
@@ -126,13 +140,22 @@ function parseRanges(
 ): readonly Readonly<{ newRange: Range; oldRange: Range }>[] {
   const hunkLines = diff.split("\n").filter((line) => line.startsWith("@@"));
   const ranges = hunkLines.map((line) => {
-    const match = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(line);
-    if (!match?.[1] || !match[3]) {
+    const match =
+      /^@@ -(?<oldStart>\d+)(?:,(?<oldCount>\d+))? \+(?<newStart>\d+)(?:,(?<newCount>\d+))? @@/u.exec(
+        line,
+      );
+    const groups = match?.groups;
+    if (
+      groups?.oldStart === undefined ||
+      groups.oldStart === "" ||
+      groups.newStart === undefined ||
+      groups.newStart === ""
+    ) {
       throw new Error(`invalid diff hunk: ${line}`);
     }
     return {
-      oldRange: parseRange(match[1], match[2]),
-      newRange: parseRange(match[3], match[4]),
+      newRange: parseRange(groups.newStart, groups.newCount),
+      oldRange: parseRange(groups.oldStart, groups.oldCount),
     };
   });
   if (ranges.length === 0) {
@@ -145,7 +168,7 @@ function targetsInRange(
   makefile: readonly string[],
   range: Range,
 ): readonly string[] {
-  return Array.from({ length: range.count }, (_, index) =>
+  return Array.from({ length: range.count }, (_unused, index) =>
     classifyLine(makefile, range.start + index),
   );
 }
@@ -160,14 +183,17 @@ export function targetsFromMakefileDiff(
   const phonyDeclarations = newMakefile.filter((line) =>
     line.startsWith(".PHONY:"),
   );
-  if (!phonyDeclarations.every((line) => /^\.PHONY: \S+$/.test(line))) {
+  if (!phonyDeclarations.every((line) => /^\.PHONY: \S+$/u.test(line))) {
     return ["all"];
   }
 
-  const candidates = parseRanges(diff).flatMap(({ oldRange, newRange }) => [
-    ...targetsInRange(oldMakefile, oldRange),
-    ...targetsInRange(newMakefile, newRange),
-  ]);
+  const candidates: string[] = [];
+  for (const { oldRange, newRange } of parseRanges(diff)) {
+    candidates.push(
+      ...targetsInRange(oldMakefile, oldRange),
+      ...targetsInRange(newMakefile, newRange),
+    );
+  }
   const valid = candidates.every(
     (target) =>
       targetPattern.test(target) && newMakefile.includes(`.PHONY: ${target}`),

--- a/tooling/ci-smoke-targets-test-support.ts
+++ b/tooling/ci-smoke-targets-test-support.ts
@@ -1,7 +1,7 @@
-import { expect } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { expect } from "bun:test";
+import { tmpdir } from "node:os";
 
 const testRoot = mkdtempSync(join(tmpdir(), "ci-smoke-targets-"));
 const selector = join(import.meta.dir, "ci-smoke-targets");
@@ -29,30 +29,29 @@ function run(command: readonly string[], cwd: string): Result {
   };
 }
 
-export function git(repository: string, ...arguments_: string[]): string {
-  const result = run(["git", ...arguments_], repository);
+function git(
+  repository: string,
+  ...commandArguments: readonly string[]
+): string {
+  const result = run(["git", ...commandArguments], repository);
   expect(result.stderr).toBe("");
   expect(result.exitCode).toBe(0);
   return result.stdout.trim();
 }
 
-export function write(
-  repository: string,
-  path: string,
-  contents: string,
-): void {
+function write(repository: string, path: string, contents: string): void {
   const destination = join(repository, path);
   mkdirSync(dirname(destination), { recursive: true });
   writeFileSync(destination, contents);
 }
 
-export function commit(repository: string, message: string): string {
+function commit(repository: string, message: string): string {
   git(repository, "add", "-A");
   git(repository, "commit", "-q", "-m", message);
   return git(repository, "rev-parse", "HEAD");
 }
 
-export function newRepository(name: string): string {
+function newRepository(name: string): string {
   const repository = join(testRoot, name);
   mkdirSync(repository);
   git(repository, "init", "-q");
@@ -79,14 +78,14 @@ export function newRepository(name: string): string {
   return repository;
 }
 
-export function select(repository: string, ...arguments_: string[]): Result {
-  return run([selector, ...arguments_], repository);
+function select(
+  repository: string,
+  ...commandArguments: readonly string[]
+): Result {
+  return run([selector, ...commandArguments], repository);
 }
 
-export function expectTargets(
-  repository: string,
-  expected: readonly string[],
-): void {
+function expectTargets(repository: string, expected: readonly string[]): void {
   const result = select(repository, "HEAD^", "HEAD");
   expect(result).toEqual({
     exitCode: 0,
@@ -95,10 +94,7 @@ export function expectTargets(
   });
 }
 
-export function makefileWithAmbiguousRule(
-  rule: string,
-  recipe: string,
-): string {
+function makefileWithAmbiguousRule(rule: string, recipe: string): string {
   return [
     "SHARED=value",
     ".PHONY: all",
@@ -115,6 +111,17 @@ export function makefileWithAmbiguousRule(
   ].join("\n");
 }
 
-export function cleanup(): void {
+function cleanup(): void {
   rmSync(testRoot, { force: true, recursive: true });
 }
+
+export {
+  cleanup,
+  commit,
+  expectTargets,
+  git,
+  makefileWithAmbiguousRule,
+  newRepository,
+  select,
+  write,
+};

--- a/tooling/ci-smoke-targets.test.ts
+++ b/tooling/ci-smoke-targets.test.ts
@@ -1,6 +1,4 @@
-import { afterAll, describe, expect, test } from "bun:test";
-import { rmSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, expect, test } from "bun:test";
 import {
   cleanup,
   commit,
@@ -11,247 +9,250 @@ import {
   select,
   write,
 } from "./ci-smoke-targets-test-support.ts";
+import { join } from "node:path";
+import { rmSync } from "node:fs";
 
 afterAll(cleanup);
 
-describe("ci-smoke-targets entry point", () => {
-  test("refuses invalid invocation without publishing a matrix", () => {
-    const repository = newRepository("invalid-invocation");
+test("refuses invalid invocation without publishing a matrix", () => {
+  const repository = newRepository("invalid-invocation");
 
-    for (const arguments_ of [[], ["missing", "missing"], ["HEAD", "HEAD"]]) {
-      const result = select(repository, ...arguments_);
-      expect(result.exitCode).not.toBe(0);
-      expect(result.stdout).toBe("");
-      expect(result.stderr).toContain("ci-smoke-targets:");
-    }
-  });
-
-  test("returns an empty matrix for unrelated changes", () => {
-    const repository = newRepository("unrelated");
-    write(repository, "README.md", "text\n");
-    commit(repository, "docs");
-
-    expectTargets(repository, []);
-  });
-
-  test("returns unique targets in lexical order", () => {
-    const repository = newRepository("targets");
-    write(
-      repository,
-      "Makefile",
-      [
-        "SHARED=value",
-        ".PHONY: all",
-        "all: alpha beta",
-        ".PHONY: alpha",
-        "alpha:",
-        "\t@echo changed-alpha",
-        "\t@echo alpha-again",
-        ".PHONY: beta",
-        "beta:",
-        "\t@echo changed-beta",
-        "",
-      ].join("\n"),
-    );
-    commit(repository, "targets");
-
-    expectTargets(repository, ["alpha", "beta"]);
-  });
-
-  test("returns one changed target", () => {
-    const repository = newRepository("one-target");
-    write(
-      repository,
-      "Makefile",
-      "SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo changed-alpha\n.PHONY: beta\nbeta:\n\t@echo beta\n",
-    );
-    commit(repository, "alpha");
-
-    expectTargets(repository, ["alpha"]);
-  });
-
-  test.each([
-    ["installer", "install.sh", "#!/usr/bin/env bash\nmake all twice\n"],
-    ["workflow", ".github/workflows/test.yml", "name: changed\n"],
-    ["selector", "tooling/ci-smoke-targets", "changed\n"],
-    ["selector-source", "tooling/ci-smoke-targets.ts", "changed\n"],
-    ["selector-parser", "tooling/ci-smoke-targets-makefile.ts", "changed\n"],
-  ])("selects all when %s infrastructure changes", (name, path, contents) => {
-    const repository = newRepository(`infrastructure-${name}`);
-    write(repository, path, contents);
-    commit(repository, name);
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test.each([
-    [
-      "assignment",
-      "SHARED=changed\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\n.PHONY: beta\nbeta:\n\t@echo beta\n",
-    ],
-    [
-      "directive",
-      "SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ninclude shared.mk\n.PHONY: beta\nbeta:\n\t@echo beta\n",
-    ],
-    [
-      "missing-phony",
-      "SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ngamma:\n\t@echo gamma\n.PHONY: beta\nbeta:\n\t@echo beta\n",
-    ],
-    [
-      "invalid-phony",
-      "SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha beta\nalpha:\n\t@echo alpha\n.PHONY: beta\nbeta:\n\t@echo beta\n",
-    ],
-  ])("selects all for ambiguous %s changes", (name, makefile) => {
-    const repository = newRepository(`ambiguous-${name}`);
-    write(repository, "Makefile", makefile);
-    commit(repository, name);
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test.each([
-    ["multi-target", "alpha beta:"],
-    ["pattern", "%.out: %.in"],
-    ["special", ".DEFAULT:"],
-  ])("selects all when an ambiguous %s rule recipe changes", (name, rule) => {
-    const repository = newRepository(`ambiguous-${name}-recipe`);
-    write(repository, "Makefile", makefileWithAmbiguousRule(rule, "original"));
-    commit(repository, "add ambiguous rule");
-    write(repository, "Makefile", makefileWithAmbiguousRule(rule, "changed"));
-    commit(repository, "change ambiguous recipe");
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test.each(["export SHARED", "unexport SHARED"])(
-    "selects all when the global directive %s is added",
-    (directive) => {
-      const repository = newRepository(`global-${directive.split(" ")[0]}`);
-      write(
-        repository,
-        "Makefile",
-        `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\n.PHONY: beta\nbeta:\n\t@echo beta\n${directive}\n`,
-      );
-      commit(repository, "add global directive");
-
-      expectTargets(repository, ["all"]);
-    },
-  );
-
-  test("selects all when a global assignment continuation changes", () => {
-    const repository = newRepository("global-continuation");
-    const makefile = (value: string) =>
-      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\nGLOBAL = one \\\n  ${value}\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
-    write(repository, "Makefile", makefile("original"));
-    commit(repository, "add global continuation");
-    write(repository, "Makefile", makefile("changed"));
-    commit(repository, "change global continuation");
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test("selects all when a tab-indented global continuation changes", () => {
-    const repository = newRepository("tabbed-global-continuation");
-    const makefile = (value: string) =>
-      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\nGLOBAL = one \\\n\t${value}\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
-    write(repository, "Makefile", makefile("original"));
-    commit(repository, "add tabbed global continuation");
-    write(repository, "Makefile", makefile("changed"));
-    commit(repository, "change tabbed global continuation");
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test("selects all when a comment starts a logical-line continuation", () => {
-    const repository = newRepository("comment-continuation");
-    const makefile = (suffix: string) =>
-      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\n# shared${suffix}\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
-    write(repository, "Makefile", makefile(""));
-    commit(repository, "add comment");
-    write(repository, "Makefile", makefile(" \\"));
-    commit(repository, "continue comment");
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test("selects all when an inline comment continues a logical line", () => {
-    const repository = newRepository("inline-comment-continuation");
-    const makefile = (suffix: string) =>
-      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\nalpha: # shared${suffix}\ninclude shared.mk\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
-    write(repository, "Makefile", makefile(""));
-    commit(repository, "add inline comment");
-    write(repository, "Makefile", makefile(" \\"));
-    commit(repository, "continue inline comment");
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test("selects all when a tab-indented define body changes", () => {
-    const repository = newRepository("define-body");
-    const makefile = (value: string) =>
-      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ndefine SHARED_RECIPE\n\t${value}\nendef\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
-    write(repository, "Makefile", makefile("original"));
-    commit(repository, "add define body");
-    write(repository, "Makefile", makefile("changed"));
-    commit(repository, "change define body");
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test("selects all when a continued define body changes", () => {
-    const repository = newRepository("continued-define-body");
-    const makefile = (value: string) =>
-      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ndefine GLOBAL\none \\\nendef\n\t${value}\nendef\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
-    write(repository, "Makefile", makefile("original"));
-    commit(repository, "add continued define body");
-    write(repository, "Makefile", makefile("changed"));
-    commit(repository, "change continued define body");
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test("selects all when a target is deleted", () => {
-    const repository = newRepository("deleted-target");
-    write(
-      repository,
-      "Makefile",
-      "SHARED=value\n.PHONY: all\nall: alpha\n.PHONY: alpha\nalpha:\n\t@echo alpha\n",
-    );
-    commit(repository, "delete beta");
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test("selects all when the installer is renamed", () => {
-    const repository = newRepository("renamed-installer");
-    git(repository, "mv", "install.sh", "setup.sh");
-    commit(repository, "rename installer");
-
-    expectTargets(repository, ["all"]);
-  });
-
-  test("selects all when Makefile evidence is unavailable", () => {
-    const repository = newRepository("missing-makefile");
-    rmSync(join(repository, "Makefile"));
-    commit(repository, "delete Makefile");
-
-    const result = select(repository, "HEAD^", "HEAD");
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toBe('["all"]\n');
-    expect(result.stderr).toContain("does not exist in");
-  });
-
-  test("fails closed when Git has no merge base", () => {
-    const repository = newRepository("no-merge-base");
-    const base = git(repository, "rev-parse", "HEAD");
-    git(repository, "checkout", "-q", "--orphan", "unrelated");
-    rmSync(join(repository, "Makefile"));
-    rmSync(join(repository, "install.sh"));
-    write(repository, "README.md", "unrelated history\n");
-    const head = commit(repository, "unrelated history");
-
-    const result = select(repository, base, head);
+  for (const commandArguments of [
+    [],
+    ["missing", "missing"],
+    ["HEAD", "HEAD"],
+  ]) {
+    const result = select(repository, ...commandArguments);
     expect(result.exitCode).not.toBe(0);
     expect(result.stdout).toBe("");
-  });
+    expect(result.stderr).toContain("ci-smoke-targets:");
+  }
+});
+
+test("returns an empty matrix for unrelated changes", () => {
+  const repository = newRepository("unrelated");
+  write(repository, "README.md", "text\n");
+  commit(repository, "docs");
+
+  expectTargets(repository, []);
+});
+
+test("returns unique targets in lexical order", () => {
+  const repository = newRepository("targets");
+  write(
+    repository,
+    "Makefile",
+    [
+      "SHARED=value",
+      ".PHONY: all",
+      "all: alpha beta",
+      ".PHONY: alpha",
+      "alpha:",
+      "\t@echo changed-alpha",
+      "\t@echo alpha-again",
+      ".PHONY: beta",
+      "beta:",
+      "\t@echo changed-beta",
+      "",
+    ].join("\n"),
+  );
+  commit(repository, "targets");
+
+  expectTargets(repository, ["alpha", "beta"]);
+});
+
+test("returns one changed target", () => {
+  const repository = newRepository("one-target");
+  write(
+    repository,
+    "Makefile",
+    "SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo changed-alpha\n.PHONY: beta\nbeta:\n\t@echo beta\n",
+  );
+  commit(repository, "alpha");
+
+  expectTargets(repository, ["alpha"]);
+});
+
+test.each([
+  ["installer", "install.sh", "#!/usr/bin/env bash\nmake all twice\n"],
+  ["workflow", ".github/workflows/test.yml", "name: changed\n"],
+  ["selector", "tooling/ci-smoke-targets", "changed\n"],
+  ["selector-source", "tooling/ci-smoke-targets.ts", "changed\n"],
+  ["selector-parser", "tooling/ci-smoke-targets-makefile.ts", "changed\n"],
+])("selects all when %s infrastructure changes", (name, path, contents) => {
+  const repository = newRepository(`infrastructure-${name}`);
+  write(repository, path, contents);
+  commit(repository, name);
+
+  expectTargets(repository, ["all"]);
+});
+
+test.each([
+  [
+    "assignment",
+    "SHARED=changed\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\n.PHONY: beta\nbeta:\n\t@echo beta\n",
+  ],
+  [
+    "directive",
+    "SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ninclude shared.mk\n.PHONY: beta\nbeta:\n\t@echo beta\n",
+  ],
+  [
+    "missing-phony",
+    "SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ngamma:\n\t@echo gamma\n.PHONY: beta\nbeta:\n\t@echo beta\n",
+  ],
+  [
+    "invalid-phony",
+    "SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha beta\nalpha:\n\t@echo alpha\n.PHONY: beta\nbeta:\n\t@echo beta\n",
+  ],
+])("selects all for ambiguous %s changes", (name, makefile) => {
+  const repository = newRepository(`ambiguous-${name}`);
+  write(repository, "Makefile", makefile);
+  commit(repository, name);
+
+  expectTargets(repository, ["all"]);
+});
+
+test.each([
+  ["multi-target", "alpha beta:"],
+  ["pattern", "%.out: %.in"],
+  ["special", ".DEFAULT:"],
+])("selects all when an ambiguous %s rule recipe changes", (name, rule) => {
+  const repository = newRepository(`ambiguous-${name}-recipe`);
+  write(repository, "Makefile", makefileWithAmbiguousRule(rule, "original"));
+  commit(repository, "add ambiguous rule");
+  write(repository, "Makefile", makefileWithAmbiguousRule(rule, "changed"));
+  commit(repository, "change ambiguous recipe");
+
+  expectTargets(repository, ["all"]);
+});
+
+test.each(["export SHARED", "unexport SHARED"])(
+  "selects all when the global directive %s is added",
+  (directive) => {
+    const repository = newRepository(`global-${directive.split(" ")[0]}`);
+    write(
+      repository,
+      "Makefile",
+      `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\n.PHONY: beta\nbeta:\n\t@echo beta\n${directive}\n`,
+    );
+    commit(repository, "add global directive");
+
+    expectTargets(repository, ["all"]);
+  },
+);
+
+test("selects all when a global assignment continuation changes", () => {
+  const repository = newRepository("global-continuation");
+  const makefile = (value: string): string =>
+    `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\nGLOBAL = one \\\n  ${value}\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+  write(repository, "Makefile", makefile("original"));
+  commit(repository, "add global continuation");
+  write(repository, "Makefile", makefile("changed"));
+  commit(repository, "change global continuation");
+
+  expectTargets(repository, ["all"]);
+});
+
+test("selects all when a tab-indented global continuation changes", () => {
+  const repository = newRepository("tabbed-global-continuation");
+  const makefile = (value: string): string =>
+    `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\nGLOBAL = one \\\n\t${value}\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+  write(repository, "Makefile", makefile("original"));
+  commit(repository, "add tabbed global continuation");
+  write(repository, "Makefile", makefile("changed"));
+  commit(repository, "change tabbed global continuation");
+
+  expectTargets(repository, ["all"]);
+});
+
+test("selects all when a comment starts a logical-line continuation", () => {
+  const repository = newRepository("comment-continuation");
+  const makefile = (suffix: string): string =>
+    `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\n# shared${suffix}\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+  write(repository, "Makefile", makefile(""));
+  commit(repository, "add comment");
+  write(repository, "Makefile", makefile(" \\"));
+  commit(repository, "continue comment");
+
+  expectTargets(repository, ["all"]);
+});
+
+test("selects all when an inline comment continues a logical line", () => {
+  const repository = newRepository("inline-comment-continuation");
+  const makefile = (suffix: string): string =>
+    `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\nalpha: # shared${suffix}\ninclude shared.mk\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+  write(repository, "Makefile", makefile(""));
+  commit(repository, "add inline comment");
+  write(repository, "Makefile", makefile(" \\"));
+  commit(repository, "continue inline comment");
+
+  expectTargets(repository, ["all"]);
+});
+
+test("selects all when a tab-indented define body changes", () => {
+  const repository = newRepository("define-body");
+  const makefile = (value: string): string =>
+    `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ndefine SHARED_RECIPE\n\t${value}\nendef\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+  write(repository, "Makefile", makefile("original"));
+  commit(repository, "add define body");
+  write(repository, "Makefile", makefile("changed"));
+  commit(repository, "change define body");
+
+  expectTargets(repository, ["all"]);
+});
+
+test("selects all when a continued define body changes", () => {
+  const repository = newRepository("continued-define-body");
+  const makefile = (value: string): string =>
+    `SHARED=value\n.PHONY: all\nall: alpha beta\n.PHONY: alpha\nalpha:\n\t@echo alpha\ndefine GLOBAL\none \\\nendef\n\t${value}\nendef\n.PHONY: beta\nbeta:\n\t@echo beta\n`;
+  write(repository, "Makefile", makefile("original"));
+  commit(repository, "add continued define body");
+  write(repository, "Makefile", makefile("changed"));
+  commit(repository, "change continued define body");
+
+  expectTargets(repository, ["all"]);
+});
+
+test("selects all when a target is deleted", () => {
+  const repository = newRepository("deleted-target");
+  write(
+    repository,
+    "Makefile",
+    "SHARED=value\n.PHONY: all\nall: alpha\n.PHONY: alpha\nalpha:\n\t@echo alpha\n",
+  );
+  commit(repository, "delete beta");
+
+  expectTargets(repository, ["all"]);
+});
+
+test("selects all when the installer is renamed", () => {
+  const repository = newRepository("renamed-installer");
+  git(repository, "mv", "install.sh", "setup.sh");
+  commit(repository, "rename installer");
+
+  expectTargets(repository, ["all"]);
+});
+
+test("selects all when Makefile evidence is unavailable", () => {
+  const repository = newRepository("missing-makefile");
+  rmSync(join(repository, "Makefile"));
+  commit(repository, "delete Makefile");
+
+  const result = select(repository, "HEAD^", "HEAD");
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toBe('["all"]\n');
+  expect(result.stderr).toContain("does not exist in");
+});
+
+test("fails closed when Git has no merge base", () => {
+  const repository = newRepository("no-merge-base");
+  const base = git(repository, "rev-parse", "HEAD");
+  git(repository, "checkout", "-q", "--orphan", "unrelated");
+  rmSync(join(repository, "Makefile"));
+  rmSync(join(repository, "install.sh"));
+  write(repository, "README.md", "unrelated history\n");
+  const head = commit(repository, "unrelated history");
+  const result = select(repository, base, head);
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stdout).toBe("");
 });

--- a/tooling/ci-smoke-targets.ts
+++ b/tooling/ci-smoke-targets.ts
@@ -1,3 +1,5 @@
+import { GitError } from "./ci-smoke-git-error.ts";
+import { SelectorError } from "./ci-smoke-selector-error.ts";
 import { targetsFromMakefileDiff } from "./ci-smoke-targets-makefile.ts";
 
 const decoder = new TextDecoder("utf-8", { fatal: true });
@@ -14,21 +16,6 @@ type GitResult = Readonly<{
   stderr: string;
   stdout: Uint8Array;
 }>;
-
-class SelectorError extends Error {
-  constructor(
-    message: string,
-    readonly details = "",
-  ) {
-    super(message);
-  }
-}
-
-class GitError extends Error {
-  constructor(readonly details: string) {
-    super("Git command failed");
-  }
-}
 
 function runGit(arguments_: readonly string[]): GitResult {
   const result = Bun.spawnSync({
@@ -62,9 +49,9 @@ function verifyCommit(reference: string, role: "base" | "head"): void {
   }
 }
 
-function decodeGitEvidence(bytes: Uint8Array): string {
+function decodeGitEvidence(bytes: Readonly<ArrayLike<number>>): string {
   try {
-    return decoder.decode(bytes);
+    return decoder.decode(Uint8Array.from(bytes));
   } catch {
     throw new SelectorError("Git returned non-UTF-8 evidence");
   }
@@ -121,10 +108,7 @@ function changedPaths(base: string, head: string): readonly string[] {
   return decodeGitEvidence(output).split("\0").filter(Boolean);
 }
 
-export function selectSmokeTargets(
-  base: string,
-  head: string,
-): readonly string[] {
+function selectSmokeTargets(base: string, head: string): readonly string[] {
   verifyCommit(base, "base");
   verifyCommit(head, "head");
 
@@ -138,7 +122,7 @@ export function selectSmokeTargets(
   if (candidates.includes("all")) {
     return ["all"];
   }
-  return [...new Set(candidates)].sort();
+  return [...new Set(candidates)].toSorted();
 }
 
 function report(error: unknown): void {
@@ -154,17 +138,22 @@ function report(error: unknown): void {
   process.stderr.write(`ci-smoke-targets: ${String(error)}\n`);
 }
 
-export function main(arguments_: readonly string[]): number {
+function main(commandArguments: readonly string[]): number {
   try {
-    if (arguments_.length !== 2) {
+    const expectedArgumentCount = 2;
+    if (commandArguments.length !== expectedArgumentCount) {
       throw new SelectorError("usage: ci-smoke-targets BASE HEAD");
     }
-    process.stdout.write(
-      `${JSON.stringify(selectSmokeTargets(arguments_[0]!, arguments_[1]!))}\n`,
-    );
+    const [base, head] = commandArguments;
+    if (base === undefined || head === undefined) {
+      throw new SelectorError("usage: ci-smoke-targets BASE HEAD");
+    }
+    process.stdout.write(`${JSON.stringify(selectSmokeTargets(base, head))}\n`);
     return 0;
   } catch (error) {
     report(error);
     return 1;
   }
 }
+
+export { main, selectSmokeTargets };

--- a/tooling/codegraph-config-files.ts
+++ b/tooling/codegraph-config-files.ts
@@ -1,48 +1,42 @@
 import {
+  ConfigurationError,
+  type JsonObject,
+  parseJsonObject,
+} from "./codegraph-config.ts";
+import {
+  type Stats,
   chmodSync,
   closeSync,
   lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
-  renameSync,
   realpathSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { randomUUID } from "node:crypto";
 import { basename, dirname, join } from "node:path";
-import {
-  ConfigurationError,
-  parseJsonObject,
-  type JsonObject,
-} from "./codegraph-config.ts";
+import { randomUUID } from "node:crypto";
 
-export type ConfigurationSnapshot = {
-  path: string;
-  content?: Buffer;
-  mode?: number;
-};
+interface ConfigurationSnapshot {
+  readonly path: string;
+  readonly content?: readonly number[];
+  readonly mode?: number;
+}
 
-export function withConfigurationLocks(
-  paths: string[],
+const configurationFileMode = 0o600;
+const jsonIndentSpaces = 2;
+
+function withConfigurationLocks(
+  paths: readonly string[],
   action: () => void,
 ): void {
   const lockPaths: string[] = [];
   try {
     for (const path of canonicalPaths(paths)) {
       const lockPath = `${path}.codegraph-configure.lock`;
-      let descriptor: number;
-      try {
-        descriptor = openSync(lockPath, "wx", 0o600);
-      } catch (error) {
-        if (isExistingFile(error)) {
-          throw new ConfigurationError(
-            `configuration update already in progress: ${lockPath}`,
-          );
-        }
-        throw error;
-      }
+      const descriptor = openConfigurationLock(lockPath);
       lockPaths.push(lockPath);
       closeSync(descriptor);
     }
@@ -54,21 +48,29 @@ export function withConfigurationLocks(
   }
 }
 
-export function inspectConfiguration(
+function openConfigurationLock(lockPath: string): number {
+  try {
+    return openSync(lockPath, "wx", configurationFileMode);
+  } catch (error) {
+    if (isExistingFile(error)) {
+      throw new ConfigurationError(
+        `configuration update already in progress: ${lockPath}`,
+      );
+    }
+    throw error;
+  }
+}
+
+function inspectConfiguration(
   path: string,
   fileLabel: string,
   jsonLabel?: string,
 ): { snapshot: ConfigurationSnapshot; parsed?: JsonObject } {
-  let status: ReturnType<typeof lstatSync>;
-  try {
-    status = lstatSync(path);
-  } catch (error) {
-    if (isMissingFile(error)) {
-      return jsonLabel === undefined
-        ? { snapshot: { path } }
-        : { snapshot: { path }, parsed: {} };
-    }
-    throw error;
+  const status = configurationStatus(path);
+  if (status === undefined) {
+    return jsonLabel === undefined
+      ? { snapshot: { path } }
+      : { parsed: {}, snapshot: { path } };
   }
   if (status.isSymbolicLink()) {
     throw new ConfigurationError(`${fileLabel} must not be a symlink: ${path}`);
@@ -81,26 +83,40 @@ export function inspectConfiguration(
       `${fileLabel} must not have multiple hard links: ${path}`,
     );
   }
-  const content = readFileSync(path);
-  const snapshot = { path, content, mode: status.mode };
+  const content = [...readFileSync(path)];
+  const snapshot = { content, mode: status.mode, path };
   return jsonLabel === undefined
     ? { snapshot }
     : {
+        parsed: parseJsonObject(
+          Buffer.from(content).toString("utf8"),
+          jsonLabel,
+        ),
         snapshot,
-        parsed: parseJsonObject(content.toString("utf8"), jsonLabel),
       };
 }
 
-export function writeJsonAtomically(path: string, value: JsonObject): void {
+function configurationStatus(path: string): Stats | undefined {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (isMissingFile(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function writeJsonAtomically(path: string, value: JsonObject): void {
   writeAtomically(
     path,
-    Buffer.from(`${JSON.stringify(value, null, 2)}\n`),
-    0o600,
+    [...Buffer.from(`${JSON.stringify(value, undefined, jsonIndentSpaces)}\n`)],
+    configurationFileMode,
   );
 }
 
-export function restoreConfigurations(
-  snapshots: ConfigurationSnapshot[],
+function restoreConfigurations(
+  snapshots: readonly ConfigurationSnapshot[],
 ): void {
   const failures: string[] = [];
   for (const snapshot of snapshots.toReversed()) {
@@ -123,11 +139,18 @@ function restoreConfiguration(snapshot: ConfigurationSnapshot): void {
   writeAtomically(snapshot.path, snapshot.content, snapshot.mode);
 }
 
-function writeAtomically(path: string, content: Buffer, mode?: number): void {
+function writeAtomically(
+  path: string,
+  content: readonly number[],
+  mode?: number,
+): void {
   mkdirSync(dirname(path), { recursive: true });
   const temporaryPath = `${path}.codegraph-configure.${randomUUID()}`;
   try {
-    writeFileSync(temporaryPath, content, { flag: "wx", mode });
+    writeFileSync(temporaryPath, Uint8Array.from(content), {
+      flag: "wx",
+      mode,
+    });
     if (mode !== undefined) {
       chmodSync(temporaryPath, mode);
     }
@@ -145,7 +168,7 @@ function isExistingFile(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "EEXIST";
 }
 
-function canonicalPaths(paths: string[]): string[] {
+function canonicalPaths(paths: readonly string[]): string[] {
   return [
     ...new Set(
       paths.map((path) => {
@@ -153,9 +176,17 @@ function canonicalPaths(paths: string[]): string[] {
         return join(realpathSync.native(dirname(path)), basename(path));
       }),
     ),
-  ].sort();
+  ].toSorted();
 }
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+export {
+  type ConfigurationSnapshot,
+  inspectConfiguration,
+  restoreConfigurations,
+  withConfigurationLocks,
+  writeJsonAtomically,
+};

--- a/tooling/codegraph-config.ts
+++ b/tooling/codegraph-config.ts
@@ -1,28 +1,34 @@
-export type JsonObject = Record<string, unknown>;
+type JsonObject = Readonly<Record<string, unknown>>;
 
 const codegraphEnvironment = {
-  CODEGRAPH_TELEMETRY: "0",
-  CODEGRAPH_NO_UPDATE_CHECK: "1",
   CODEGRAPH_NO_DOWNLOAD: "1",
+  CODEGRAPH_NO_UPDATE_CHECK: "1",
+  CODEGRAPH_TELEMETRY: "0",
 } as const;
+const configurationErrorExitCode = 2;
 
-export function parseJsonObject(content: string, label: string): JsonObject {
-  let value: unknown;
-  try {
-    value = JSON.parse(content);
-  } catch {
-    throw new ConfigurationError(`invalid ${label} JSON`);
-  }
+class ConfigurationError extends Error {
+  public override readonly name = "ConfigurationError";
+  public readonly exitCode = configurationErrorExitCode;
+}
+
+function parseJsonObject(content: string, label: string): JsonObject {
+  const value = parseJson(content, label);
   if (!isJsonObject(value)) {
     throw new ConfigurationError(`invalid ${label} JSON`);
   }
   return value;
 }
 
-export function configureCursor(
-  current: JsonObject,
-  command: string,
-): JsonObject {
+function parseJson(content: string, label: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    throw new ConfigurationError(`invalid ${label} JSON`);
+  }
+}
+
+function configureCursor(current: JsonObject, command: string): JsonObject {
   const currentServers = current.mcpServers;
   if (
     currentServers !== undefined &&
@@ -34,21 +40,24 @@ export function configureCursor(
   return {
     ...current,
     mcpServers: {
-      ...(currentServers ?? {}),
+      ...currentServers,
       codegraph: {
-        type: "stdio",
+        args: ["serve", "--mcp", "--path", String.raw`\${workspaceFolder}`],
         command,
-        args: ["serve", "--mcp", "--path", "${workspaceFolder}"],
         env: codegraphEnvironment,
+        type: "stdio",
       },
     },
   };
 }
 
-export class ConfigurationError extends Error {
-  readonly exitCode = 2;
-}
-
 function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+export {
+  ConfigurationError,
+  configureCursor,
+  type JsonObject,
+  parseJsonObject,
+};

--- a/tooling/codegraph-configure-deployment.test.ts
+++ b/tooling/codegraph-configure-deployment.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { dirname, join } from "node:path";
 import {
   existsSync,
   mkdirSync,
@@ -8,13 +9,41 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { z } from "zod";
+
+const providerConfigurationSchema = z
+  .object({
+    mcpServers: z.object({ codegraph: z.object({ command: z.string() }) }),
+    unrelated: z.string().optional(),
+  })
+  .loose();
 
 const root = dirname(import.meta.dir);
 const entryPoint = join(import.meta.dir, "codegraph-configure");
 const provider = join(import.meta.dir, "codegraph-configure-test-provider.ts");
 const temporaryDirectories: string[] = [];
+const configurationErrorExitCode = 2;
+const deploymentTestTimeoutMilliseconds = 15_000;
+
+interface CommandResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+interface ConfigurationSnapshot {
+  claude: string;
+  codex: string;
+  cursor: string;
+}
+interface RealCliFixture {
+  claudeConfig: string;
+  codegraphBinary: string;
+  codexConfig: string;
+  cursorConfig: string;
+  environment: Readonly<Record<string, string | undefined>>;
+  log: string;
+}
 
 afterEach(() => {
   for (const path of temporaryDirectories.splice(0)) {
@@ -23,6 +52,12 @@ afterEach(() => {
 });
 
 describe("CodeGraph deployment", () => {
+  registerConfiguratorDeploymentTest();
+  registerVoltaDeploymentTest();
+  registerIgnoreDeploymentTest();
+});
+
+function registerConfiguratorDeploymentTest(): void {
   test("the supported Make entry point deploys the shipped configurator", () => {
     const directory = createTemporaryDirectory();
     const result = makeDryRun(directory, "codegraph");
@@ -37,7 +72,9 @@ describe("CodeGraph deployment", () => {
     );
     expect(result.stdout).toContain("brew install bun");
   });
+}
 
+function registerVoltaDeploymentTest(): void {
   test("CodeGraph installation remains delegated to unpinned Volta commands", () => {
     const directory = createTemporaryDirectory();
     const codex = makeDryRun(
@@ -53,35 +90,41 @@ describe("CodeGraph deployment", () => {
     expect(codegraph.stdout).toContain("volta install @colbymchenry/codegraph");
     expect(codegraph.stdout).not.toContain("@colbymchenry/codegraph@");
   });
+}
 
-  test("CodeGraph ignore deployment is idempotent and refuses a foreign target", () => {
-    const directory = createTemporaryDirectory();
-    const ignorePath = join(directory, "git", "ignore");
-    expect(
-      runMake(["codegraph-ignore", `CODEGRAPH_GLOBAL_IGNORE=${ignorePath}`])
-        .exitCode,
-    ).toBe(0);
-    expect(readlinkSync(ignorePath)).toBe(
-      join(root, ".config", "git", "ignore"),
-    );
-    expect(
-      runMake(["codegraph-ignore", `CODEGRAPH_GLOBAL_IGNORE=${ignorePath}`])
-        .exitCode,
-    ).toBe(0);
+function registerIgnoreDeploymentTest(): void {
+  test(
+    "CodeGraph ignore deployment is idempotent and refuses a foreign target",
+    () => {
+      const directory = createTemporaryDirectory();
+      const ignorePath = join(directory, "git", "ignore");
+      expect(
+        runMake(["codegraph-ignore", `CODEGRAPH_GLOBAL_IGNORE=${ignorePath}`])
+          .exitCode,
+      ).toBe(0);
+      expect(readlinkSync(ignorePath)).toBe(
+        join(root, ".config", "git", "ignore"),
+      );
+      expect(
+        runMake(["codegraph-ignore", `CODEGRAPH_GLOBAL_IGNORE=${ignorePath}`])
+          .exitCode,
+      ).toBe(0);
 
-    rmSync(ignorePath);
-    writeFileSync(ignorePath, "foreign\n");
-    const result = runMake([
-      "codegraph-ignore",
-      `CODEGRAPH_GLOBAL_IGNORE=${ignorePath}`,
-    ]);
+      rmSync(ignorePath);
+      writeFileSync(ignorePath, "foreign\n");
+      const result = runMake([
+        "codegraph-ignore",
+        `CODEGRAPH_GLOBAL_IGNORE=${ignorePath}`,
+      ]);
 
-    expect(result.exitCode).toBe(2);
-    expect(result.stderr).toContain(
-      "exists and is not the expected symbolic link",
-    );
-  }, 15_000);
-});
+      expect(result.exitCode).toBe(configurationErrorExitCode);
+      expect(result.stderr).toContain(
+        "exists and is not the expected symbolic link",
+      );
+    },
+    deploymentTestTimeoutMilliseconds,
+  );
+}
 
 const realClaude = process.env.CODEGRAPH_REAL_CLAUDE_BIN;
 const realCodex = process.env.CODEGRAPH_REAL_CODEX_BIN;
@@ -96,39 +139,17 @@ test.skipIf(
 )(
   "the real Claude and Codex CLIs preserve unrelated configuration",
   () => {
-    const directory = createTemporaryDirectory();
-    const home = join(directory, "home");
-    const codexHome = join(directory, "codex-home");
-    const binaries = join(directory, "bin");
-    const state = join(directory, "state");
-    const claudeConfig = join(home, ".claude.json");
-    const codexConfig = join(codexHome, "config.toml");
-    const cursorConfig = join(directory, "cursor", "mcp.json");
-    const log = join(directory, "calls.log");
-    mkdirSync(home, { recursive: true });
-    mkdirSync(codexHome, { recursive: true });
-    mkdirSync(binaries, { recursive: true });
-    symlinkSync(provider, join(binaries, "codegraph"));
-    symlinkSync(process.execPath, join(binaries, "bun"));
-    writeFileSync(claudeConfig, '{"unrelated":"claude"}\n');
-    writeFileSync(codexConfig, 'unrelated = "codex"\n');
-
-    const environment = {
-      ...process.env,
-      HOME: home,
-      VOLTA_HOME: realVoltaHome,
-      CODEX_HOME: codexHome,
-      CODEGRAPH_CLAUDE_BIN: realClaude,
-      CODEGRAPH_CODEX_BIN: realCodex,
-      CODEGRAPH_BIN: join(binaries, "codegraph"),
-      CODEGRAPH_CLAUDE_CONFIG: claudeConfig,
-      CODEGRAPH_CODEX_CONFIG: codexConfig,
-      CODEGRAPH_CURSOR_CONFIG: cursorConfig,
-      CODEGRAPH_TEST_LOG: log,
-      CODEGRAPH_TEST_STATE: state,
-      PATH: `${binaries}:${process.env.PATH ?? ""}`,
-    };
-
+    const realCliPaths = z
+      .tuple([z.string(), z.string(), z.string()])
+      .parse([realClaude, realCodex, realVoltaHome]);
+    const {
+      claudeConfig,
+      codegraphBinary,
+      codexConfig,
+      cursorConfig,
+      environment,
+      log,
+    } = createRealCliFixture(...realCliPaths);
     const first = runEntryPoint(environment);
     expect(first.exitCode).toBe(0);
     expect(first.stdout).toContain("codegraph");
@@ -143,21 +164,66 @@ test.skipIf(
       firstConfigurations,
     );
 
-    const claude = JSON.parse(firstConfigurations.claude);
-    const cursor = JSON.parse(firstConfigurations.cursor);
-    expect(claude.unrelated).toBe("claude");
-    expect(claude.mcpServers.codegraph.command).toBe(
-      join(binaries, "codegraph"),
+    const claude = providerConfigurationSchema.parse(
+      JSON.parse(firstConfigurations.claude),
     );
+    const cursor = providerConfigurationSchema.parse(
+      JSON.parse(firstConfigurations.cursor),
+    );
+    expect(claude.unrelated).toBe("claude");
+    expect(claude.mcpServers.codegraph.command).toBe(codegraphBinary);
     expect(firstConfigurations.codex).toContain('unrelated = "codex"');
     expect(firstConfigurations.codex).toContain("[mcp_servers.codegraph]");
-    expect(cursor.mcpServers.codegraph.command).toBe(
-      join(binaries, "codegraph"),
-    );
+    expect(cursor.mcpServers.codegraph.command).toBe(codegraphBinary);
     expect(existsSync(log)).toBe(true);
   },
-  15_000,
+  deploymentTestTimeoutMilliseconds,
 );
+
+function createRealCliFixture(
+  claudeBinary: string,
+  codexBinary: string,
+  voltaHome: string,
+): Readonly<RealCliFixture> {
+  const directory = createTemporaryDirectory();
+  const home = join(directory, "home");
+  const codexHome = join(directory, "codex-home");
+  const binaries = join(directory, "bin");
+  const claudeConfig = join(home, ".claude.json");
+  const codexConfig = join(codexHome, "config.toml");
+  const cursorConfig = join(directory, "cursor", "mcp.json");
+  const log = join(directory, "calls.log");
+  const codegraphBinary = join(binaries, "codegraph");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(codexHome, { recursive: true });
+  mkdirSync(binaries, { recursive: true });
+  symlinkSync(provider, codegraphBinary);
+  symlinkSync(process.execPath, join(binaries, "bun"));
+  writeFileSync(claudeConfig, '{"unrelated":"claude"}\n');
+  writeFileSync(codexConfig, 'unrelated = "codex"\n');
+  return {
+    claudeConfig,
+    codegraphBinary,
+    codexConfig,
+    cursorConfig,
+    environment: {
+      ...process.env,
+      CODEGRAPH_BIN: codegraphBinary,
+      CODEGRAPH_CLAUDE_BIN: claudeBinary,
+      CODEGRAPH_CLAUDE_CONFIG: claudeConfig,
+      CODEGRAPH_CODEX_BIN: codexBinary,
+      CODEGRAPH_CODEX_CONFIG: codexConfig,
+      CODEGRAPH_CURSOR_CONFIG: cursorConfig,
+      CODEGRAPH_TEST_LOG: log,
+      CODEGRAPH_TEST_STATE: join(directory, "state"),
+      CODEX_HOME: codexHome,
+      HOME: home,
+      PATH: `${binaries}:${process.env.PATH ?? ""}`,
+      VOLTA_HOME: voltaHome,
+    },
+    log,
+  };
+}
 
 function createTemporaryDirectory(): string {
   const directory = join(
@@ -169,7 +235,7 @@ function createTemporaryDirectory(): string {
   return directory;
 }
 
-function makeDryRun(home: string, target: string) {
+function makeDryRun(home: string, target: string): CommandResult {
   return runMake([
     "-Bn",
     `HOME=${home}`,
@@ -180,31 +246,37 @@ function makeDryRun(home: string, target: string) {
   ]);
 }
 
-function runMake(arguments_: string[]) {
+function runMake(arguments_: readonly string[]): CommandResult {
   return run(["make", "-s", "-C", root, ...arguments_], process.env);
 }
 
-function runEntryPoint(environment: Record<string, string | undefined>) {
+function runEntryPoint(
+  environment: Readonly<Record<string, string | undefined>>,
+): CommandResult {
   return run([entryPoint], environment);
 }
 
 function run(
-  command: string[],
-  environment: Record<string, string | undefined>,
-) {
-  const result = Bun.spawnSync(command, {
+  command: readonly string[],
+  environment: Readonly<Record<string, string | undefined>>,
+): CommandResult {
+  const result = Bun.spawnSync([...command], {
     env: environment,
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   });
   return {
     exitCode: result.exitCode,
-    stdout: result.stdout.toString(),
     stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
   };
 }
 
-function readConfigurations(claude: string, codex: string, cursor: string) {
+function readConfigurations(
+  claude: string,
+  codex: string,
+  cursor: string,
+): ConfigurationSnapshot {
   return {
     claude: readFileSync(claude, "utf8"),
     codex: readFileSync(codex, "utf8"),

--- a/tooling/codegraph-configure-files.test.ts
+++ b/tooling/codegraph-configure-files.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  cleanupFixtures,
+  createFixture,
+  readLog,
+  run,
+  snapshot,
+} from "./codegraph-configure-test-support.ts";
+import { linkSync, lstatSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const configurationErrorExitCode = 2;
+
+afterEach(cleanupFixtures);
+
+describe("codegraph-configure file boundaries", () => {
+  test("fails closed when an existing lock prevents serialization", () => {
+    const fixture = createFixture();
+    writeFileSync(
+      `${fixture.claudeConfig}.codegraph-configure.lock`,
+      `${process.pid}\n`,
+    );
+    const before = snapshot(fixture);
+    const result = run(fixture);
+
+    expect(result.exitCode).toBe(configurationErrorExitCode);
+    expect(result.stderr).toContain("configuration update already in progress");
+    expect(snapshot(fixture)).toEqual(before);
+    expect(readLog(fixture)).toBe("");
+  });
+
+  test("rejects symlinked configuration paths before mutation", () => {
+    const fixture = createFixture();
+    const target = join(fixture.directory, "cursor-target.json");
+    writeFileSync(target, "{}\n");
+    symlinkSync(target, fixture.cursorConfig);
+
+    const result = run(fixture);
+
+    expect(result.exitCode).toBe(configurationErrorExitCode);
+    expect(result.stderr).toContain("must not be a symlink");
+    expect(lstatSync(fixture.cursorConfig).isSymbolicLink()).toBe(true);
+    expect(readLog(fixture)).toBe("");
+  });
+
+  test("rejects hard-linked configuration paths before mutation", () => {
+    const fixture = createFixture();
+    const alias = join(fixture.directory, "cursor-alias.json");
+    writeFileSync(alias, "{}\n");
+    linkSync(alias, fixture.cursorConfig);
+
+    const result = run(fixture);
+
+    expect(result.exitCode).toBe(configurationErrorExitCode);
+    expect(result.stderr).toContain("must not have multiple hard links");
+    expect(readLog(fixture)).toBe("");
+  });
+});

--- a/tooling/codegraph-configure-reported-error.ts
+++ b/tooling/codegraph-configure-reported-error.ts
@@ -1,0 +1,9 @@
+class ReportedCommandError extends Error {
+  public override readonly name = "ReportedCommandError";
+
+  public constructor(public readonly exitCode: number) {
+    super(`command failed with exit ${exitCode}`);
+  }
+}
+
+export { ReportedCommandError };

--- a/tooling/codegraph-configure-test-provider.ts
+++ b/tooling/codegraph-configure-test-provider.ts
@@ -9,16 +9,31 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
+import { z } from "zod";
 
-const arguments_ = process.argv.slice(2);
-const provider = identifyProvider(arguments_);
-const operation = process.argv.slice(2, 4).join(" ");
+const jsonObjectSchema = z.record(z.string(), z.unknown());
+const commandArgumentOffset = 2;
+const operationArgumentEnd = 4;
+const pauseAttemptLimit = 1000;
+const pausePollMilliseconds = 5;
+const pauseTimeoutExitCode = 8;
+const providerFailureExitCode = 9;
+const unsupportedOperationExitCode = 3;
+
+const providerArguments = process.argv.slice(commandArgumentOffset);
+const provider = identifyProvider(providerArguments);
+const operation = process.argv
+  .slice(commandArgumentOffset, operationArgumentEnd)
+  .join(" ");
 const stateDirectory = requiredEnvironment("CODEGRAPH_TEST_STATE");
 const logPath = requiredEnvironment("CODEGRAPH_TEST_LOG");
 const markerPath = join(stateDirectory, provider);
 
 mkdirSync(stateDirectory, { recursive: true });
-appendFileSync(logPath, `${provider} ${process.argv.slice(2).join(" ")}\n`);
+appendFileSync(
+  logPath,
+  `${provider} ${process.argv.slice(commandArgumentOffset).join(" ")}\n`,
+);
 
 if (provider === "codegraph") {
   finish("telemetry off");
@@ -26,16 +41,16 @@ if (provider === "codegraph") {
 
 if (operation === "mcp get") {
   if (process.env.CODEGRAPH_TEST_UNEXPECTED_GET === provider) {
-    console.error("unexpected provider response");
+    process.stderr.write("unexpected provider response\n");
     process.exit(1);
   }
   if (existsSync(markerPath)) {
     process.exit(0);
   }
-  console.error(
+  process.stderr.write(
     provider === "claude"
-      ? 'No MCP server named "codegraph".'
-      : "Error: No MCP server named 'codegraph' found.",
+      ? 'No MCP server named "codegraph".\n'
+      : "Error: No MCP server named 'codegraph' found.\n",
   );
   process.exit(1);
 }
@@ -52,7 +67,7 @@ if (operation === "mcp add") {
   finish("mcp add");
 }
 
-process.exit(3);
+process.exit(unsupportedOperationExitCode);
 
 function mutateConfiguration(value: string): void {
   const path =
@@ -62,12 +77,15 @@ function mutateConfiguration(value: string): void {
   mkdirSync(dirname(path), { recursive: true });
   const current = existsSync(path) ? readFileSync(path, "utf8") : "";
   if (provider === "claude") {
-    const configuration = current === "" ? {} : JSON.parse(current);
-    const servers = configuration.mcpServers ?? {};
+    const configuration =
+      current === "" ? {} : jsonObjectSchema.parse(JSON.parse(current));
+    const serversValue = configuration.mcpServers;
+    const servers =
+      serversValue === undefined ? {} : jsonObjectSchema.parse(serversValue);
     if (value === "removed") {
       delete servers.codegraph;
     } else {
-      servers.codegraph = { command: "codegraph", args: ["serve", "--mcp"] };
+      servers.codegraph = { args: ["serve", "--mcp"], command: "codegraph" };
     }
     configuration.mcpServers = servers;
     writeFileSync(path, `${JSON.stringify(configuration)}\n`);
@@ -76,7 +94,10 @@ function mutateConfiguration(value: string): void {
   const unrelated = current
     .split("\n")
     .filter((line) => !line.startsWith(`${provider}:`))
-    .filter((line, index, lines) => line !== "" || index < lines.length - 1)
+    .filter(
+      (line, index, lines: readonly string[]) =>
+        line !== "" || index < lines.length - 1,
+    )
     .join("\n");
   writeFileSync(
     path,
@@ -89,20 +110,24 @@ function finish(expectedOperation: string): never {
     const ready = requiredEnvironment("CODEGRAPH_TEST_PAUSE_READY");
     const release = requiredEnvironment("CODEGRAPH_TEST_PAUSE_RELEASE");
     writeFileSync(ready, "ready\n");
-    for (let attempt = 0; attempt < 1_000 && !existsSync(release); attempt++) {
-      Bun.sleepSync(5);
+    for (
+      let attempt = 0;
+      attempt < pauseAttemptLimit && !existsSync(release);
+      attempt += 1
+    ) {
+      Bun.sleepSync(pausePollMilliseconds);
     }
     if (!existsSync(release)) {
-      process.exit(8);
+      process.exit(pauseTimeoutExitCode);
     }
   }
   if (process.env.CODEGRAPH_TEST_EMIT === "1") {
-    console.log(`out ${provider}:${expectedOperation}`);
-    console.error(`err ${provider}:${expectedOperation}`);
+    process.stdout.write(`out ${provider}:${expectedOperation}\n`);
+    process.stderr.write(`err ${provider}:${expectedOperation}\n`);
   }
   if (process.env.CODEGRAPH_TEST_FAIL === `${provider}:${expectedOperation}`) {
-    console.error(`failed ${provider}:${expectedOperation}`);
-    process.exit(9);
+    process.stderr.write(`failed ${provider}:${expectedOperation}\n`);
+    process.exit(providerFailureExitCode);
   }
   process.exit(0);
 }
@@ -116,17 +141,17 @@ function requiredEnvironment(name: string): string {
 }
 
 function identifyProvider(
-  arguments_: string[],
+  commandArguments: readonly string[],
 ): "claude" | "codex" | "codegraph" {
-  if (arguments_[0] === "telemetry") {
+  if (commandArguments[0] === "telemetry") {
     return "codegraph";
   }
   if (
-    arguments_.includes("--json") ||
-    arguments_.includes("--env") ||
-    (arguments_[0] === "mcp" &&
-      arguments_[1] === "remove" &&
-      !arguments_.includes("--scope"))
+    commandArguments.includes("--json") ||
+    commandArguments.includes("--env") ||
+    (commandArguments[0] === "mcp" &&
+      commandArguments[1] === "remove" &&
+      !commandArguments.includes("--scope"))
   ) {
     return "codex";
   }

--- a/tooling/codegraph-configure-test-support.ts
+++ b/tooling/codegraph-configure-test-support.ts
@@ -6,60 +6,69 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
 
 const root = dirname(import.meta.dir);
 const entryPoint = join(import.meta.dir, "codegraph-configure");
 const provider = join(import.meta.dir, "codegraph-configure-test-provider.ts");
 const temporaryDirectories: string[] = [];
+const executableFileMode = 0o755;
 
-export type Fixture = ReturnType<typeof createFixture>;
+interface Fixture {
+  claudeConfig: string;
+  codegraphBinary: string;
+  codexConfig: string;
+  cursorConfig: string;
+  directory: string;
+  environment: Record<string, string> & { CODEGRAPH_TEST_LOG: string };
+}
 
-export function createFixture(
-  overrides: Record<string, string> = {},
+type FixtureView = Omit<Readonly<Fixture>, "environment"> & {
+  readonly environment: Readonly<Fixture["environment"]>;
+};
+
+interface CommandResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+interface ConfigurationSnapshot {
+  claude: string;
+  codex: string;
+  cursor: string;
+}
+interface SpawnOptions {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  stderr: "pipe";
+  stdout: "pipe";
+}
+type FixtureValueOptions = Readonly<{
+  binaries: string;
+  directory: string;
+  links: Readonly<Record<"claude" | "codegraph" | "codex", string>>;
+  overrides: Readonly<Record<string, string>>;
+  state: string;
+}>;
+
+function createFixture(
+  overrides: Readonly<Record<string, string>> = {},
   registered = false,
-) {
+): Fixture {
   const directory = join(
     tmpdir(),
     `codegraph-configure-${crypto.randomUUID()}`,
   );
   temporaryDirectories.push(directory);
-  const binaries = join(directory, "bin");
-  const state = join(directory, "state");
-  mkdirSync(binaries, { recursive: true });
-  mkdirSync(state, { recursive: true });
-  mkdirSync(join(directory, "cursor"), { recursive: true });
-  symlinkSync(process.execPath, join(binaries, "bun"));
-  const links = Object.fromEntries(
-    ["claude", "codex", "codegraph"].map((name) => {
-      const path = join(binaries, name);
-      symlinkSync(provider, path);
-      return [name, path];
-    }),
-  ) as Record<"claude" | "codex" | "codegraph", string>;
-  chmodSync(provider, 0o755);
-  const fixture = {
+  const { binaries, links, state } = createFixtureDirectories(directory);
+  const fixture = createFixtureValues({
+    binaries,
     directory,
-    claudeConfig: join(directory, "claude.json"),
-    codexConfig: join(directory, "codex.toml"),
-    cursorConfig: join(directory, "cursor", "mcp.json"),
-    codegraphBinary: links.codegraph,
-    environment: {
-      HOME: join(directory, "home"),
-      CODEX_HOME: join(directory, "codex-home"),
-      CODEGRAPH_CLAUDE_BIN: links.claude,
-      CODEGRAPH_CODEX_BIN: links.codex,
-      CODEGRAPH_BIN: links.codegraph,
-      CODEGRAPH_CLAUDE_CONFIG: join(directory, "claude.json"),
-      CODEGRAPH_CODEX_CONFIG: join(directory, "codex.toml"),
-      CODEGRAPH_CURSOR_CONFIG: join(directory, "cursor", "mcp.json"),
-      CODEGRAPH_TEST_LOG: join(directory, "calls.log"),
-      CODEGRAPH_TEST_STATE: state,
-      PATH: `${binaries}:${process.env.PATH ?? ""}`,
-      ...overrides,
-    },
-  };
+    links,
+    overrides,
+    state,
+  });
   writeFileSync(fixture.claudeConfig, '{"unrelated":"claude"}\n');
   writeFileSync(fixture.codexConfig, 'unrelated = "codex"\n');
   if (registered) {
@@ -69,35 +78,90 @@ export function createFixture(
   return fixture;
 }
 
-export function cleanupFixtures(): void {
+function createFixtureDirectories(directory: string): Readonly<{
+  binaries: string;
+  links: Readonly<Record<"claude" | "codegraph" | "codex", string>>;
+  state: string;
+}> {
+  const binaries = join(directory, "bin");
+  const state = join(directory, "state");
+  mkdirSync(binaries, { recursive: true });
+  mkdirSync(state, { recursive: true });
+  mkdirSync(join(directory, "cursor"), { recursive: true });
+  symlinkSync(process.execPath, join(binaries, "bun"));
+  const linkProvider = (name: string): string => {
+    const path = join(binaries, name);
+    symlinkSync(provider, path);
+    return path;
+  };
+  const links = {
+    claude: linkProvider("claude"),
+    codegraph: linkProvider("codegraph"),
+    codex: linkProvider("codex"),
+  };
+  chmodSync(provider, executableFileMode);
+  return { binaries, links, state };
+}
+
+function createFixtureValues({
+  binaries,
+  directory,
+  links,
+  overrides,
+  state,
+}: FixtureValueOptions): Fixture {
+  return {
+    claudeConfig: join(directory, "claude.json"),
+    codegraphBinary: links.codegraph,
+    codexConfig: join(directory, "codex.toml"),
+    cursorConfig: join(directory, "cursor", "mcp.json"),
+    directory,
+    environment: {
+      CODEGRAPH_BIN: links.codegraph,
+      CODEGRAPH_CLAUDE_BIN: links.claude,
+      CODEGRAPH_CLAUDE_CONFIG: join(directory, "claude.json"),
+      CODEGRAPH_CODEX_BIN: links.codex,
+      CODEGRAPH_CODEX_CONFIG: join(directory, "codex.toml"),
+      CODEGRAPH_CURSOR_CONFIG: join(directory, "cursor", "mcp.json"),
+      CODEGRAPH_TEST_LOG: join(directory, "calls.log"),
+      CODEGRAPH_TEST_STATE: state,
+      CODEX_HOME: join(directory, "codex-home"),
+      HOME: join(directory, "home"),
+      PATH: `${binaries}:${process.env.PATH ?? ""}`,
+      ...overrides,
+    },
+  };
+}
+
+function cleanupFixtures(): void {
   for (const path of temporaryDirectories.splice(0)) {
     rmSync(path, { force: true, recursive: true });
   }
 }
 
-export function run(fixture: Fixture) {
+function run(fixture: FixtureView): CommandResult {
   const result = Bun.spawnSync([entryPoint], spawnOptions(fixture));
   return {
     exitCode: result.exitCode,
-    stdout: result.stdout.toString(),
     stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
   };
 }
 
-export function start(fixture: Fixture) {
+function start(fixture: FixtureView): ReturnType<typeof Bun.spawn> {
   return Bun.spawn([entryPoint], spawnOptions(fixture));
 }
 
-function spawnOptions(fixture: Fixture) {
+function spawnOptions(fixture: FixtureView): SpawnOptions {
   return {
     cwd: root,
     env: { ...process.env, ...fixture.environment },
-    stdout: "pipe" as const,
     stderr: "pipe" as const,
+    stdout: "pipe" as const,
   };
 }
 
-export function snapshot(fixture: Fixture) {
+function snapshot(fixture: FixtureView): ConfigurationSnapshot {
   return {
     claude: readOrAbsent(fixture.claudeConfig),
     codex: readOrAbsent(fixture.codexConfig),
@@ -105,7 +169,7 @@ export function snapshot(fixture: Fixture) {
   };
 }
 
-export function readLog(fixture: Fixture): string {
+function readLog(fixture: FixtureView): string {
   return readOrAbsent(fixture.environment.CODEGRAPH_TEST_LOG).replace(
     "<absent>",
     "",
@@ -119,3 +183,13 @@ function readOrAbsent(path: string): string {
     return "<absent>";
   }
 }
+
+export {
+  cleanupFixtures,
+  createFixture,
+  type Fixture,
+  readLog,
+  run,
+  snapshot,
+  start,
+};

--- a/tooling/codegraph-configure.test.ts
+++ b/tooling/codegraph-configure.test.ts
@@ -1,16 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
-  existsSync,
-  linkSync,
-  lstatSync,
-  readFileSync,
-  statSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import {
   cleanupFixtures,
   createFixture,
   readLog,
@@ -18,10 +7,37 @@ import {
   snapshot,
   start,
 } from "./codegraph-configure-test-support.ts";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { z } from "zod";
+
+const mcpConfigurationSchema = z
+  .object({
+    mcpServers: z.object({ codegraph: z.unknown() }).loose(),
+    unrelated: z.string().optional(),
+  })
+  .loose();
+const configurationErrorExitCode = 2;
+const providerFailureExitCode = 9;
+const fileModeMask = 0o777;
+const privateFileMode = 0o600;
+const maximumFilenameLength = 220;
+const pauseAttemptLimit = 1000;
+const pausePollMilliseconds = 5;
 
 afterEach(cleanupFixtures);
 
 describe("codegraph-configure entry point", () => {
+  registerConfigurationTest();
+  registerOutputTests();
+  registerValidationTests();
+  registerProviderValidationTests();
+  registerRollbackTests();
+  registerTransactionTest();
+});
+
+function registerConfigurationTest(): void {
   test("configures all providers, preserves unrelated data, and is idempotent", () => {
     const fixture = createFixture();
     writeFileSync(fixture.claudeConfig, '{"unrelated":"claude"}\n');
@@ -35,25 +51,29 @@ describe("codegraph-configure entry point", () => {
     const first = snapshot(fixture);
     expect(run(fixture).exitCode).toBe(0);
     expect(snapshot(fixture)).toEqual(first);
-    expect(JSON.parse(first.claude).unrelated).toBe("claude");
+    expect(
+      mcpConfigurationSchema.parse(JSON.parse(first.claude)).unrelated,
+    ).toBe("claude");
     expect(first.codex).toContain('unrelated = "codex"');
     expect(JSON.parse(first.cursor)).toEqual({
-      unrelated: "cursor",
       mcpServers: {
-        existing: { command: "existing" },
         codegraph: {
-          type: "stdio",
+          args: ["serve", "--mcp", "--path", String.raw`\${workspaceFolder}`],
           command: fixture.codegraphBinary,
-          args: ["serve", "--mcp", "--path", "${workspaceFolder}"],
           env: {
-            CODEGRAPH_TELEMETRY: "0",
-            CODEGRAPH_NO_UPDATE_CHECK: "1",
             CODEGRAPH_NO_DOWNLOAD: "1",
+            CODEGRAPH_NO_UPDATE_CHECK: "1",
+            CODEGRAPH_TELEMETRY: "0",
           },
+          type: "stdio",
         },
+        existing: { command: "existing" },
       },
+      unrelated: "cursor",
     });
-    expect(statSync(fixture.cursorConfig).mode & 0o777).toBe(0o600);
+    expect(statSync(fixture.cursorConfig).mode & fileModeMask).toBe(
+      privateFileMode,
+    );
     const calls = readLog(fixture);
     expect(calls).toContain(
       `claude mcp add --scope user codegraph -e CODEGRAPH_TELEMETRY=0 -e CODEGRAPH_NO_UPDATE_CHECK=1 -e CODEGRAPH_NO_DOWNLOAD=1 -- ${fixture.codegraphBinary} serve --mcp`,
@@ -62,10 +82,11 @@ describe("codegraph-configure entry point", () => {
       `codex mcp add codegraph --env CODEGRAPH_TELEMETRY=0 --env CODEGRAPH_NO_UPDATE_CHECK=1 --env CODEGRAPH_NO_DOWNLOAD=1 -- ${fixture.codegraphBinary} serve --mcp`,
     );
   });
+}
 
+function registerOutputTests(): void {
   test("preserves mutation output channels and order", () => {
     const fixture = createFixture({ CODEGRAPH_TEST_EMIT: "1" });
-
     const result = run(fixture);
 
     expect(result.exitCode).toBe(0);
@@ -82,10 +103,9 @@ describe("codegraph-configure entry point", () => {
       CODEGRAPH_TEST_EMIT: "1",
       CODEGRAPH_TEST_FAIL: "claude:mcp add",
     });
-
     const result = run(fixture);
 
-    expect(result.exitCode).toBe(9);
+    expect(result.exitCode).toBe(providerFailureExitCode);
     expect(result.stdout).toBe(
       "out codegraph:telemetry off\nout claude:mcp add\n",
     );
@@ -93,14 +113,16 @@ describe("codegraph-configure entry point", () => {
       "err codegraph:telemetry off\nerr claude:mcp add\nfailed claude:mcp add\n",
     );
   });
+}
 
+function registerValidationTests(): void {
   test("rejects invalid Cursor JSON before invoking a provider", () => {
     const fixture = createFixture();
     writeFileSync(fixture.cursorConfig, "{invalid\n");
 
     const result = run(fixture);
 
-    expect(result.exitCode).toBe(2);
+    expect(result.exitCode).toBe(configurationErrorExitCode);
     expect(result.stderr).toContain("invalid Cursor MCP JSON");
     expect(readLog(fixture)).toBe("");
   });
@@ -114,8 +136,9 @@ describe("codegraph-configure entry point", () => {
 
     expect(run(fixture).exitCode).toBe(0);
     expect(
-      JSON.parse(readFileSync(fixture.cursorConfig, "utf8")).mcpServers
-        .codegraph,
+      mcpConfigurationSchema.parse(
+        JSON.parse(readFileSync(fixture.cursorConfig, "utf8")),
+      ).mcpServers.codegraph,
     ).toBeDefined();
   });
 
@@ -125,18 +148,19 @@ describe("codegraph-configure entry point", () => {
 
     const result = run(fixture);
 
-    expect(result.exitCode).toBe(2);
+    expect(result.exitCode).toBe(configurationErrorExitCode);
     expect(result.stderr).toContain("invalid Claude configuration JSON");
     expect(readLog(fixture)).toBe("");
   });
+}
 
+function registerProviderValidationTests(): void {
   for (const provider of ["claude", "codex"]) {
     test(`rejects an unexpected ${provider} response before mutation`, () => {
       const fixture = createFixture({
         CODEGRAPH_TEST_UNEXPECTED_GET: provider,
       });
       const before = snapshot(fixture);
-
       const result = run(fixture);
 
       expect(result.exitCode).toBe(1);
@@ -151,15 +175,16 @@ describe("codegraph-configure entry point", () => {
       CODEGRAPH_CLAUDE_BIN: join(tmpdir(), "missing-claude"),
     });
     const before = snapshot(fixture);
-
     const result = run(fixture);
 
-    expect(result.exitCode).toBe(2);
+    expect(result.exitCode).toBe(configurationErrorExitCode);
     expect(result.stderr).toContain("missing executable");
     expect(snapshot(fixture)).toEqual(before);
     expect(readLog(fixture)).toBe("");
   });
+}
 
+function registerRollbackTests(): void {
   for (const failure of [
     "codegraph:telemetry off",
     "claude:mcp remove",
@@ -170,10 +195,9 @@ describe("codegraph-configure entry point", () => {
     test(`restores every agent configuration after ${failure} fails`, () => {
       const fixture = createFixture({ CODEGRAPH_TEST_FAIL: failure }, true);
       const before = snapshot(fixture);
-
       const result = run(fixture);
 
-      expect(result.exitCode).toBe(9);
+      expect(result.exitCode).toBe(providerFailureExitCode);
       expect(snapshot(fixture)).toEqual(before);
     });
   }
@@ -181,7 +205,10 @@ describe("codegraph-configure entry point", () => {
   test("restores native configurations when the Cursor write cannot start", () => {
     const fixture = createFixture({}, true);
     const before = snapshot(fixture);
-    fixture.cursorConfig = join(fixture.directory, "c".repeat(220));
+    fixture.cursorConfig = join(
+      fixture.directory,
+      "c".repeat(maximumFilenameLength),
+    );
     fixture.environment.CODEGRAPH_CURSOR_CONFIG = fixture.cursorConfig;
 
     const result = run(fixture);
@@ -190,7 +217,9 @@ describe("codegraph-configure entry point", () => {
     expect(snapshot(fixture)).toEqual({ ...before, cursor: "<absent>" });
     expect(readLog(fixture)).toContain("codex mcp add");
   });
+}
 
+function registerTransactionTest(): void {
   test("refuses an overlapping transaction before it can roll back a committed update", async () => {
     const ready = join(tmpdir(), `codegraph-ready-${crypto.randomUUID()}`);
     const release = join(tmpdir(), `codegraph-release-${crypto.randomUUID()}`);
@@ -200,81 +229,50 @@ describe("codegraph-configure entry point", () => {
       CODEGRAPH_TEST_PAUSE_RELEASE: release,
     });
     const first = start(fixture);
-    for (let attempt = 0; attempt < 1_000 && !existsSync(ready); attempt++) {
-      Bun.sleepSync(5);
+    for (
+      let attempt = 0;
+      attempt < pauseAttemptLimit && !existsSync(ready);
+      attempt += 1
+    ) {
+      Bun.sleepSync(pausePollMilliseconds);
     }
     const competingFixture = {
       ...fixture,
       environment: {
         ...fixture.environment,
-        CODEGRAPH_TEST_PAUSE: "",
         CODEGRAPH_TEST_FAIL: "codex:mcp add",
+        CODEGRAPH_TEST_PAUSE: "",
       },
     };
 
-    let competing: ReturnType<typeof run>;
-    try {
-      expect(existsSync(ready)).toBe(true);
-      competing = run(competingFixture);
-    } finally {
-      writeFileSync(release, "release\n");
-    }
+    expect(existsSync(ready)).toBe(true);
+    const competing = runAndRelease(competingFixture, release);
 
-    expect(competing.exitCode).toBe(2);
+    expect(competing.exitCode).toBe(configurationErrorExitCode);
     expect(competing.stderr).toContain(
       "configuration update already in progress",
     );
     expect(await first.exited).toBe(0);
     const configurations = snapshot(fixture);
     expect(
-      JSON.parse(configurations.claude).mcpServers.codegraph,
+      mcpConfigurationSchema.parse(JSON.parse(configurations.claude)).mcpServers
+        .codegraph,
     ).toBeDefined();
     expect(configurations.codex).toContain("codex:added");
     expect(
-      JSON.parse(configurations.cursor).mcpServers.codegraph,
+      mcpConfigurationSchema.parse(JSON.parse(configurations.cursor)).mcpServers
+        .codegraph,
     ).toBeDefined();
   });
+}
 
-  test("fails closed when an existing lock prevents serialization", () => {
-    const fixture = createFixture();
-    writeFileSync(
-      `${fixture.claudeConfig}.codegraph-configure.lock`,
-      `${process.pid}\n`,
-    );
-    const before = snapshot(fixture);
-
-    const result = run(fixture);
-
-    expect(result.exitCode).toBe(2);
-    expect(result.stderr).toContain("configuration update already in progress");
-    expect(snapshot(fixture)).toEqual(before);
-    expect(readLog(fixture)).toBe("");
-  });
-
-  test("rejects symlinked configuration paths before mutation", () => {
-    const fixture = createFixture();
-    const target = join(fixture.directory, "cursor-target.json");
-    writeFileSync(target, "{}\n");
-    symlinkSync(target, fixture.cursorConfig);
-
-    const result = run(fixture);
-
-    expect(result.exitCode).toBe(2);
-    expect(result.stderr).toContain("must not be a symlink");
-    expect(lstatSync(fixture.cursorConfig).isSymbolicLink()).toBe(true);
-    expect(readLog(fixture)).toBe("");
-  });
-
-  test("rejects hard-linked configuration paths before mutation", () => {
-    const fixture = createFixture();
-    const alias = join(fixture.directory, "cursor-alias.json");
-    writeFileSync(alias, "{}\n");
-    linkSync(alias, fixture.cursorConfig);
-
-    const result = run(fixture);
-
-    expect(result.exitCode).toBe(2);
-    expect(result.stderr).toContain("must not have multiple hard links");
-    expect(readLog(fixture)).toBe("");
-  });
-});
+function runAndRelease(
+  fixture: Parameters<typeof run>[0],
+  release: string,
+): ReturnType<typeof run> {
+  try {
+    return run(fixture);
+  } finally {
+    writeFileSync(release, "release\n");
+  }
+}

--- a/tooling/codegraph-configure.ts
+++ b/tooling/codegraph-configure.ts
@@ -1,24 +1,39 @@
-import { accessSync, constants } from "node:fs";
-import { join } from "node:path";
-import { configureCursor, ConfigurationError } from "./codegraph-config.ts";
+import { ConfigurationError, configureCursor } from "./codegraph-config.ts";
 import {
+  type ConfigurationSnapshot,
   inspectConfiguration,
   restoreConfigurations,
   withConfigurationLocks,
   writeJsonAtomically,
-  type ConfigurationSnapshot,
 } from "./codegraph-config-files.ts";
+import { accessSync, constants } from "node:fs";
+import { ReportedCommandError } from "./codegraph-configure-reported-error.ts";
+import { join } from "node:path";
 
-type CommandResult = { exitCode: number; output: string };
+interface CommandResult {
+  exitCode: number;
+  output: string;
+}
 type Registration = "absent" | "registered";
 
-export function main(): number {
+class CommandError extends Error {
+  public override readonly name = "CommandError";
+
+  public constructor(
+    public readonly exitCode: number,
+    message: string,
+  ) {
+    super(message || `command failed with exit ${exitCode}`);
+  }
+}
+
+function main(): number {
   try {
     configureCodegraph();
     return 0;
   } catch (error) {
     if (!(error instanceof ReportedCommandError)) {
-      console.error(errorMessage(error));
+      process.stderr.write(`${errorMessage(error)}\n`);
     }
     return error instanceof ConfigurationError
       ? error.exitCode
@@ -72,7 +87,7 @@ function configureCodegraph(): void {
 }
 
 function runTransaction(
-  snapshots: ConfigurationSnapshot[],
+  snapshots: readonly ConfigurationSnapshot[],
   mutation: () => void,
 ): void {
   try {
@@ -81,7 +96,10 @@ function runTransaction(
     try {
       restoreConfigurations(snapshots);
     } catch (rollbackError) {
-      throw new Error(`${errorMessage(error)}\n${errorMessage(rollbackError)}`);
+      throw new Error(
+        `${errorMessage(error)}\n${errorMessage(rollbackError)}`,
+        { cause: rollbackError },
+      );
     }
     throw error;
   }
@@ -181,11 +199,11 @@ function configureCodex(
 
 function runCapturedCommand(
   binary: string,
-  arguments_: string[],
+  arguments_: readonly string[],
 ): CommandResult {
   const result = Bun.spawnSync([binary, ...arguments_], {
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   });
   return {
     exitCode: result.exitCode,
@@ -193,10 +211,13 @@ function runCapturedCommand(
   };
 }
 
-function runMutationCommand(binary: string, arguments_: string[]): void {
+function runMutationCommand(
+  binary: string,
+  arguments_: readonly string[],
+): void {
   const result = Bun.spawnSync([binary, ...arguments_], {
-    stdout: "inherit",
     stderr: "inherit",
+    stdout: "inherit",
   });
   if (result.exitCode !== 0) {
     throw new ReportedCommandError(result.exitCode);
@@ -220,21 +241,6 @@ function requiredEnvironment(name: string): string {
   return value;
 }
 
-class CommandError extends Error {
-  constructor(
-    readonly exitCode: number,
-    message: string,
-  ) {
-    super(message || `command failed with exit ${exitCode}`);
-  }
-}
-
-class ReportedCommandError extends Error {
-  constructor(readonly exitCode: number) {
-    super(`command failed with exit ${exitCode}`);
-  }
-}
-
 function commandExitCode(error: unknown): number {
   return error instanceof CommandError || error instanceof ReportedCommandError
     ? error.exitCode
@@ -244,3 +250,5 @@ function commandExitCode(error: unknown): number {
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+export { main };

--- a/tooling/codegraph-integration.test.ts
+++ b/tooling/codegraph-integration.test.ts
@@ -1,74 +1,80 @@
-import { describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { z } from "zod";
 import {
   cleanupFreshnessFixture,
   createFreshnessFixture,
 } from "./codegraph/integration-fixture.ts";
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
 
 const provider = join(import.meta.dir, "codegraph", "mcp-test-provider.ts");
 const probeEntryPoint = join(import.meta.dir, "codegraph-mcp-probe.ts");
 const repository = import.meta.dir;
+const expectedQueryCount = 9;
+const integrationTimeoutMilliseconds = 180_000;
 const mcpReportSchema = z.object({
   environment: z.object({
-    os: z.literal("macOS"),
     linuxExercised: z.literal(false),
+    os: z.literal("macOS"),
   }),
-  initialIndexSeconds: z.number().nonnegative(),
-  initialIndexMaxRssBytes: z.number().positive(),
-  initialIndexCpuUserSeconds: z.number().nonnegative(),
-  initialIndexCpuSystemSeconds: z.number().nonnegative(),
   indexDiskKiB: z.number().positive(),
+  initialIndexCpuSystemSeconds: z.number().nonnegative(),
+  initialIndexCpuUserSeconds: z.number().nonnegative(),
+  initialIndexMaxRssBytes: z.number().positive(),
+  initialIndexSeconds: z.number().nonnegative(),
   mcp: z.object({
-    tools: z.tuple([z.literal("codegraph_explore")]),
+    queryLatencyMs: z.record(z.string(), z.number().nonnegative()),
     scenarios: z.object({
-      initial: z.literal(true),
       branchSwitch: z.literal(true),
-      edit: z.literal(true),
-      rename: z.literal(true),
+      daemonStopped: z.literal(true),
       delete: z.literal(true),
+      edit: z.literal(true),
+      initial: z.literal(true),
+      reconciliation: z.literal(true),
+      rename: z.literal(true),
       restart: z.literal(true),
       watcherInterruption: z.enum(["fresh", "alerted-stale"]),
-      reconciliation: z.literal(true),
-      daemonStopped: z.literal(true),
     }),
-    queryLatencyMs: z.record(z.string(), z.number().nonnegative()),
     synchronizationMs: z.number().nonnegative(),
+    tools: z.tuple([z.literal("codegraph_explore")]),
   }),
 });
 
 describe("CodeGraph MCP failure paths", () => {
   test.each([
-    ["startup", "1000", /stopped before replying|status=42/],
-    ["timeout", "100", /timed out/],
-    ["malformed", "1000", /malformed MCP response/],
-  ])("fails explicitly on %s", (scenario, requestTimeout, expected) => {
-    const result = Bun.spawnSync([probeEntryPoint, repository], {
-      env: {
-        ...process.env,
-        CODEGRAPH_BIN: provider,
-        CODEGRAPH_MCP_TEST_SCENARIO: scenario,
-        CODEGRAPH_MCP_REQUEST_TIMEOUT_MS: requestTimeout,
-        CODEGRAPH_MCP_STOP_TIMEOUT_MS: "100",
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    ["startup", "1000", /stopped before replying|status=42/u],
+    ["timeout", "100", /timed out/u],
+    ["malformed", "1000", /malformed MCP response/u],
+  ])(
+    "fails explicitly on %s",
+    (scenario, requestTimeout, expected: Readonly<RegExp>) => {
+      const result = Bun.spawnSync([probeEntryPoint, repository], {
+        env: {
+          ...process.env,
+          CODEGRAPH_BIN: provider,
+          CODEGRAPH_MCP_REQUEST_TIMEOUT_MS: requestTimeout,
+          CODEGRAPH_MCP_STOP_TIMEOUT_MS: "100",
+          CODEGRAPH_MCP_TEST_SCENARIO: scenario,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
 
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stdout.toString()).toBe("");
-    expect(result.stderr.toString()).toMatch(expected);
-  });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stdout.toString()).toBe("");
+      expect(result.stderr.toString()).toMatch(expected);
+    },
+  );
 
   test("reports cleanup failure after removing the isolated fixture", async () => {
     const fixture = createFreshnessFixture(
       join(import.meta.dir, "codegraph", "fixtures", "freshness"),
     );
 
-    await expect(
+    const cleanupError = await captureFailure(() =>
       cleanupFreshnessFixture(fixture, [process.execPath, provider]),
-    ).rejects.toThrow(/cleanup failed/);
+    );
+    expect(String(cleanupError)).toMatch(/cleanup failed/u);
     expect(existsSync(fixture.root)).toBeFalse();
   });
 });
@@ -79,21 +85,34 @@ test.skipIf(process.env.CODEGRAPH_INTEGRATION !== "1")(
     const result = Bun.spawnSync(
       [join(import.meta.dir, "codegraph-mcp-test")],
       {
-        stdout: "pipe",
         stderr: "pipe",
+        stdout: "pipe",
       },
     );
     expect(result.exitCode, result.stderr.toString()).toBe(0);
     const report = mcpReportSchema.parse(JSON.parse(result.stdout.toString()));
-    expect(report.environment).toEqual({ os: "macOS", linuxExercised: false });
+    expect(report.environment).toEqual({ linuxExercised: false, os: "macOS" });
     expect(report.mcp.tools).toEqual(["codegraph_explore"]);
-    expect(Object.keys(report.mcp.queryLatencyMs)).toHaveLength(9);
+    expect(Object.keys(report.mcp.queryLatencyMs)).toHaveLength(
+      expectedQueryCount,
+    );
     expect(report.initialIndexSeconds).toBeGreaterThanOrEqual(0);
     expect(report.initialIndexMaxRssBytes).toBeGreaterThan(0);
     expect(report.indexDiskKiB).toBeGreaterThan(0);
   },
-  180_000,
+  integrationTimeoutMilliseconds,
 );
+
+async function captureFailure(
+  operation: () => Promise<void>,
+): Promise<unknown> {
+  try {
+    await operation();
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
 
 test.skipIf(
   process.env.CODEGRAPH_INTEGRATION !== "1" || process.platform !== "darwin",
@@ -103,19 +122,19 @@ test.skipIf(
     const result = Bun.spawnSync(
       [join(import.meta.dir, "codegraph-network-test")],
       {
-        stdout: "pipe",
         stderr: "pipe",
+        stdout: "pipe",
       },
     );
     expect(result.exitCode, result.stderr.toString()).toBe(0);
-    const report = JSON.parse(result.stdout.toString());
+    const report = z.unknown().parse(JSON.parse(result.stdout.toString()));
     expect(report).toEqual({
-      sampleIntervalMs: 50,
-      descendantsRecursive: true,
-      phases: { init: true, sync: true, mcp: true },
-      networkSocketsObserved: 0,
       daemonStopped: true,
+      descendantsRecursive: true,
+      networkSocketsObserved: 0,
+      phases: { init: true, mcp: true, sync: true },
+      sampleIntervalMs: 50,
     });
   },
-  180_000,
+  integrationTimeoutMilliseconds,
 );

--- a/tooling/codegraph-mcp-probe.ts
+++ b/tooling/codegraph-mcp-probe.ts
@@ -3,22 +3,30 @@
 import { realpathSync } from "node:fs";
 import { runFreshnessProbe } from "./codegraph/mcp-probe.ts";
 
-const repositoryArgument = process.argv[2];
 const binary = process.env.CODEGRAPH_BIN ?? Bun.which("codegraph");
+const firstArgumentIndex = 2;
+const maximumPauseMilliseconds = 10_000;
+const [repositoryArgument] = process.argv.slice(firstArgumentIndex);
+const usageExitCode = 64;
 if (
-  repositoryArgument === undefined ||
+  process.argv.length <= firstArgumentIndex ||
+  repositoryArgument === "" ||
   binary === null ||
-  binary === undefined
+  !binary
 ) {
   process.stderr.write("usage: codegraph-mcp-probe REPOSITORY\n");
-  process.exit(64);
+  process.exit(usageExitCode);
 }
 
 try {
-  const repository = realpathSync(repositoryArgument);
-  if (process.env.CODEGRAPH_PROBE_PAUSE_MS !== undefined) {
+  const repository = realpathSync(repositoryArgument ?? "");
+  if ("CODEGRAPH_PROBE_PAUSE_MS" in process.env) {
     const pause = Number(process.env.CODEGRAPH_PROBE_PAUSE_MS);
-    if (!Number.isSafeInteger(pause) || pause < 0 || pause > 10_000) {
+    if (
+      !Number.isSafeInteger(pause) ||
+      pause < Number.MIN_SAFE_INTEGER + Math.abs(Number.MIN_SAFE_INTEGER) ||
+      pause > maximumPauseMilliseconds
+    ) {
       throw new Error(
         `invalid probe pause: ${process.env.CODEGRAPH_PROBE_PAUSE_MS}`,
       );
@@ -29,8 +37,10 @@ try {
     `${JSON.stringify(await runFreshnessProbe(repository, [binary]))}\n`,
   );
 } catch (error) {
-  process.stderr.write(
-    `${error instanceof Error ? error.message : String(error)}\n`,
-  );
-  process.exit(1);
+  let message = String(error);
+  if (error instanceof Error) {
+    ({ message } = error);
+  }
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
 }

--- a/tooling/codegraph-mcp-runner.ts
+++ b/tooling/codegraph-mcp-runner.ts
@@ -1,61 +1,100 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { z } from "zod";
 import {
+  type Command,
+  type FreshnessFixture,
+  captureOperation,
   cleanupFreshnessFixture,
   createFreshnessFixture,
   privacyEnvironment,
   runCommand,
-  type Command,
 } from "./codegraph/integration-fixture.ts";
-import { runFreshnessProbe } from "./codegraph/mcp-probe.ts";
+import { type ProbeReport, runFreshnessProbe } from "./codegraph/mcp-probe.ts";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { z } from "zod";
 
 const statusSchema = z.record(z.string(), z.unknown());
+const millisecondsPerSecond = 1000;
+const jsonIndentSpaces = 2;
+const userMetricIndex = 2;
+const systemMetricIndex = 4;
 
-export async function runCodeGraphMcpTest() {
+interface InitialIndexMeasurement {
+  cpuSystemSeconds: number;
+  cpuUserSeconds: number;
+  maxRssBytes: number;
+  seconds: number;
+}
+
+interface McpTestReport {
+  environment: { linuxExercised: false; os: "macOS" };
+  indexDiskKiB: number;
+  initialIndexCpuSystemSeconds: number;
+  initialIndexCpuUserSeconds: number;
+  initialIndexMaxRssBytes: number;
+  initialIndexSeconds: number;
+  mcp: ProbeReport;
+}
+
+async function runCodeGraphMcpTest(): Promise<McpTestReport> {
   requirePlatform();
   const codegraph = resolveCommand("CODEGRAPH_BIN", "codegraph");
   const fixture = createFreshnessFixture(
     join(import.meta.dir, "codegraph", "fixtures", "freshness"),
   );
-  let operationError: unknown;
+  const outcome = await captureOperation(() =>
+    collectMcpTestReport(fixture, codegraph),
+  );
+  const operationError = outcome.ok ? undefined : outcome.error;
+  await cleanupMcpFixture(fixture, codegraph, operationError);
+  if (!outcome.ok) {
+    throw new Error(message(outcome.error), { cause: outcome.error });
+  }
+  return outcome.value;
+}
+
+async function collectMcpTestReport(
+  fixture: FreshnessFixture,
+  codegraph: Command,
+): Promise<McpTestReport> {
+  const initial = measureInitialIndex(
+    codegraph,
+    fixture.repository,
+    fixture.root,
+  );
+  statusSchema.parse(
+    JSON.parse(
+      runCommand(codegraph, ["status", "--json", fixture.repository], {
+        cwd: fixture.repository,
+      }),
+    ),
+  );
+  const mcp = await runFreshnessProbe(fixture.repository, codegraph);
+  return {
+    environment: { linuxExercised: false, os: "macOS" },
+    indexDiskKiB: diskKiB(fixture.repository),
+    initialIndexCpuSystemSeconds: initial.cpuSystemSeconds,
+    initialIndexCpuUserSeconds: initial.cpuUserSeconds,
+    initialIndexMaxRssBytes: initial.maxRssBytes,
+    initialIndexSeconds: initial.seconds,
+    mcp,
+  };
+}
+
+async function cleanupMcpFixture(
+  fixture: FreshnessFixture,
+  codegraph: Command,
+  operationError: unknown,
+): Promise<void> {
   try {
-    const initial = measureInitialIndex(
-      codegraph,
-      fixture.repository,
-      fixture.root,
-    );
-    statusSchema.parse(
-      JSON.parse(
-        runCommand(
-          codegraph,
-          ["status", "--json", fixture.repository],
-          fixture.repository,
-        ),
-      ),
-    );
-    const mcp = await runFreshnessProbe(fixture.repository, codegraph);
-    return {
-      environment: { os: "macOS", linuxExercised: false },
-      initialIndexSeconds: initial.seconds,
-      initialIndexMaxRssBytes: initial.maxRssBytes,
-      initialIndexCpuUserSeconds: initial.cpuUserSeconds,
-      initialIndexCpuSystemSeconds: initial.cpuSystemSeconds,
-      indexDiskKiB: diskKiB(fixture.repository),
-      mcp,
-    };
-  } catch (error) {
-    operationError = error;
-    throw error;
-  } finally {
-    try {
-      await cleanupFreshnessFixture(fixture, codegraph);
-    } catch (cleanupError) {
-      if (operationError === undefined) throw cleanupError;
-      throw new Error(
-        `CodeGraph test failed: ${message(operationError)}; cleanup failed: ${message(cleanupError)}`,
-      );
+    await cleanupFreshnessFixture(fixture, codegraph);
+  } catch (cleanupError) {
+    if (operationError === undefined) {
+      throw cleanupError;
     }
+    throw new Error(
+      `CodeGraph test failed: ${message(operationError)}; cleanup failed: ${message(cleanupError)}`,
+      { cause: cleanupError },
+    );
   }
 }
 
@@ -63,7 +102,7 @@ function measureInitialIndex(
   codegraph: Command,
   repository: string,
   root: string,
-) {
+): InitialIndexMeasurement {
   const timeLog = join(root, "index-time");
   const started = performance.now();
   runCommand(
@@ -78,16 +117,15 @@ function measureInitialIndex(
       "init",
       repository,
     ],
-    repository,
-    process.env,
+    { cwd: repository, environment: process.env },
   );
   const report = readFileSync(timeLog, "utf8");
-  const firstLine = report.split("\n")[0]?.trim().split(/\s+/) ?? [];
-  const maximumRss = report.match(
-    /^\s*(\d+)\s+maximum resident set size/m,
-  )?.[1];
-  const userSeconds = firstLine[2];
-  const systemSeconds = firstLine[4];
+  const firstLine = report.split("\n")[0]?.trim().split(/\s+/u) ?? [];
+  const maximumRss =
+    /^\s*(?<maximumRss>\d+)\s+maximum resident set size/mu.exec(report)?.groups
+      ?.maximumRss;
+  const userSeconds = firstLine.at(userMetricIndex);
+  const systemSeconds = firstLine.at(systemMetricIndex);
   if (
     maximumRss === undefined ||
     userSeconds === undefined ||
@@ -96,26 +134,25 @@ function measureInitialIndex(
     throw new Error(`invalid /usr/bin/time report: ${report}`);
   }
   return {
-    seconds: Math.floor((performance.now() - started) / 1_000),
-    maxRssBytes: parseMetric(maximumRss, "maximum RSS"),
-    cpuUserSeconds: parseMetric(userSeconds, "user CPU"),
     cpuSystemSeconds: parseMetric(systemSeconds, "system CPU"),
+    cpuUserSeconds: parseMetric(userSeconds, "user CPU"),
+    maxRssBytes: parseMetric(maximumRss, "maximum RSS"),
+    seconds: Math.floor((performance.now() - started) / millisecondsPerSecond),
   };
 }
 
 function diskKiB(repository: string): number {
-  const output = runCommand(
-    ["du"],
-    ["-sk", join(repository, ".codegraph")],
-    repository,
-  );
-  return parseMetric(output.trim().split(/\s+/)[0] ?? "", "index disk KiB");
+  const output = runCommand(["du"], ["-sk", join(repository, ".codegraph")], {
+    cwd: repository,
+  });
+  return parseMetric(output.trim().split(/\s+/u)[0] ?? "", "index disk KiB");
 }
 
 function parseMetric(value: string, name: string): number {
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0)
+  if (!Number.isFinite(parsed) || parsed < 0) {
     throw new Error(`invalid ${name}: ${value}`);
+  }
   return parsed;
 }
 
@@ -137,12 +174,18 @@ function resolveCommand(variable: string, fallback: string): Command {
 }
 
 function requirePlatform(): void {
-  if (process.platform !== "darwin")
+  if (process.platform !== "darwin") {
     throw new Error("CodeGraph MCP test requires macOS");
-  if (Bun.which("git") === null) throw new Error("git is required");
-  if (Bun.which("du") === null) throw new Error("du is required");
-  if (!Bun.file("/usr/bin/time").size)
+  }
+  if (Bun.which("git") === null) {
+    throw new Error("git is required");
+  }
+  if (Bun.which("du") === null) {
+    throw new Error("du is required");
+  }
+  if (Bun.file("/usr/bin/time").size === 0) {
     throw new Error("/usr/bin/time is required");
+  }
 }
 
 function message(error: unknown): string {
@@ -152,7 +195,7 @@ function message(error: unknown): string {
 if (import.meta.main) {
   try {
     process.stdout.write(
-      `${JSON.stringify(await runCodeGraphMcpTest(), null, 2)}\n`,
+      `${JSON.stringify(await runCodeGraphMcpTest(), undefined, jsonIndentSpaces)}\n`,
     );
   } catch (error) {
     process.stderr.write(
@@ -161,3 +204,5 @@ if (import.meta.main) {
     process.exit(1);
   }
 }
+
+export { runCodeGraphMcpTest };

--- a/tooling/codegraph-network-runner.ts
+++ b/tooling/codegraph-network-runner.ts
@@ -1,75 +1,110 @@
-import { join } from "node:path";
-import { z } from "zod";
 import {
+  type Command,
+  type FreshnessFixture,
+  captureOperation,
   cleanupFreshnessFixture,
   createFreshnessFixture,
   privacyEnvironment,
-  type Command,
 } from "./codegraph/integration-fixture.ts";
 import {
+  NetworkViolationError,
   auditProcessNetwork,
-  NetworkViolation,
 } from "./codegraph/network-audit.ts";
+import { join } from "node:path";
+import { z } from "zod";
 
 const probeSchema = z.object({
   scenarios: z.object({ daemonStopped: z.literal(true) }),
 });
+const networkSampleIntervalMilliseconds = 50;
 
-export async function runCodeGraphNetworkTest() {
+interface NetworkTestReport {
+  daemonStopped: true;
+  descendantsRecursive: true;
+  networkSocketsObserved: 0;
+  phases: { init: true; mcp: true; sync: true };
+  sampleIntervalMs: typeof networkSampleIntervalMilliseconds;
+}
+
+async function runCodeGraphNetworkTest(): Promise<NetworkTestReport> {
   requireNetworkPlatform();
   const binary = process.env.CODEGRAPH_BIN ?? Bun.which("codegraph");
-  if (binary === null || binary === undefined)
+  if (binary === null || binary === undefined) {
     throw new Error("codegraph is required");
+  }
   const codegraph: Command = [binary];
   await proveNetworkCanary();
   const fixture = createFreshnessFixture(
     join(import.meta.dir, "codegraph", "fixtures", "freshness"),
   );
-  let operationError: unknown;
-  try {
-    await auditProcessNetwork(
-      [...codegraph, "init", fixture.repository],
-      privacyEnvironment,
+  const outcome = await captureOperation(() =>
+    collectNetworkTestReport(fixture, codegraph, binary),
+  );
+  const operationError = outcome.ok ? undefined : outcome.error;
+  await cleanupNetworkFixture(fixture, codegraph, operationError);
+  if (!outcome.ok) {
+    throw new Error(message(outcome.error), { cause: outcome.error });
+  }
+  return outcome.value;
+}
+
+async function collectNetworkTestReport(
+  fixture: FreshnessFixture,
+  codegraph: Command,
+  binary: string,
+): Promise<NetworkTestReport> {
+  const options = {
+    environment: privacyEnvironment,
+    repository: fixture.repository,
+  };
+  await auditProcessNetwork(
+    [...codegraph, "init", fixture.repository],
+    options,
+  );
+  await auditProcessNetwork(
+    [...codegraph, "sync", fixture.repository],
+    options,
+  );
+  const probe = await auditProcessNetwork(
+    [
+      process.execPath,
+      join(import.meta.dir, "codegraph-mcp-probe.ts"),
       fixture.repository,
-    );
-    await auditProcessNetwork(
-      [...codegraph, "sync", fixture.repository],
-      privacyEnvironment,
-      fixture.repository,
-    );
-    const probe = await auditProcessNetwork(
-      [
-        process.execPath,
-        join(import.meta.dir, "codegraph-mcp-probe.ts"),
-        fixture.repository,
-      ],
-      {
+    ],
+    {
+      environment: {
         ...privacyEnvironment,
         CODEGRAPH_BIN: binary,
         CODEGRAPH_PROBE_PAUSE_MS: "500",
       },
-      fixture.repository,
-    );
-    probeSchema.parse(JSON.parse(probe.stdout));
-    return {
-      sampleIntervalMs: 50,
-      descendantsRecursive: true,
-      phases: { init: true, sync: true, mcp: true },
-      networkSocketsObserved: 0,
-      daemonStopped: true,
-    };
-  } catch (error) {
-    operationError = error;
-    throw error;
-  } finally {
-    try {
-      await cleanupFreshnessFixture(fixture, codegraph);
-    } catch (cleanupError) {
-      if (operationError === undefined) throw cleanupError;
-      throw new Error(
-        `network test failed: ${message(operationError)}; cleanup failed: ${message(cleanupError)}`,
-      );
+      repository: fixture.repository,
+    },
+  );
+  probeSchema.parse(JSON.parse(probe.stdout));
+  return {
+    daemonStopped: true,
+    descendantsRecursive: true,
+    networkSocketsObserved: 0,
+    phases: { init: true, mcp: true, sync: true },
+    sampleIntervalMs: networkSampleIntervalMilliseconds,
+  };
+}
+
+async function cleanupNetworkFixture(
+  fixture: FreshnessFixture,
+  codegraph: Command,
+  operationError: unknown,
+): Promise<void> {
+  try {
+    await cleanupFreshnessFixture(fixture, codegraph);
+  } catch (cleanupError) {
+    if (operationError === undefined) {
+      throw cleanupError;
     }
+    throw new Error(
+      `network test failed: ${message(operationError)}; cleanup failed: ${message(cleanupError)}`,
+      { cause: cleanupError },
+    );
   }
 }
 
@@ -81,28 +116,34 @@ async function proveNetworkCanary(): Promise<void> {
         join(import.meta.dir, "codegraph", "network-canary.ts"),
         "root",
       ],
-      process.env,
-      undefined,
-      10_000,
+      {
+        environment: process.env,
+        repository: undefined,
+        timeoutMilliseconds: 10_000,
+      },
     );
   } catch (error) {
-    if (error instanceof NetworkViolation && error.sockets.trim() !== "")
+    if (error instanceof NetworkViolationError && error.sockets.trim() !== "") {
       return;
+    }
     throw error;
   }
   throw new Error("recursive network canary was not detected");
 }
 
 function requireNetworkPlatform(): void {
-  if (process.platform !== "darwin")
+  if (process.platform !== "darwin") {
     throw new Error("CodeGraph network test requires macOS");
+  }
   for (const dependency of ["git", "lsof", "pgrep"]) {
-    if (Bun.which(dependency) === null)
+    if (Bun.which(dependency) === null) {
       throw new Error(`${dependency} is required`);
+    }
   }
   const selfAudit = Bun.spawnSync(["lsof", "-nP", "-p", String(process.pid)]);
-  if (selfAudit.exitCode !== 0)
+  if (selfAudit.exitCode !== 0) {
     throw new Error("lsof cannot inspect the current process");
+  }
 }
 
 function message(error: unknown): string {
@@ -121,3 +162,5 @@ if (import.meta.main) {
     process.exit(1);
   }
 }
+
+export { runCodeGraphNetworkTest };

--- a/tooling/codegraph-repository-files.ts
+++ b/tooling/codegraph-repository-files.ts
@@ -1,4 +1,4 @@
-import { lstatSync, readdirSync, realpathSync, type Dirent } from "node:fs";
+import { type Dirent, lstatSync, readdirSync, realpathSync } from "node:fs";
 import { relative, resolve, sep } from "node:path";
 import { MeasurementError } from "./codegraph-repository-measurement.ts";
 
@@ -18,7 +18,7 @@ const excludedDirectories = new Set([
   "fixtures",
 ]);
 
-export function gitOpenTofuFiles(
+function gitOpenTofuFiles(
   repository: string,
   nulSeparatedFiles: string,
 ): string[] {
@@ -35,16 +35,29 @@ export function gitOpenTofuFiles(
   return files.flatMap((file) => eligibleFile(repository, file));
 }
 
-export function nonGitOpenTofuFiles(repository: string): string[] {
-  const files: string[] = [];
-  visit(repository, "", files);
-  return files;
+function nonGitOpenTofuFiles(repository: string): string[] {
+  return filesBelow(repository, "");
 }
 
-function visit(repository: string, directory: string, files: string[]): void {
-  let entries: Dirent[];
+function filesBelow(repository: string, directory: string): string[] {
+  const entries = readDirectory(repository, directory);
+  return entries.flatMap((entry: Readonly<Dirent>) => {
+    const path = directory === "" ? entry.name : `${directory}/${entry.name}`;
+    if (entry.isDirectory()) {
+      return excludedDirectories.has(entry.name)
+        ? []
+        : filesBelow(repository, path);
+    }
+    if (entry.isFile() && /\.tofu$/iu.test(entry.name)) {
+      return [realpathSync.native(resolve(repository, path))];
+    }
+    return [];
+  });
+}
+
+function readDirectory(repository: string, directory: string): Dirent[] {
   try {
-    entries = readdirSync(resolve(repository, directory), {
+    return readdirSync(resolve(repository, directory), {
       withFileTypes: true,
     });
   } catch (error) {
@@ -52,22 +65,10 @@ function visit(repository: string, directory: string, files: string[]): void {
       `repository traversal failed: ${message(error)}`,
     );
   }
-  for (const entry of entries) {
-    const path = directory === "" ? entry.name : `${directory}/${entry.name}`;
-    if (entry.isDirectory()) {
-      if (!excludedDirectories.has(entry.name)) {
-        visit(repository, path, files);
-      }
-      continue;
-    }
-    if (entry.isFile() && /\.tofu$/i.test(entry.name)) {
-      files.push(realpathSync.native(resolve(repository, path)));
-    }
-  }
 }
 
 function eligibleFile(repository: string, file: string): string[] {
-  if (!/\.tofu$/i.test(file) || hasExcludedSegment(file)) {
+  if (!/\.tofu$/iu.test(file) || hasExcludedSegment(file)) {
     return [];
   }
   const path = resolve(repository, file);
@@ -97,3 +98,5 @@ function hasExcludedSegment(path: string): boolean {
 function message(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+export { gitOpenTofuFiles, nonGitOpenTofuFiles };

--- a/tooling/codegraph-repository-measurement.test.ts
+++ b/tooling/codegraph-repository-measurement.test.ts
@@ -1,18 +1,36 @@
-import { describe, expect, test } from "bun:test";
 import {
+  type SourceMeasurement,
   aggregateMeasurements,
   parseTokeiOutput,
 } from "./codegraph-repository-measurement.ts";
+import { describe, expect, test } from "bun:test";
+
+const belowLineThreshold = 49_999;
+const belowFileThreshold = 499;
+const lineThreshold = 50_000;
+const fileThreshold = 500;
+const cjsLines = 2;
+const tofuLines = 3;
+const ignoredHclLines = 5;
+const ignoredYamlLines = 7;
+const expectedKeptFileCount = 2;
+const expectedKeptSourceLines = cjsLines + tofuLines;
 
 describe("repository measurement", () => {
   test("aggregates source records at both initialization boundaries", () => {
-    expect(aggregateMeasurements(records(49_999, 499))).toEqual({
-      loc: 49_999,
-      files: 499,
+    expect(
+      aggregateMeasurements(records(belowLineThreshold, belowFileThreshold)),
+    ).toEqual({
+      files: belowFileThreshold,
       initialize: false,
+      loc: belowLineThreshold,
     });
-    expect(aggregateMeasurements(records(50_000, 1)).initialize).toBe(true);
-    expect(aggregateMeasurements(records(1, 500)).initialize).toBe(true);
+    expect(aggregateMeasurements(records(lineThreshold, 1)).initialize).toBe(
+      true,
+    );
+    expect(aggregateMeasurements(records(1, fileThreshold)).initialize).toBe(
+      true,
+    );
   });
 
   test("accepts supported extensions case-insensitively and rejects other records", () => {
@@ -20,14 +38,18 @@ describe("repository measurement", () => {
       aggregateMeasurements(
         parseTokeiOutput(
           [
-            record("kept.CJS", 2),
-            record("kept.tofu.tf", 3),
-            record("ignored.hcl", 5),
-            record("ignored.yaml", 7),
+            record("kept.CJS", cjsLines),
+            record("kept.tofu.tf", tofuLines),
+            record("ignored.hcl", ignoredHclLines),
+            record("ignored.yaml", ignoredYamlLines),
           ].join(""),
         ),
       ),
-    ).toEqual({ loc: 5, files: 2, initialize: false });
+    ).toEqual({
+      files: expectedKeptFileCount,
+      initialize: false,
+      loc: expectedKeptSourceLines,
+    });
   });
 
   test("rejects malformed or unsafe Tokei records", () => {
@@ -38,19 +60,17 @@ describe("repository measurement", () => {
     expect(() =>
       aggregateMeasurements(
         parseTokeiOutput(
-          record("fixture.ts", Number.MAX_SAFE_INTEGER).concat(
-            record("second.ts", 1),
-          ),
+          `${record("fixture.ts", Number.MAX_SAFE_INTEGER)}${record("second.ts", 1)}`,
         ),
       ),
     ).toThrow("safe integer");
   });
 });
 
-function records(loc: number, files: number) {
-  return Array.from({ length: files }, (_, index) => ({
-    name: `fixture-${index}.ts`,
+function records(loc: number, files: number): SourceMeasurement[] {
+  return Array.from({ length: files }, (_unusedValue, index) => ({
     code: index === 0 ? loc : 0,
+    name: `fixture-${index}.ts`,
   }));
 }
 

--- a/tooling/codegraph-repository-measurement.ts
+++ b/tooling/codegraph-repository-measurement.ts
@@ -1,23 +1,39 @@
 import { z } from "zod";
 
-export type SourceMeasurement = { name: string; code: number };
-export type RepositoryMeasurement = {
-  loc: number;
-  files: number;
-  initialize: boolean;
-};
+interface SourceMeasurement {
+  readonly name: string;
+  readonly code: number;
+}
+interface RepositoryMeasurement {
+  readonly loc: number;
+  readonly files: number;
+  readonly initialize: boolean;
+}
 
 const sourceExtension =
-  /\.(astro|c|cc|cbl|cob|cobol|cfc|cfm|cfs|cjs|cpp|cpy|cs|cshtml|cts|cu|cuh|cxx|dart|dfm|dpk|dpr|erl|escript|ets|fmx|go|h|hpp|hrl|hxx|inc|install|java|js|jsx|kt|kts|liquid|lpr|lua|luau|m|metal|mjs|mm|module|mts|nix|pas|php|py|pyw|r|rake|razor|rb|rs|sc|scala|sol|svelte|swift|tf|tfvars|theme|ts|tsx|vb|vue|xsjs|xsjslib)$/i;
-
+  /\.(?:astro|c|cc|cbl|cob|cobol|cfc|cfm|cfs|cjs|cpp|cpy|cs|cshtml|cts|cu|cuh|cxx|dart|dfm|dpk|dpr|erl|escript|ets|fmx|go|h|hpp|hrl|hxx|inc|install|java|js|jsx|kt|kts|liquid|lpr|lua|luau|m|metal|mjs|mm|module|mts|nix|pas|php|py|pyw|r|rake|razor|rb|rs|sc|scala|sol|svelte|swift|tf|tfvars|theme|ts|tsx|vb|vue|xsjs|xsjslib)$/iu;
 const tokeiRecordSchema = z.object({
   stats: z.object({
     name: z.string(),
     stats: z.object({ code: z.number().int().nonnegative() }),
   }),
 });
+const measurementErrorExitCode = 2;
+const sourceLineThreshold = 50_000;
+const sourceFileThreshold = 500;
 
-export function parseTokeiOutput(output: string): SourceMeasurement[] {
+class MeasurementError extends Error {
+  public override readonly name = "MeasurementError";
+
+  public constructor(
+    message: string,
+    public readonly exitCode = measurementErrorExitCode,
+  ) {
+    super(message);
+  }
+}
+
+function parseTokeiOutput(output: string): SourceMeasurement[] {
   if (output === "") {
     return [];
   }
@@ -25,25 +41,28 @@ export function parseTokeiOutput(output: string): SourceMeasurement[] {
     ? output.slice(0, -1).split("\n")
     : output.split("\n");
   return lines.map((line) => {
-    let value: unknown;
-    try {
-      value = JSON.parse(line);
-    } catch {
-      throw new MeasurementError("invalid Tokei JSON");
-    }
+    const value = parseTokeiLine(line);
     const parsed = tokeiRecordSchema.safeParse(value);
     if (!parsed.success) {
       throw new MeasurementError("invalid Tokei record");
     }
     return {
-      name: parsed.data.stats.name,
       code: parsed.data.stats.stats.code,
+      name: parsed.data.stats.name,
     };
   });
 }
 
-export function aggregateMeasurements(
-  measurements: SourceMeasurement[],
+function parseTokeiLine(line: string): unknown {
+  try {
+    return JSON.parse(line);
+  } catch {
+    throw new MeasurementError("invalid Tokei JSON");
+  }
+}
+
+function aggregateMeasurements(
+  measurements: readonly SourceMeasurement[],
 ): RepositoryMeasurement {
   const source = measurements.filter(({ name }) => sourceExtension.test(name));
   const loc = source.reduce((total, measurement) => {
@@ -54,14 +73,17 @@ export function aggregateMeasurements(
     return next;
   }, 0);
   const files = source.length;
-  return { loc, files, initialize: loc >= 50_000 || files >= 500 };
+  return {
+    loc,
+    files,
+    initialize: loc >= sourceLineThreshold || files >= sourceFileThreshold,
+  };
 }
 
-export class MeasurementError extends Error {
-  constructor(
-    message: string,
-    readonly exitCode = 2,
-  ) {
-    super(message);
-  }
-}
+export {
+  aggregateMeasurements,
+  MeasurementError,
+  type RepositoryMeasurement,
+  type SourceMeasurement,
+  parseTokeiOutput,
+};

--- a/tooling/codegraph-repository-size-failures.test.ts
+++ b/tooling/codegraph-repository-size-failures.test.ts
@@ -1,53 +1,68 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import {
   cleanupFixtures,
   createFixture,
   readArguments,
   runEntryPoint,
 } from "./codegraph-repository-size-test-support.ts";
+import { join } from "node:path";
+
+const measurementErrorExitCode = 2;
+const operationalFailureExitCode = 7;
+const expectedGitCommandCount = 2;
+const restoredDirectoryMode = 0o700;
 
 afterEach(cleanupFixtures);
 
 describe("codegraph-repository-size failures", () => {
+  registerGitFailureTests();
+  registerInvalidPathTests();
+  registerInvalidOutputTests();
+  registerDependencyTests();
+  registerRepositoryTests();
+});
+
+function registerGitFailureTests(): void {
   for (const operation of ["rev-parse", "ls-files"]) {
     test(`fails closed without publishing a measurement when Git ${operation} fails`, () => {
       const fixture = createFixture();
       const result = runEntryPoint(fixture.repository, {
         ...fixture.environment,
         CODEGRAPH_GIT_BIN: fixture.fakeGit,
-        CODEGRAPH_TEST_GIT_REPOSITORY: "1",
         CODEGRAPH_TEST_GIT_FAILURE: operation,
+        CODEGRAPH_TEST_GIT_REPOSITORY: "1",
       });
 
-      expect(result.exitCode).toBe(7);
+      expect(result.exitCode).toBe(operationalFailureExitCode);
       expect(result.stdout).toBe("");
       expect(result.stderr).toContain(`${operation} operational failure`);
       expect(readArguments(fixture.argumentsLog)).toHaveLength(
-        operation === "rev-parse" ? 1 : 2,
+        operation === "rev-parse" ? 1 : expectedGitCommandCount,
       );
     });
   }
+}
 
+function registerInvalidPathTests(): void {
   for (const invalidPath of [
     {
-      label: "truncated",
-      environment: { CODEGRAPH_TEST_GIT_FILES: "truncated.tofu" },
       diagnostic: "NUL-terminated",
+      environment: { CODEGRAPH_TEST_GIT_FILES: "truncated.tofu" },
+      label: "truncated",
     },
     {
-      label: "escaping",
+      diagnostic: "outside repository",
       environment: {
         CODEGRAPH_TEST_GIT_FILES_JSON: '["../escaping.tofu"]',
       },
-      diagnostic: "outside repository",
+      label: "escaping",
     },
-  ] satisfies Array<{
+  ] satisfies {
     label: string;
     environment: Record<string, string>;
     diagnostic: string;
-  }>) {
+  }[]) {
     test(`rejects ${invalidPath.label} Git paths before Tokei runs`, () => {
       const fixture = createFixture();
       const result = runEntryPoint(fixture.repository, {
@@ -57,13 +72,17 @@ describe("codegraph-repository-size failures", () => {
         ...invalidPath.environment,
       });
 
-      expect(result.exitCode).toBe(2);
+      expect(result.exitCode).toBe(measurementErrorExitCode);
       expect(result.stdout).toBe("");
       expect(result.stderr).toContain(invalidPath.diagnostic);
-      expect(readArguments(fixture.argumentsLog)).toHaveLength(2);
+      expect(readArguments(fixture.argumentsLog)).toHaveLength(
+        expectedGitCommandCount,
+      );
     });
   }
+}
 
+function registerInvalidOutputTests(): void {
   test("fails closed when Tokei emits partial output and fails", () => {
     const fixture = createFixture();
     const result = runEntryPoint(fixture.repository, {
@@ -71,7 +90,7 @@ describe("codegraph-repository-size failures", () => {
       CODEGRAPH_TEST_TOKEI_FAILURE: "7",
     });
 
-    expect(result.exitCode).toBe(7);
+    expect(result.exitCode).toBe(operationalFailureExitCode);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("tokei operational failure");
   });
@@ -81,16 +100,20 @@ describe("codegraph-repository-size failures", () => {
     const result = runEntryPoint(fixture.repository, {
       ...fixture.environment,
       CODEGRAPH_GIT_BIN: fixture.fakeGit,
-      CODEGRAPH_TEST_GIT_REPOSITORY: "1",
       CODEGRAPH_TEST_GIT_INVALID_UTF8: "1",
+      CODEGRAPH_TEST_GIT_REPOSITORY: "1",
     });
 
-    expect(result.exitCode).toBe(2);
+    expect(result.exitCode).toBe(measurementErrorExitCode);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("invalid UTF-8");
-    expect(readArguments(fixture.argumentsLog)).toHaveLength(2);
+    expect(readArguments(fixture.argumentsLog)).toHaveLength(
+      expectedGitCommandCount,
+    );
   });
+}
 
+function registerDependencyTests(): void {
   test("rejects invalid UTF-8 from Tokei without publishing a measurement", () => {
     const fixture = createFixture();
     const result = runEntryPoint(fixture.repository, {
@@ -98,7 +121,7 @@ describe("codegraph-repository-size failures", () => {
       CODEGRAPH_TEST_TOKEI_INVALID_UTF8: "1",
     });
 
-    expect(result.exitCode).toBe(2);
+    expect(result.exitCode).toBe(measurementErrorExitCode);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("invalid UTF-8");
   });
@@ -116,12 +139,14 @@ describe("codegraph-repository-size failures", () => {
         ...fixture.environment,
         ...environment,
       });
-      expect(result.exitCode).toBe(2);
+      expect(result.exitCode).toBe(measurementErrorExitCode);
       expect(result.stdout).toBe("");
       expect(result.stderr).toContain(`${name} is required`);
     }
   });
+}
 
+function registerRepositoryTests(): void {
   test("rejects missing, non-directory, and unreadable repositories", () => {
     const fixture = createFixture();
     const file = join(fixture.directory, "file");
@@ -136,12 +161,12 @@ describe("codegraph-repository-size failures", () => {
         unreadable,
       ]) {
         const result = runEntryPoint(path, fixture.environment);
-        expect(result.exitCode).toBe(2);
+        expect(result.exitCode).toBe(measurementErrorExitCode);
         expect(result.stdout).toBe("");
         expect(result.stderr).toContain("repository");
       }
     } finally {
-      chmodSync(unreadable, 0o700);
+      chmodSync(unreadable, restoredDirectoryMode);
     }
   });
 
@@ -152,9 +177,9 @@ describe("codegraph-repository-size failures", () => {
         ...fixture.environment,
         CODEGRAPH_TEST_TOKEI_OUTPUT: output,
       });
-      expect(result.exitCode).toBe(2);
+      expect(result.exitCode).toBe(measurementErrorExitCode);
       expect(result.stdout).toBe("");
       expect(result.stderr).toContain("invalid Tokei");
     }
   });
-});
+}

--- a/tooling/codegraph-repository-size-test-provider.ts
+++ b/tooling/codegraph-repository-size-test-provider.ts
@@ -1,20 +1,28 @@
 #!/usr/bin/env bun
 
 import { appendFileSync, lstatSync } from "node:fs";
+import { z } from "zod";
 
-const arguments_ = process.argv.slice(2);
+const filesSchema = z.array(z.string());
+const commandArgumentOffset = 2;
+const invalidByte = 0xff;
+const lineFeedByte = 0x0a;
+const gitFailureExitCode = 7;
+const gitNotRepositoryExitCode = 128;
+
+const providerArguments = process.argv.slice(commandArgumentOffset);
 const logPath = process.env.CODEGRAPH_TEST_ARGUMENTS_LOG;
 if (logPath !== undefined) {
-  appendFileSync(logPath, `${JSON.stringify(arguments_)}\n`);
+  appendFileSync(logPath, `${JSON.stringify(providerArguments)}\n`);
 }
 
-if (arguments_.includes("rev-parse")) {
+if (providerArguments.includes("rev-parse")) {
   finishGit("rev-parse", "true\n");
 }
 
-if (arguments_.includes("ls-files")) {
+if (providerArguments.includes("ls-files")) {
   if (process.env.CODEGRAPH_TEST_GIT_INVALID_UTF8 === "1") {
-    process.stdout.write(new Uint8Array([0xff, 0]));
+    process.stdout.write(new Uint8Array([invalidByte, 0]));
     process.exit(0);
   }
   const files = process.env.CODEGRAPH_TEST_GIT_FILES_JSON;
@@ -22,22 +30,26 @@ if (arguments_.includes("ls-files")) {
     "ls-files",
     files === undefined
       ? (process.env.CODEGRAPH_TEST_GIT_FILES ?? "")
-      : `${(JSON.parse(files) as string[]).join("\0")}\0`,
+      : `${filesSchema.parse(JSON.parse(files)).join("\0")}\0`,
   );
 }
 
 const failure = process.env.CODEGRAPH_TEST_TOKEI_FAILURE;
 if (failure !== undefined) {
   process.stdout.write('{"partial":true}\n');
-  console.error("tokei operational failure");
+  process.stderr.write("tokei operational failure\n");
   process.exit(Number(failure));
 }
 
-const streamingIndex = arguments_.indexOf("--streaming");
-const inputs = streamingIndex === -1 ? [] : arguments_.slice(0, streamingIndex);
-if (arguments_[0] !== undefined && lstatSync(arguments_[0]).isDirectory()) {
+const streamingIndex = providerArguments.indexOf("--streaming");
+const inputs =
+  streamingIndex === -1 ? [] : providerArguments.slice(0, streamingIndex);
+if (
+  providerArguments[0] !== undefined &&
+  lstatSync(providerArguments[0]).isDirectory()
+) {
   if (process.env.CODEGRAPH_TEST_TOKEI_INVALID_UTF8 === "1") {
-    process.stdout.write(new Uint8Array([0xff, 0x0a]));
+    process.stdout.write(new Uint8Array([invalidByte, lineFeedByte]));
     process.exit(0);
   }
   process.stdout.write(process.env.CODEGRAPH_TEST_TOKEI_OUTPUT ?? "");
@@ -51,15 +63,15 @@ for (const input of inputs) {
 function finishGit(operation: string, output: string): never {
   if (process.env.CODEGRAPH_TEST_GIT_FAILURE === operation) {
     process.stdout.write(operation === "ls-files" ? "partial.tofu\0" : "");
-    console.error(`${operation} operational failure`);
-    process.exit(7);
+    process.stderr.write(`${operation} operational failure\n`);
+    process.exit(gitFailureExitCode);
   }
   if (
     operation === "rev-parse" &&
     process.env.CODEGRAPH_TEST_GIT_REPOSITORY !== "1"
   ) {
-    console.error("fatal: not a git repository (or any parent): .git");
-    process.exit(128);
+    process.stderr.write("fatal: not a git repository (or any parent): .git\n");
+    process.exit(gitNotRepositoryExitCode);
   }
   process.stdout.write(output);
   process.exit(0);

--- a/tooling/codegraph-repository-size-test-support.ts
+++ b/tooling/codegraph-repository-size-test-support.ts
@@ -5,8 +5,11 @@ import {
   rmSync,
   symlinkSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { z } from "zod";
+
+const argumentsSchema = z.array(z.string());
 
 const root = dirname(import.meta.dir);
 const entryPoint = join(import.meta.dir, "codegraph-repository-size");
@@ -15,8 +18,23 @@ const provider = join(
   "codegraph-repository-size-test-provider.ts",
 );
 const temporaryDirectories: string[] = [];
+const executableFileMode = 0o755;
 
-export function createFixture() {
+interface CommandResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+interface Fixture {
+  argumentsLog: string;
+  directory: string;
+  environment: NodeJS.ProcessEnv;
+  fakeGit: string;
+  fakeTokei: string;
+  repository: string;
+}
+
+function createFixture(): Fixture {
   const directory = join(
     tmpdir(),
     `codegraph-repository-size-${crypto.randomUUID()}`,
@@ -27,72 +45,74 @@ export function createFixture() {
   temporaryDirectories.push(directory);
   mkdirSync(repository, { recursive: true });
   mkdirSync(binaries, { recursive: true });
-  chmodSync(provider, 0o755);
+  chmodSync(provider, executableFileMode);
   symlinkSync(process.execPath, join(binaries, "bun"));
   symlinkSync(provider, join(binaries, "tokei"));
   symlinkSync(provider, join(binaries, "git"));
   return {
-    directory,
-    repository,
     argumentsLog,
-    fakeGit: join(binaries, "git"),
-    fakeTokei: join(binaries, "tokei"),
+    directory,
     environment: {
       ...process.env,
-      CODEGRAPH_TOKEI_BIN: join(binaries, "tokei"),
       CODEGRAPH_GIT_BIN: Bun.which("git") ?? "git",
       CODEGRAPH_TEST_ARGUMENTS_LOG: argumentsLog,
+      CODEGRAPH_TOKEI_BIN: join(binaries, "tokei"),
       PATH: `${binaries}:${process.env.PATH ?? ""}`,
     },
+    fakeGit: join(binaries, "git"),
+    fakeTokei: join(binaries, "tokei"),
+    repository,
   };
 }
 
-export function runEntryPoint(
+function runEntryPoint(
   repository: string,
-  environment: Record<string, string | undefined>,
-) {
+  environment: Readonly<Record<string, string | undefined>>,
+): CommandResult {
   const result = Bun.spawnSync([entryPoint, repository], {
     cwd: root,
     env: environment,
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   });
   return {
     exitCode: result.exitCode,
-    stdout: result.stdout.toString(),
     stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
   };
 }
 
-export function run(command: string[], cwd?: string) {
+function run(command: readonly string[], cwd?: string): CommandResult {
   const options = {
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   } as const;
   const result = Bun.spawnSync(
-    command,
+    [...command],
     cwd === undefined ? options : { ...options, cwd },
   );
   return {
     exitCode: result.exitCode,
-    stdout: result.stdout.toString(),
     stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
   };
 }
 
-export function readArguments(path: string): string[][] {
+function readArguments(path: string): string[][] {
   try {
     return readFileSync(path, "utf8")
       .trimEnd()
       .split("\n")
-      .map((line) => JSON.parse(line) as string[]);
+      .map((line) => argumentsSchema.parse(JSON.parse(line)));
   } catch {
     return [];
   }
 }
 
-export function cleanupFixtures(): void {
+function cleanupFixtures(): void {
   for (const path of temporaryDirectories.splice(0)) {
     rmSync(path, { force: true, recursive: true });
   }
 }
+
+export { cleanupFixtures, createFixture, readArguments, run, runEntryPoint };

--- a/tooling/codegraph-repository-size.test.ts
+++ b/tooling/codegraph-repository-size.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
 import {
   cleanupFixtures,
   createFixture,
@@ -8,31 +6,48 @@ import {
   run,
   runEntryPoint,
 } from "./codegraph-repository-size-test-support.ts";
+import { dirname, join } from "node:path";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { z } from "zod";
+
+const measurementSchema = z.object({ files: z.number() });
+const fixtureSourceLines = 12;
 
 afterEach(cleanupFixtures);
 
 describe("codegraph-repository-size entry point", () => {
+  registerMeasurementTests();
+  registerGitSelectionTest();
+  registerFilesystemSelectionTest();
+  registerNonGitSelectionTest();
+  registerRealTokeiTest();
+  registerDeploymentTest();
+});
+
+function registerMeasurementTests(): void {
   test("reports an empty non-Git repository without initialization", () => {
     const fixture = createFixture();
 
     expect(runEntryPoint(fixture.repository, fixture.environment)).toEqual({
       exitCode: 0,
-      stdout: '{"loc":0,"files":0,"initialize":false}\n',
       stderr: "",
+      stdout: '{"loc":0,"files":0,"initialize":false}\n',
     });
   });
+}
 
+function registerGitSelectionTest(): void {
   test("publishes the stable schema and forwards the preserved Tokei policy", () => {
     const fixture = createFixture();
     const result = runEntryPoint(fixture.repository, {
       ...fixture.environment,
-      CODEGRAPH_TEST_TOKEI_OUTPUT: record("src/fixture.ts", 12),
+      CODEGRAPH_TEST_TOKEI_OUTPUT: record("src/fixture.ts", fixtureSourceLines),
     });
 
     expect(result).toEqual({
       exitCode: 0,
-      stdout: '{"loc":12,"files":1,"initialize":false}\n',
       stderr: "",
+      stdout: `{"loc":${fixtureSourceLines},"files":1,"initialize":false}\n`,
     });
     const [arguments_] = readArguments(fixture.argumentsLog);
     expect(arguments_).toContain("--hidden");
@@ -43,7 +58,9 @@ describe("codegraph-repository-size entry point", () => {
     expect(arguments_?.join(" ")).toContain("TypeScript");
     expect(arguments_?.join(" ")).toContain("Razor");
   });
+}
 
+function registerFilesystemSelectionTest(): void {
   test("selects only eligible OpenTofu files in a Git repository", () => {
     const fixture = createFixture();
     mkdirSync(join(fixture.repository, "src"));
@@ -79,18 +96,21 @@ describe("codegraph-repository-size entry point", () => {
 
     expect(result.exitCode).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
-      loc: 1,
       files: 1,
       initialize: false,
+      loc: 1,
     });
-    const tofuCall = readArguments(fixture.argumentsLog).find((arguments_) =>
-      arguments_.some((argument) => argument.endsWith(".tf")),
+    const tofuCall = readArguments(fixture.argumentsLog).find(
+      (arguments_: readonly string[]) =>
+        arguments_.some((argument) => argument.endsWith(".tf")),
     );
     expect(
       tofuCall?.filter((argument) => argument.endsWith(".tf")),
     ).toHaveLength(1);
   });
+}
 
+function registerNonGitSelectionTest(): void {
   test("selects OpenTofu files without Git and ignores symlinks and excluded trees", () => {
     const fixture = createFixture();
     mkdirSync(join(fixture.repository, "src"));
@@ -107,57 +127,57 @@ describe("codegraph-repository-size entry point", () => {
     const result = runEntryPoint(fixture.repository, fixture.environment);
 
     expect(result.exitCode).toBe(0);
-    expect(JSON.parse(result.stdout).files).toBe(1);
+    expect(measurementSchema.parse(JSON.parse(result.stdout)).files).toBe(1);
   });
+}
 
+function registerRealTokeiTest(): void {
   test.skipIf(Bun.which("tokei") === null)(
     "matches real Tokei exclusions and supported extensions",
     () => {
       const fixture = createFixture();
-      mkdirSync(join(fixture.repository, "src"));
-      mkdirSync(join(fixture.repository, "docs"));
-      mkdirSync(join(fixture.repository, "ignored"));
-      writeFileSync(join(fixture.repository, ".gitignore"), "ignored/\n");
-      writeFileSync(
-        join(fixture.repository, "src", "kept.ts"),
-        "const kept = 1;\n",
-      );
-      writeFileSync(
-        join(fixture.repository, "src", "kept.cjs"),
-        "exports.kept = 1;\n",
-      );
-      writeFileSync(
-        join(fixture.repository, "src", "kept.tofu"),
-        'resource "fixture" "kept" {}\n',
-      );
-      writeFileSync(
-        join(fixture.repository, "src", "excluded.hcl"),
-        "kept = true\n",
-      );
-      writeFileSync(
-        join(fixture.repository, "docs", "excluded.ts"),
-        "const docs = 1;\n",
-      );
-      writeFileSync(
-        join(fixture.repository, "ignored", "excluded.ts"),
-        "const ignored = 1;\n",
-      );
+      populateRealTokeiFixture(fixture.repository);
       expect(run(["git", "init", "-q"], fixture.repository).exitCode).toBe(0);
 
+      const tokeiBinary = Bun.which("tokei");
+      if (tokeiBinary === null) {
+        throw new Error("tokei is required");
+      }
       const result = runEntryPoint(fixture.repository, {
         ...fixture.environment,
-        CODEGRAPH_TOKEI_BIN: Bun.which("tokei")!,
+        CODEGRAPH_TOKEI_BIN: tokeiBinary,
       });
 
       expect(result.exitCode).toBe(0);
       expect(JSON.parse(result.stdout)).toEqual({
-        loc: 3,
         files: 3,
         initialize: false,
+        loc: 3,
       });
     },
   );
+}
 
+function populateRealTokeiFixture(repository: string): void {
+  mkdirSync(join(repository, "src"));
+  mkdirSync(join(repository, "docs"));
+  mkdirSync(join(repository, "ignored"));
+  writeFileSync(join(repository, ".gitignore"), "ignored/\n");
+  writeFileSync(join(repository, "src", "kept.ts"), "const kept = 1;\n");
+  writeFileSync(join(repository, "src", "kept.cjs"), "exports.kept = 1;\n");
+  writeFileSync(
+    join(repository, "src", "kept.tofu"),
+    'resource "fixture" "kept" {}\n',
+  );
+  writeFileSync(join(repository, "src", "excluded.hcl"), "kept = true\n");
+  writeFileSync(join(repository, "docs", "excluded.ts"), "const docs = 1;\n");
+  writeFileSync(
+    join(repository, "ignored", "excluded.ts"),
+    "const ignored = 1;\n",
+  );
+}
+
+function registerDeploymentTest(): void {
   test("the Make deployment preserves the command name and provisions dependencies", () => {
     const fixture = createFixture();
     const root = dirname(import.meta.dir);
@@ -178,7 +198,7 @@ describe("codegraph-repository-size entry point", () => {
     expect(result.stdout).toContain("tooling/codegraph-repository-size");
     expect(result.stdout).toContain("codegraph-repository-size");
   });
-});
+}
 
 function record(name: string, code: number): string {
   return `${JSON.stringify({ stats: { name, stats: { code } } })}\n`;

--- a/tooling/codegraph-repository-size.ts
+++ b/tooling/codegraph-repository-size.ts
@@ -1,4 +1,11 @@
 import {
+  MeasurementError,
+  type RepositoryMeasurement,
+  type SourceMeasurement,
+  aggregateMeasurements,
+  parseTokeiOutput,
+} from "./codegraph-repository-measurement.ts";
+import {
   accessSync,
   constants,
   lstatSync,
@@ -7,18 +14,12 @@ import {
   rmSync,
   symlinkSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import {
   gitOpenTofuFiles,
   nonGitOpenTofuFiles,
 } from "./codegraph-repository-files.ts";
-import {
-  aggregateMeasurements,
-  MeasurementError,
-  parseTokeiOutput,
-  type SourceMeasurement,
-} from "./codegraph-repository-measurement.ts";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 const types =
   "Ark TypeScript,Astro,C,C Header,C#,COBOL,ColdFusion,ColdFusion CFScript,C++,C++ Header,C++ Module,CUDA,Dart,Erlang,Go,HCL,Java,JavaScript,JSX,Kotlin,Liquid,Lua,Metal Shading Language,Nix,Objective-C,Objective-C++,Pascal,PHP,Python,R,Razor,Ruby,Rust,Scala,Solidity,Svelte,Swift,TSX,TypeScript,Visual Basic,Vue";
@@ -39,19 +40,30 @@ const exclusions = [
   "*.lock",
   "*.min.js",
 ];
+const commandArgumentOffset = 2;
+const gitNotRepositoryExitCode = 128;
+const tokeiBatchSize = 200;
 
-export function main(arguments_: string[] = process.argv.slice(2)): number {
+interface CommandResult {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+function main(
+  arguments_: readonly string[] = process.argv.slice(commandArgumentOffset),
+): number {
   try {
     const measurement = measureRepository(arguments_[0] ?? ".");
     process.stdout.write(`${JSON.stringify(measurement)}\n`);
     return 0;
   } catch (error) {
-    console.error(message(error));
+    process.stderr.write(`${message(error)}\n`);
     return error instanceof MeasurementError ? error.exitCode : 1;
   }
 }
 
-function measureRepository(input: string) {
+function measureRepository(input: string): RepositoryMeasurement {
   const tokei = requireExecutable(
     process.env.CODEGRAPH_TOKEI_BIN ?? "tokei",
     "Tokei",
@@ -70,14 +82,7 @@ function measureRepository(input: string) {
 }
 
 function resolveRepository(input: string): string {
-  let repository: string;
-  try {
-    repository = realpathSync.native(input);
-  } catch (error) {
-    throw new MeasurementError(
-      `repository is not accessible: ${message(error)}`,
-    );
-  }
+  const repository = resolveAccessiblePath(input);
   if (!lstatSync(repository).isDirectory()) {
     throw new MeasurementError(`repository is not a directory: ${repository}`);
   }
@@ -87,6 +92,16 @@ function resolveRepository(input: string): string {
     throw new MeasurementError(`repository is not readable: ${repository}`);
   }
   return repository;
+}
+
+function resolveAccessiblePath(input: string): string {
+  try {
+    return realpathSync.native(input);
+  } catch (error) {
+    throw new MeasurementError(
+      `repository is not accessible: ${message(error)}`,
+    );
+  }
 }
 
 function isGitRepository(git: string, repository: string): boolean {
@@ -105,7 +120,7 @@ function isGitRepository(git: string, repository: string): boolean {
     return true;
   }
   if (
-    result.exitCode === 128 &&
+    result.exitCode === gitNotRepositoryExitCode &&
     result.stderr.startsWith("fatal: not a git repository")
   ) {
     return false;
@@ -129,7 +144,10 @@ function listGitFiles(git: string, repository: string): string {
   return result.stdout;
 }
 
-function measureOpenTofu(tokei: string, files: string[]): SourceMeasurement[] {
+function measureOpenTofu(
+  tokei: string,
+  files: readonly string[],
+): SourceMeasurement[] {
   if (files.length === 0) {
     return [];
   }
@@ -140,7 +158,7 @@ function measureOpenTofu(tokei: string, files: string[]): SourceMeasurement[] {
       symlinkSync(file, link);
       return link;
     });
-    return chunk(links, 200).flatMap((batch) =>
+    return chunk(links, tokeiBatchSize).flatMap((batch: readonly string[]) =>
       runTokei(tokei, [...batch, "--streaming", "json", "--types", "HCL"]),
     );
   } finally {
@@ -159,7 +177,10 @@ function tokeiArguments(): string[] {
   ];
 }
 
-function runTokei(tokei: string, arguments_: string[]): SourceMeasurement[] {
+function runTokei(
+  tokei: string,
+  arguments_: readonly string[],
+): SourceMeasurement[] {
   const result = runCommand(tokei, arguments_);
   if (result.exitCode !== 0) {
     throw commandError(result);
@@ -172,24 +193,27 @@ function runTokei(tokei: string, arguments_: string[]): SourceMeasurement[] {
 
 function runCommand(
   binary: string,
-  arguments_: string[],
-  environment: Record<string, string | undefined> = process.env,
-) {
+  arguments_: readonly string[],
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): CommandResult {
   const result = Bun.spawnSync([binary, ...arguments_], {
     env: environment,
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   });
   return {
     exitCode: result.exitCode,
-    stdout: result.exitCode === 0 ? decodeStandardOutput(result.stdout) : "",
     stderr: result.stderr.toString(),
+    stdout:
+      result.exitCode === 0 ? decodeStandardOutput([...result.stdout]) : "",
   };
 }
 
-function decodeStandardOutput(output: Uint8Array): string {
+function decodeStandardOutput(output: readonly number[]): string {
   try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(output);
+    return new TextDecoder("utf-8", { fatal: true }).decode(
+      Uint8Array.from(output),
+    );
   } catch {
     throw new MeasurementError("command stdout contains invalid UTF-8");
   }
@@ -212,12 +236,15 @@ function requireExecutable(binary: string, name: string): string {
   return found ?? binary;
 }
 
-function chunk<T>(values: T[], size: number): T[][] {
-  return Array.from({ length: Math.ceil(values.length / size) }, (_, index) =>
-    values.slice(index * size, (index + 1) * size),
+function chunk<Value>(values: readonly Value[], size: number): Value[][] {
+  return Array.from(
+    { length: Math.ceil(values.length / size) },
+    (_unusedValue, index) => values.slice(index * size, (index + 1) * size),
   );
 }
 
 function message(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+export { main };

--- a/tooling/codegraph/fixtures/freshness/src/branch.ts
+++ b/tooling/codegraph/fixtures/freshness/src/branch.ts
@@ -1,2 +1,4 @@
-export const branchMainValue = 3;
-export const branchSentinel = "FIXTURE_BRANCH_MAIN";
+const branchMainValue = 3;
+const branchSentinel = "FIXTURE_BRANCH_MAIN";
+
+export { branchMainValue, branchSentinel };

--- a/tooling/codegraph/fixtures/freshness/src/live.ts
+++ b/tooling/codegraph/fixtures/freshness/src/live.ts
@@ -1,2 +1,4 @@
-export const liveValue = 1;
-export const liveSentinel = "FIXTURE_LIVE_V1";
+const liveSentinel = "FIXTURE_LIVE_V1";
+const liveValue = 1;
+
+export { liveSentinel, liveValue };

--- a/tooling/codegraph/fixtures/freshness/src/removable.ts
+++ b/tooling/codegraph/fixtures/freshness/src/removable.ts
@@ -1,2 +1,4 @@
-export const removableValue = 2;
-export const removableSentinel = "FIXTURE_REMOVABLE";
+const removableSentinel = "FIXTURE_REMOVABLE";
+const removableValue = 2;
+
+export { removableSentinel, removableValue };

--- a/tooling/codegraph/integration-fixture.ts
+++ b/tooling/codegraph/integration-fixture.ts
@@ -6,48 +6,55 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { z } from "zod";
 
-export type Command = readonly [string, ...string[]];
+type Command = readonly [string, ...string[]];
 
-export type FreshnessFixture = Readonly<{
+type FreshnessFixture = Readonly<{
   root: string;
   repository: string;
 }>;
 
-export const privacyEnvironment: NodeJS.ProcessEnv = {
+type RunCommandOptions = Readonly<{
+  cwd: string;
+  environment?: Readonly<NodeJS.ProcessEnv>;
+}>;
+
+type OperationOutcome<Result> =
+  | Readonly<{ ok: true; value: Result }>
+  | Readonly<{ error: unknown; ok: false }>;
+
+const privacyEnvironment: NodeJS.ProcessEnv = {
   ...process.env,
-  CODEGRAPH_TELEMETRY: "0",
-  CODEGRAPH_NO_UPDATE_CHECK: "1",
-  CODEGRAPH_NO_DOWNLOAD: "1",
   CODEGRAPH_DAEMON_IDLE_TIMEOUT_MS: "500",
+  CODEGRAPH_NO_DOWNLOAD: "1",
+  CODEGRAPH_NO_UPDATE_CHECK: "1",
+  CODEGRAPH_TELEMETRY: "0",
 };
 
 const decoder = new TextDecoder("utf-8", { fatal: true });
 const daemonSchema = z.object({ pid: z.number().int().positive() });
+const daemonStopAttemptLimit = 30;
+const daemonStopPollMilliseconds = 100;
 
-export function runCommand(
+function runCommand(
   command: Command,
   arguments_: readonly string[],
-  cwd: string,
-  environment: NodeJS.ProcessEnv = privacyEnvironment,
+  { cwd, environment = privacyEnvironment }: RunCommandOptions,
 ): string {
   const result = Bun.spawnSync([...command, ...arguments_], {
     cwd,
     env: environment,
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   });
-  let stdout: string;
-  let stderr: string;
-  try {
-    stdout = decoder.decode(result.stdout);
-    stderr = decoder.decode(result.stderr);
-  } catch {
-    throw new Error(`${command[0]} returned invalid UTF-8`);
-  }
+  const { stderr, stdout } = decodeCommandOutput(
+    [...result.stdout],
+    [...result.stderr],
+    command,
+  );
   if (result.exitCode !== 0) {
     throw new Error(
       `${[...command, ...arguments_].join(" ")} failed (${result.exitCode}): ${stderr}`,
@@ -56,14 +63,30 @@ export function runCommand(
   return stdout;
 }
 
-export function createFreshnessFixture(
-  fixtureSource: string,
-): FreshnessFixture {
+function decodeCommandOutput(
+  stdoutBytes: readonly number[],
+  stderrBytes: readonly number[],
+  command: Command,
+): Readonly<{ stderr: string; stdout: string }> {
+  try {
+    return {
+      stderr: decoder.decode(Uint8Array.from(stderrBytes)),
+      stdout: decoder.decode(Uint8Array.from(stdoutBytes)),
+    };
+  } catch {
+    throw new Error(`${command[0]} returned invalid UTF-8`);
+  }
+}
+
+function createFreshnessFixture(fixtureSource: string): FreshnessFixture {
   const root = mkdtempSync(join(tmpdir(), "codegraph-integration-"));
   const repository = join(root, "repository");
   cpSync(fixtureSource, repository, { recursive: true });
-  const git = (arguments_: readonly string[]) =>
-    runCommand(["git"], arguments_, repository, process.env);
+  const git = (arguments_: readonly string[]): string =>
+    runCommand(["git"], arguments_, {
+      cwd: repository,
+      environment: process.env,
+    });
   git(["init", "-b", "main"]);
   git(["config", "user.email", "codegraph-fixture@example.invalid"]);
   git(["config", "user.name", "CodeGraph Fixture"]);
@@ -77,43 +100,64 @@ export function createFreshnessFixture(
   git(["add", "src/branch.ts"]);
   git(["commit", "-m", "alternate"]);
   git(["switch", "main"]);
-  return { root, repository };
+  return { repository, root };
 }
 
-export async function cleanupFreshnessFixture(
+async function cleanupFreshnessFixture(
   fixture: FreshnessFixture,
   codegraph: Command,
 ): Promise<void> {
-  let cleanupError: Error | undefined;
-  try {
-    runCommand(
-      codegraph,
-      ["uninit", "--force", fixture.repository],
-      fixture.repository,
-    );
-    if (existsSync(join(fixture.repository, ".codegraph"))) {
-      cleanupError = new Error("CodeGraph index remains after uninit");
-      await stopRecordedDaemon(fixture.repository);
-    }
-  } catch (error) {
-    cleanupError = error instanceof Error ? error : new Error(String(error));
-    await stopRecordedDaemon(fixture.repository);
-  } finally {
-    rmSync(fixture.root, { recursive: true, force: true });
-  }
+  const outcome = await captureOperation(() =>
+    uninitializeFreshnessFixture(fixture, codegraph),
+  );
+  rmSync(fixture.root, { force: true, recursive: true });
+  const cleanupError = outcome.ok ? outcome.value : asError(outcome.error);
   if (cleanupError !== undefined) {
     throw new Error(`CodeGraph cleanup failed: ${cleanupError.message}`);
   }
 }
 
-export function requireDaemonStopped(repository: string): void {
+async function uninitializeFreshnessFixture(
+  fixture: FreshnessFixture,
+  codegraph: Command,
+): Promise<Error | undefined> {
+  try {
+    runCommand(codegraph, ["uninit", "--force", fixture.repository], {
+      cwd: fixture.repository,
+    });
+    if (existsSync(join(fixture.repository, ".codegraph"))) {
+      await stopRecordedDaemon(fixture.repository);
+      return new Error("CodeGraph index remains after uninit");
+    }
+    return undefined;
+  } catch (error) {
+    await stopRecordedDaemon(fixture.repository);
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+async function captureOperation<Result>(
+  operation: () => Promise<Result>,
+): Promise<OperationOutcome<Result>> {
+  try {
+    return { ok: true, value: await operation() };
+  } catch (error) {
+    return { error, ok: false };
+  }
+}
+
+function requireDaemonStopped(repository: string): void {
   const pidFile = join(repository, ".codegraph", "daemon.pid");
-  if (!existsSync(pidFile)) return;
+  if (!existsSync(pidFile)) {
+    return;
+  }
   const { pid } = daemonSchema.parse(JSON.parse(readFileSync(pidFile, "utf8")));
   try {
     process.kill(pid, 0);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+    if (hasErrorCode(error, "ESRCH")) {
+      return;
+    }
     throw error;
   }
   throw new Error(`CodeGraph daemon still running: ${pid}`);
@@ -121,31 +165,74 @@ export function requireDaemonStopped(repository: string): void {
 
 async function stopRecordedDaemon(repository: string): Promise<void> {
   const pidFile = join(repository, ".codegraph", "daemon.pid");
-  if (!existsSync(pidFile)) return;
-  let processId: number;
-  try {
-    const parsed = JSON.parse(readFileSync(pidFile, "utf8")) as {
-      pid?: unknown;
-    };
-    if (!Number.isSafeInteger(parsed.pid) || Number(parsed.pid) <= 0) return;
-    processId = Number(parsed.pid);
-  } catch {
+  const processId = recordedProcessId(pidFile);
+  if (processId === undefined) {
     return;
   }
-  try {
-    process.kill(processId, "SIGTERM");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
-    throw error;
+  if (!signalProcess(processId, "SIGTERM")) {
+    return;
   }
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    await Bun.sleep(100);
-    try {
-      process.kill(processId, 0);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
-      throw error;
-    }
+  if (await waitForProcessExit(processId)) {
+    return;
   }
   process.kill(processId, "SIGKILL");
 }
+
+function recordedProcessId(pidFile: string): number | undefined {
+  if (!existsSync(pidFile)) {
+    return undefined;
+  }
+  try {
+    const parsed = daemonSchema.safeParse(
+      JSON.parse(readFileSync(pidFile, "utf8")),
+    );
+    return parsed.success ? parsed.data.pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function signalProcess(
+  processId: number,
+  signal: NodeJS.Signals | number,
+): boolean {
+  try {
+    process.kill(processId, signal);
+    return true;
+  } catch (error) {
+    if (hasErrorCode(error, "ESRCH")) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+async function waitForProcessExit(processId: number): Promise<boolean> {
+  for (let attempt = 0; attempt < daemonStopAttemptLimit; attempt += 1) {
+    await Bun.sleep(daemonStopPollMilliseconds);
+    if (!signalProcess(processId, 0)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return z.object({ code: z.literal(code) }).safeParse(error).success;
+}
+
+export {
+  cleanupFreshnessFixture,
+  captureOperation,
+  type Command,
+  createFreshnessFixture,
+  type FreshnessFixture,
+  privacyEnvironment,
+  requireDaemonStopped,
+  type RunCommandOptions,
+  runCommand,
+};

--- a/tooling/codegraph/mcp-client.ts
+++ b/tooling/codegraph/mcp-client.ts
@@ -1,54 +1,81 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { z } from "zod";
 
 const responseSchema = z
   .object({
-    jsonrpc: z.literal("2.0"),
-    id: z.number().int(),
-    result: z.unknown().optional(),
     error: z.unknown().optional(),
+    id: z.number().int(),
+    jsonrpc: z.literal("2.0"),
+    result: z.unknown().optional(),
   })
   .refine(
     ({ result, error }) => (result === undefined) !== (error === undefined),
   );
-
 const toolsSchema = z.object({
   tools: z.array(z.object({ name: z.string() })),
 });
-
 const callResultSchema = z.object({
-  content: z.array(z.object({ type: z.string(), text: z.string().optional() })),
+  content: z.array(z.object({ text: z.string().optional(), type: z.string() })),
   isError: z.boolean().optional(),
 });
+const byteChunkSchema = z.instanceof(Uint8Array);
 
-type PendingRequest = {
+interface PendingRequest {
   resolve: (value: unknown) => void;
-  reject: (error: Error) => void;
+  reject: (error: Readonly<Error>) => void;
   timer: ReturnType<typeof setTimeout>;
-};
+}
 
-export class McpClient {
+type McpClientOptions = Readonly<{
+  command: readonly [string, ...string[]];
+  environment: Readonly<NodeJS.ProcessEnv>;
+  repository: string;
+  requestTimeoutMilliseconds: number;
+  stopTimeoutMilliseconds: number;
+}>;
+
+class McpClient {
   private server: ChildProcessWithoutNullStreams | undefined;
   private nextId = 0;
   private readonly pending = new Map<number, PendingRequest>();
   private buffer = "";
   private stderr = "";
   private decoder = new TextDecoder("utf-8", { fatal: true });
+  private readonly command: readonly [string, ...string[]];
+  private readonly environment: Readonly<NodeJS.ProcessEnv>;
+  private readonly repository: string;
+  private readonly requestTimeoutMilliseconds: number;
+  private readonly stopTimeoutMilliseconds: number;
 
-  constructor(
-    private readonly command: readonly [string, ...string[]],
-    private readonly repository: string,
-    private readonly environment: NodeJS.ProcessEnv,
-    private readonly requestTimeoutMilliseconds: number,
-    private readonly stopTimeoutMilliseconds: number,
-  ) {}
+  public constructor(options: McpClientOptions) {
+    this.command = options.command;
+    this.environment = options.environment;
+    this.repository = options.repository;
+    this.requestTimeoutMilliseconds = options.requestTimeoutMilliseconds;
+    this.stopTimeoutMilliseconds = options.stopTimeoutMilliseconds;
+  }
 
-  async start(extraArguments: readonly string[] = []): Promise<void> {
+  public async start(extraArguments: readonly string[] = []): Promise<void> {
     this.buffer = "";
     this.stderr = "";
     this.decoder = new TextDecoder("utf-8", { fatal: true });
+    const server = this.spawnServer(extraArguments);
+    this.server = server;
+    this.observeServer();
+    await this.request("initialize", {
+      capabilities: {},
+      clientInfo: { name: "dotfiles-codegraph-probe", version: "1" },
+      protocolVersion: "2025-06-18",
+    });
+    this.notify("notifications/initialized");
+    await this.requireExpectedTools();
+  }
+
+  private spawnServer(
+    extraArguments: readonly string[],
+  ): ChildProcessWithoutNullStreams {
     const [binary, ...prefixArguments] = this.command;
-    this.server = spawn(
+    return spawn(
       binary,
       [
         ...prefixArguments,
@@ -64,12 +91,23 @@ export class McpClient {
         stdio: ["pipe", "pipe", "pipe"],
       },
     );
-    this.server.stdout.on("data", (chunk: Buffer) => this.consume(chunk));
-    this.server.stderr.on("data", (chunk: Buffer) => {
-      this.stderr += chunk.toString();
+  }
+
+  private observeServer(): void {
+    const { server } = this;
+    if (server === undefined) {
+      throw new Error("MCP server is not running");
+    }
+    server.stdout.on("data", (chunk: unknown) => {
+      this.consume([...byteChunkSchema.parse(chunk)]);
     });
-    this.server.once("error", (error) => this.rejectAll(error));
-    this.server.once("close", (status, signal) => {
+    server.stderr.on("data", (chunk: unknown) => {
+      this.stderr += Buffer.from(byteChunkSchema.parse(chunk)).toString();
+    });
+    server.once("error", (error: unknown) => {
+      this.rejectAll(error instanceof Error ? error : new Error(String(error)));
+    });
+    server.once("close", (status, signal) => {
       if (this.pending.size > 0) {
         this.rejectAll(
           new Error(
@@ -78,30 +116,26 @@ export class McpClient {
         );
       }
     });
+  }
 
-    await this.request("initialize", {
-      protocolVersion: "2025-06-18",
-      capabilities: {},
-      clientInfo: { name: "dotfiles-codegraph-probe", version: "1" },
-    });
-    this.notify("notifications/initialized");
+  private async requireExpectedTools(): Promise<void> {
     const listed = toolsSchema.parse(await this.request("tools/list"));
-    const names = listed.tools.map(({ name }) => name).sort();
+    const names = listed.tools.map(({ name }) => name).toSorted();
     if (JSON.stringify(names) !== JSON.stringify(["codegraph_explore"])) {
       throw new Error(`unexpected MCP tools: ${names.join(",")}`);
     }
   }
 
-  async explore(query: string, allowError = false): Promise<string> {
+  public async explore(query: string, allowError = false): Promise<string> {
     const result = callResultSchema.parse(
       await this.request("tools/call", {
-        name: "codegraph_explore",
         arguments: { query },
+        name: "codegraph_explore",
       }),
     );
     const text = result.content
       .filter(({ type }) => type === "text")
-      .map(({ text }) => text ?? "")
+      .map(({ text: contentText }) => contentText ?? "")
       .join("\n");
     if (result.isError === true && !allowError) {
       throw new Error(`codegraph_explore failed: ${text}`);
@@ -109,14 +143,16 @@ export class McpClient {
     return text;
   }
 
-  async stop(): Promise<void> {
-    const server = this.server;
+  public async stop(): Promise<void> {
+    const { server } = this;
     this.server = undefined;
-    if (server === undefined || server.exitCode !== null) return;
+    if (server === undefined || server.exitCode !== null) {
+      return;
+    }
     const processId = server.pid;
-    const closing = new Promise<void>((resolve) =>
-      server.once("close", resolve),
-    );
+    const closing = new Promise<void>((resolve) => {
+      server.once("close", resolve);
+    });
     server.stdin.end();
     server.kill("SIGTERM");
     const stopped = await Promise.race([
@@ -129,23 +165,25 @@ export class McpClient {
     }
   }
 
-  diagnostic(): string {
+  public diagnostic(): string {
     return this.stderr;
   }
 
   private request(method: string, params: unknown = {}): Promise<unknown> {
-    const server = this.server;
-    if (server === undefined)
+    const { server } = this;
+    if (server === undefined) {
       return Promise.reject(new Error("MCP server is not running"));
-    const id = ++this.nextId;
+    }
+    this.nextId += 1;
+    const id = this.nextId;
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
         reject(new Error(`MCP request timed out: ${method}`));
       }, this.requestTimeoutMilliseconds);
-      this.pending.set(id, { resolve, reject, timer });
+      this.pending.set(id, { reject, resolve, timer });
       server.stdin.write(
-        `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+        `${JSON.stringify({ id, jsonrpc: "2.0", method, params })}\n`,
       );
     });
   }
@@ -156,26 +194,14 @@ export class McpClient {
     );
   }
 
-  private consume(chunk: Buffer): void {
+  private consume(chunk: readonly number[]): void {
     try {
-      this.buffer += this.decoder.decode(chunk, { stream: true });
-      for (;;) {
-        const newline = this.buffer.indexOf("\n");
-        if (newline < 0) return;
-        const line = this.buffer.slice(0, newline).trim();
-        this.buffer = this.buffer.slice(newline + 1);
-        if (!line.startsWith("{")) continue;
-        const parsed = responseSchema.safeParse(JSON.parse(line));
-        if (!parsed.success) throw new Error("malformed MCP response");
-        const waiter = this.pending.get(parsed.data.id);
-        if (waiter === undefined) continue;
-        this.pending.delete(parsed.data.id);
-        clearTimeout(waiter.timer);
-        if (parsed.data.error !== undefined) {
-          waiter.reject(new Error(JSON.stringify(parsed.data.error)));
-        } else {
-          waiter.resolve(parsed.data.result);
-        }
+      this.buffer += this.decoder.decode(Uint8Array.from(chunk), {
+        stream: true,
+      });
+      let consumedLine = this.consumeNextLine();
+      while (consumedLine) {
+        consumedLine = this.consumeNextLine();
       }
     } catch (error) {
       this.rejectAll(
@@ -187,7 +213,31 @@ export class McpClient {
     }
   }
 
-  private rejectAll(error: Error): void {
+  private consumeNextLine(): boolean {
+    const newline = this.buffer.indexOf("\n");
+    if (newline === -1) {
+      return false;
+    }
+    const line = this.buffer.slice(0, newline).trim();
+    this.buffer = this.buffer.slice(newline + 1);
+    if (!line.startsWith("{")) {
+      return true;
+    }
+    const parsed = responseSchema.safeParse(JSON.parse(line));
+    if (!parsed.success) {
+      throw new Error("malformed MCP response");
+    }
+    const waiter = this.pending.get(parsed.data.id);
+    if (waiter === undefined) {
+      return true;
+    }
+    this.pending.delete(parsed.data.id);
+    clearTimeout(waiter.timer);
+    settleRequest(waiter, parsed.data);
+    return true;
+  }
+
+  private rejectAll(error: Readonly<Error>): void {
     for (const waiter of this.pending.values()) {
       clearTimeout(waiter.timer);
       waiter.reject(error);
@@ -196,6 +246,21 @@ export class McpClient {
   }
 }
 
-export function delay(milliseconds: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+function settleRequest(
+  waiter: Readonly<Pick<PendingRequest, "reject" | "resolve">>,
+  response: Readonly<{ error?: unknown; result?: unknown }>,
+): void {
+  if (response.error === undefined) {
+    waiter.resolve(response.result);
+    return;
+  }
+  waiter.reject(new Error(JSON.stringify(response.error)));
 }
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+export { delay, McpClient };

--- a/tooling/codegraph/mcp-probe-report.ts
+++ b/tooling/codegraph/mcp-probe-report.ts
@@ -1,0 +1,10 @@
+type ScenarioValue = boolean | "fresh" | "alerted-stale";
+
+type ProbeReport = Readonly<{
+  queryLatencyMs: Readonly<Record<string, number>>;
+  scenarios: Readonly<Record<string, ScenarioValue>>;
+  synchronizationMs: number;
+  tools: readonly ["codegraph_explore"];
+}>;
+
+export { type ProbeReport };

--- a/tooling/codegraph/mcp-probe.ts
+++ b/tooling/codegraph/mcp-probe.ts
@@ -1,104 +1,157 @@
-import { readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import {
   type Command,
   privacyEnvironment,
   requireDaemonStopped,
   runCommand,
 } from "./integration-fixture.ts";
-import { delay, McpClient } from "./mcp-client.ts";
+import { McpClient, delay } from "./mcp-client.ts";
+import { readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import type { ProbeReport } from "./mcp-probe-report.ts";
+import { join } from "node:path";
+import { mcpTimeout } from "./mcp-timeout.ts";
 
-type ScenarioValue = boolean | "fresh" | "alerted-stale";
-
-export type ProbeReport = Readonly<{
-  tools: readonly ["codegraph_explore"];
-  scenarios: Readonly<Record<string, ScenarioValue>>;
-  queryLatencyMs: Readonly<Record<string, number>>;
-  synchronizationMs: number;
+type FreshnessClient = Readonly<
+  Pick<McpClient, "diagnostic" | "explore" | "start" | "stop">
+>;
+type TimingRecorder = Readonly<{
+  record: (query: string, milliseconds: number) => void;
+}>;
+type WatcherInterruptionOptions = Readonly<{
+  client: FreshnessClient;
+  codegraph: Command;
+  repository: string;
+  source: string;
+  timings: TimingRecorder;
+}>;
+type FreshnessScenarioOptions = Readonly<{
+  client: FreshnessClient;
+  codegraph: Command;
+  repository: string;
+  timings: TimingRecorder;
 }>;
 
-export async function runFreshnessProbe(
+const initialExpectation = {
+  current: ["entryValue", "liveValue", "removableValue", "branchMainValue"],
+  query:
+    "How does entryValue depend on liveValue, removableValue, and branchMainValue?",
+  stale: [],
+};
+const defaultRequestTimeoutMilliseconds = 30_000;
+const defaultStopTimeoutMilliseconds = 3000;
+const daemonShutdownDelayMilliseconds = 2000;
+const freshnessAttemptLimit = 30;
+const freshnessPollDelayMilliseconds = 300;
+
+async function runFreshnessProbe(
   repository: string,
   codegraph: Command,
 ): Promise<ProbeReport> {
-  const source = join(repository, "src");
-  const timings: Record<string, number> = {};
-  const client = new McpClient(
+  const timingValues: Record<string, number> = {};
+  const timings: TimingRecorder = {
+    record: (query, milliseconds) => {
+      timingValues[query] = milliseconds;
+    },
+  };
+  const client = createFreshnessClient(repository, codegraph);
+  const outcome = await proveFreshnessScenarios({
+    client,
     codegraph,
     repository,
-    privacyEnvironment,
-    timeout("REQUEST", 30_000),
-    timeout("STOP", 3_000),
-  );
-  let watcherInterruption: "fresh" | "alerted-stale" = "fresh";
-  let synchronizationMilliseconds = 0;
+    timings,
+  });
+  return {
+    queryLatencyMs: timingValues,
+    scenarios: {
+      branchSwitch: true,
+      daemonStopped: true,
+      delete: true,
+      edit: true,
+      initial: true,
+      reconciliation: true,
+      rename: true,
+      restart: true,
+      watcherInterruption: outcome.watcherInterruption,
+    },
+    synchronizationMs: outcome.synchronizationMilliseconds,
+    tools: ["codegraph_explore"],
+  };
+}
+
+function createFreshnessClient(
+  repository: string,
+  codegraph: Command,
+): McpClient {
+  return new McpClient({
+    command: codegraph,
+    environment: privacyEnvironment,
+    repository,
+    requestTimeoutMilliseconds: mcpTimeout(
+      "REQUEST",
+      defaultRequestTimeoutMilliseconds,
+    ),
+    stopTimeoutMilliseconds: mcpTimeout("STOP", defaultStopTimeoutMilliseconds),
+  });
+}
+
+async function proveFreshnessScenarios({
+  client,
+  codegraph,
+  repository,
+  timings,
+}: FreshnessScenarioOptions): Promise<{
+  synchronizationMilliseconds: number;
+  watcherInterruption: "fresh" | "alerted-stale";
+}> {
+  const source = join(repository, "src");
   try {
     await client.start();
     await waitFresh(client, timings, initialExpectation);
     await proveBranchSwitches(client, timings, repository);
     await proveMutations(client, timings, source);
     await restartAndProveFresh(client, timings);
-    const reconciliation = await proveWatcherInterruption(
+    const outcome = await proveWatcherInterruption({
       client,
-      timings,
+      codegraph,
       repository,
       source,
-      codegraph,
-    );
-    watcherInterruption = reconciliation.watcherInterruption;
-    synchronizationMilliseconds = reconciliation.synchronizationMilliseconds;
-    await delay(2_000);
+      timings,
+    });
+    await delay(daemonShutdownDelayMilliseconds);
     requireDaemonStopped(repository);
+    return outcome;
   } finally {
     await client.stop();
   }
-  return {
-    tools: ["codegraph_explore"],
-    scenarios: {
-      initial: true,
-      branchSwitch: true,
-      edit: true,
-      rename: true,
-      delete: true,
-      restart: true,
-      watcherInterruption,
-      reconciliation: true,
-      daemonStopped: true,
-    },
-    queryLatencyMs: timings,
-    synchronizationMs: synchronizationMilliseconds,
-  };
 }
 
-const initialExpectation = {
-  query:
-    "How does entryValue depend on liveValue, removableValue, and branchMainValue?",
-  current: ["entryValue", "liveValue", "removableValue", "branchMainValue"],
-  stale: [],
-};
-
 async function proveBranchSwitches(
-  client: McpClient,
-  timings: Record<string, number>,
+  client: FreshnessClient,
+  timings: TimingRecorder,
   repository: string,
 ): Promise<void> {
-  runCommand(["git"], ["switch", "codegraph-alt"], repository, process.env);
+  runCommand(["git"], ["switch", "codegraph-alt"], {
+    cwd: repository,
+    environment: process.env,
+  });
   await waitFresh(client, timings, {
-    query: "Where is branchAltValue defined?",
     current: ["branchAltValue", "FIXTURE_BRANCH_ALT"],
+    query: "Where is branchAltValue defined?",
     stale: ["FIXTURE_BRANCH_MAIN"],
   });
-  runCommand(["git"], ["switch", "main"], repository, process.env);
+  runCommand(["git"], ["switch", "main"], {
+    cwd: repository,
+    environment: process.env,
+  });
   await waitFresh(client, timings, {
-    query: "Where is branchMainValue defined?",
     current: ["branchMainValue", "FIXTURE_BRANCH_MAIN"],
+    query: "Where is branchMainValue defined?",
     stale: ["branchAltValue", "FIXTURE_BRANCH_ALT"],
   });
 }
 
 async function proveMutations(
-  client: McpClient,
-  timings: Record<string, number>,
+  client: FreshnessClient,
+  timings: TimingRecorder,
   source: string,
 ): Promise<void> {
   const live = join(source, "live.ts");
@@ -106,8 +159,8 @@ async function proveMutations(
   const entry = join(source, "entry.ts");
   replace(live, "FIXTURE_LIVE_V1", "FIXTURE_LIVE_V2");
   await waitFresh(client, timings, {
-    query: "Where is liveSentinel defined?",
     current: ["FIXTURE_LIVE_V2"],
+    query: "Where is liveSentinel defined?",
     stale: ["FIXTURE_LIVE_V1"],
   });
   renameSync(live, renamed);
@@ -115,42 +168,45 @@ async function proveMutations(
   replace(entry, "./live.js", "./renamed-live.js");
   replace(entry, "liveValue", "renamedLiveValue");
   await waitFresh(client, timings, {
-    query: "How does entryValue use renamedLiveValue?",
     current: ["src/renamed-live.ts", "renamedLiveValue"],
+    query: "How does entryValue use renamedLiveValue?",
     stale: ["src/live.ts", "liveValue"],
   });
   unlinkSync(join(source, "removable.ts"));
   replace(entry, 'import { removableValue } from "./removable.js";\n', "");
   replace(entry, " + removableValue", "");
   await waitFresh(client, timings, {
-    query: "How is entryValue computed?",
     current: ["entryValue", "renamedLiveValue"],
+    query: "How is entryValue computed?",
     stale: ["removableValue", "FIXTURE_REMOVABLE"],
   });
 }
 
 async function restartAndProveFresh(
-  client: McpClient,
-  timings: Record<string, number>,
+  client: FreshnessClient,
+  timings: TimingRecorder,
 ): Promise<void> {
   await client.stop();
   await client.start();
   await waitFresh(client, timings, {
-    query: "How is entryValue computed after restart?",
     current: ["entryValue", "renamedLiveValue"],
+    query: "How is entryValue computed after restart?",
     stale: ["removableValue", "liveValue"],
   });
   await client.stop();
-  await delay(2_000);
+  await delay(daemonShutdownDelayMilliseconds);
 }
 
-async function proveWatcherInterruption(
-  client: McpClient,
-  timings: Record<string, number>,
-  repository: string,
-  source: string,
-  codegraph: Command,
-) {
+async function proveWatcherInterruption({
+  client,
+  codegraph,
+  repository,
+  source,
+  timings,
+}: WatcherInterruptionOptions): Promise<{
+  synchronizationMilliseconds: number;
+  watcherInterruption: "fresh" | "alerted-stale";
+}> {
   await client.start(["--no-watch"]);
   replace(
     join(source, "branch.ts"),
@@ -160,9 +216,9 @@ async function proveWatcherInterruption(
   const query = "Where is branchSentinel defined?";
   const queryStarted = performance.now();
   const immediate = await client.explore(query, true);
-  timings[query] = Math.round(performance.now() - queryStarted);
+  timings.record(query, Math.round(performance.now() - queryStarted));
   const immediateFresh = immediate.includes("FIXTURE_WATCHER_INTERRUPTED");
-  const explicitStale = /stale|out[- ]of[- ]date|sync|refresh|reindex/i.test(
+  const explicitStale = /stale|out[- ]of[- ]date|sync|refresh|reindex/iu.test(
     immediate,
   );
   if (!immediateFresh && !explicitStale) {
@@ -172,26 +228,26 @@ async function proveWatcherInterruption(
   }
   await client.stop();
   const started = performance.now();
-  runCommand(codegraph, ["sync", repository], repository);
+  runCommand(codegraph, ["sync", repository], { cwd: repository });
   const synchronizationMilliseconds = Math.round(performance.now() - started);
   await client.start();
   await waitFresh(client, timings, {
-    query: "Where is branchSentinel defined after reconciliation?",
     current: ["FIXTURE_WATCHER_INTERRUPTED"],
+    query: "Where is branchSentinel defined after reconciliation?",
     stale: ["FIXTURE_BRANCH_MAIN"],
   });
   await client.stop();
   return {
+    synchronizationMilliseconds,
     watcherInterruption: immediateFresh
       ? ("fresh" as const)
       : ("alerted-stale" as const),
-    synchronizationMilliseconds,
   };
 }
 
 async function waitFresh(
-  client: McpClient,
-  timings: Record<string, number>,
+  client: FreshnessClient,
+  timings: TimingRecorder,
   expectation: Readonly<{
     query: string;
     current: readonly string[];
@@ -199,39 +255,45 @@ async function waitFresh(
   }>,
 ): Promise<void> {
   let last = "";
-  for (let attempt = 0; attempt < 30; attempt += 1) {
+  for (let attempt = 0; attempt < freshnessAttemptLimit; attempt += 1) {
     const started = performance.now();
     try {
       last = await client.explore(expectation.query);
-      timings[expectation.query] = Math.round(performance.now() - started);
+      timings.record(
+        expectation.query,
+        Math.round(performance.now() - started),
+      );
       if (
-        expectation.current.every((term) => last.includes(term)) &&
-        expectation.stale.every((term) => !last.includes(term))
-      )
+        includesEvery(last, expectation.current) &&
+        includesNone(last, expectation.stale)
+      ) {
         return;
+      }
     } catch (error) {
       last = String(error);
     }
-    await delay(300);
+    await delay(freshnessPollDelayMilliseconds);
   }
   throw new Error(
     `freshness timeout for ${expectation.query}: ${last}\n${client.diagnostic()}`,
   );
 }
 
+function includesEvery(value: string, terms: readonly string[]): boolean {
+  return terms.every((term) => value.includes(term));
+}
+
+function includesNone(value: string, terms: readonly string[]): boolean {
+  return terms.every((term) => !value.includes(term));
+}
+
 function replace(file: string, before: string, after: string): void {
   const current = readFileSync(file, "utf8");
-  if (!current.includes(before))
+  if (!current.includes(before)) {
     throw new Error(`missing fixture text: ${before}`);
+  }
   writeFileSync(file, current.replaceAll(before, after));
 }
 
-function timeout(name: string, fallback: number): number {
-  const value = process.env[`CODEGRAPH_MCP_${name}_TIMEOUT_MS`];
-  if (value === undefined) return fallback;
-  const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 30_000) {
-    throw new Error(`invalid MCP ${name.toLowerCase()} timeout: ${value}`);
-  }
-  return parsed;
-}
+export type { ProbeReport } from "./mcp-probe-report.ts";
+export { runFreshnessProbe };

--- a/tooling/codegraph/mcp-test-provider.ts
+++ b/tooling/codegraph/mcp-test-provider.ts
@@ -1,15 +1,22 @@
 #!/usr/bin/env bun
 
+const malformedPauseMilliseconds = 60_000;
 const scenario = process.env.CODEGRAPH_MCP_TEST_SCENARIO;
+const startupExitCode = 42;
+const usageExitCode = 64;
 
-if (scenario === "startup") process.exit(42);
-if (scenario === "timeout") await Bun.sleep(60_000);
+if (scenario === "startup") {
+  process.exit(startupExitCode);
+}
+if (scenario === "timeout") {
+  await Bun.sleep(malformedPauseMilliseconds);
+}
 if (scenario === "malformed") {
-  process.stdin.once("data", () =>
-    process.stdout.write('{"jsonrpc":"2.0","id":1,"result":\n'),
-  );
-  await Bun.sleep(60_000);
+  process.stdin.once("data", () => {
+    process.stdout.write('{"jsonrpc":"2.0","id":1,"result":\n');
+  });
+  await Bun.sleep(malformedPauseMilliseconds);
 }
 
 process.stderr.write(`unknown MCP test scenario: ${scenario ?? "missing"}\n`);
-process.exit(64);
+process.exit(usageExitCode);

--- a/tooling/codegraph/mcp-timeout.ts
+++ b/tooling/codegraph/mcp-timeout.ts
@@ -1,0 +1,19 @@
+const maximumTimeoutMilliseconds = 30_000;
+
+function mcpTimeout(name: string, fallback: number): number {
+  const value = process.env[`CODEGRAPH_MCP_${name}_TIMEOUT_MS`];
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > maximumTimeoutMilliseconds
+  ) {
+    throw new Error(`invalid MCP ${name.toLowerCase()} timeout: ${value}`);
+  }
+  return parsed;
+}
+
+export { mcpTimeout };

--- a/tooling/codegraph/network-audit.ts
+++ b/tooling/codegraph/network-audit.ts
@@ -1,94 +1,171 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { spawn } from "node:child_process";
-import { z } from "zod";
 import type { Command } from "./integration-fixture.ts";
 import { delay } from "./mcp-client.ts";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { z } from "zod";
 
 const daemonSchema = z.object({ pid: z.number().int().positive() });
 const decoder = new TextDecoder("utf-8", { fatal: true });
+const defaultTimeoutMilliseconds = 120_000;
+const sampleIntervalMilliseconds = 50;
+const samplePending = Symbol("sample pending");
+const byteChunkSchema = z.instanceof(Uint8Array);
 
-export class NetworkViolation extends Error {
-  constructor(readonly sockets: string) {
+class NetworkViolationError extends Error {
+  public override readonly name = "NetworkViolationError";
+
+  public constructor(public readonly sockets: string) {
     super("network sockets observed");
   }
 }
 
-export async function auditProcessNetwork(
+type NetworkAuditOptions = Readonly<{
+  environment: Readonly<NodeJS.ProcessEnv>;
+  repository: string | undefined;
+  timeoutMilliseconds?: number;
+}>;
+type ExitOutcome = Readonly<{
+  signal: NodeJS.Signals | null;
+  status: number | null;
+}>;
+type ProcessObservationOptions = Readonly<{
+  command: Command;
+  exit: Readonly<Promise<ExitOutcome>>;
+  processId: number | undefined;
+  repository: string | undefined;
+  timeoutMilliseconds: number;
+}>;
+
+async function auditProcessNetwork(
   command: Command,
-  environment: NodeJS.ProcessEnv,
-  repository: string | undefined,
-  timeoutMilliseconds = 120_000,
+  {
+    environment,
+    repository,
+    timeoutMilliseconds = defaultTimeoutMilliseconds,
+  }: NetworkAuditOptions,
 ): Promise<{ stdout: string; stderr: string }> {
+  const process = startAuditedProcess(command, environment);
+  const { outcome, sockets } = await observeProcess({
+    command,
+    exit: process.exit,
+    processId: process.processId,
+    repository,
+    timeoutMilliseconds,
+  });
+  const decoded = decodeOutput(process.stdout, process.stderr);
+  requireNoSockets(sockets);
+  requireSuccessfulExit(outcome, decoded.stderr);
+  return decoded;
+}
+
+function startAuditedProcess(
+  command: Command,
+  environment: Readonly<NodeJS.ProcessEnv>,
+): Readonly<{
+  exit: Promise<ExitOutcome>;
+  processId: number | undefined;
+  stderr: number[][];
+  stdout: number[][];
+}> {
   const [binary, ...arguments_] = command;
   const child = spawn(binary, arguments_, {
+    detached: true,
     env: environment,
     stdio: ["ignore", "pipe", "pipe"],
-    detached: true,
   });
-  const stdout: Buffer[] = [];
-  const stderr: Buffer[] = [];
-  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
-  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-  const exit = new Promise<{
-    status: number | null;
-    signal: NodeJS.Signals | null;
-  }>((resolve, reject) => {
+  const stdout: number[][] = [];
+  const stderr: number[][] = [];
+  child.stdout.on("data", (chunk: unknown) => {
+    stdout.push([...byteChunkSchema.parse(chunk)]);
+  });
+  child.stderr.on("data", (chunk: unknown) => {
+    stderr.push([...byteChunkSchema.parse(chunk)]);
+  });
+  const exit = new Promise<ExitOutcome>((resolve, reject) => {
     child.once("error", reject);
-    child.once("exit", (status, signal) => resolve({ status, signal }));
+    child.once("exit", (status, signal) => {
+      resolve({ signal, status });
+    });
   });
+  return { exit, processId: child.pid, stderr, stdout };
+}
+
+async function observeProcess({
+  command,
+  exit,
+  processId,
+  repository,
+  timeoutMilliseconds,
+}: ProcessObservationOptions): Promise<
+  Readonly<{ outcome: ExitOutcome; sockets: string[] }>
+> {
   const sockets: string[] = [];
   const started = performance.now();
   let outcome:
     | { status: number | null; signal: NodeJS.Signals | null }
-    | undefined;
+    | typeof samplePending = samplePending;
   try {
-    while (outcome === undefined) {
-      sampleSockets(child.pid, repository, sockets);
+    while (outcome === samplePending) {
+      sockets.push(...sampleSockets(processId, repository));
       if (performance.now() - started >= timeoutMilliseconds) {
         throw new Error(`audited process timed out: ${command.join(" ")}`);
       }
-      outcome = await Promise.race([exit, delay(50).then(() => undefined)]);
+      outcome = await Promise.race([
+        exit,
+        delay(sampleIntervalMilliseconds).then(
+          (): typeof samplePending => samplePending,
+        ),
+      ]);
     }
-    sampleSockets(child.pid, repository, sockets);
+    sockets.push(...sampleSockets(processId, repository));
   } catch (error) {
-    stopProcessGroup(child.pid);
-    await exit.catch(() => undefined);
+    stopProcessGroup(processId);
+    await exit.catch(() => samplePending);
     throw error;
   }
-  const decoded = decodeOutput(stdout, stderr);
-  if (sockets.length > 0) throw new NetworkViolation(sockets.join(""));
+  return { outcome, sockets };
+}
+
+function requireNoSockets(sockets: readonly string[]): void {
+  if (sockets.length > 0) {
+    throw new NetworkViolationError(sockets.join(""));
+  }
+}
+
+function requireSuccessfulExit(outcome: ExitOutcome, stderr: string): void {
   if (outcome.status !== 0) {
     throw new Error(
-      `audited process failed: status=${outcome.status ?? "none"} signal=${outcome.signal ?? "none"}\n${decoded.stderr}`,
+      `audited process failed: status=${outcome.status ?? "none"} signal=${outcome.signal ?? "none"}\n${stderr}`,
     );
   }
-  return decoded;
 }
 
 function sampleSockets(
   rootProcessId: number | undefined,
   repository: string | undefined,
-  sockets: string[],
-): void {
-  if (rootProcessId === undefined)
+): string[] {
+  if (rootProcessId === undefined) {
     throw new Error("audited process has no PID");
-  for (const processId of collectProcessIds(rootProcessId, repository)) {
+  }
+  return collectProcessIds(rootProcessId, repository).flatMap((processId) => {
     const result = Bun.spawnSync(
       ["lsof", "-nP", "-a", "-p", String(processId), "-i"],
       {
-        stdout: "pipe",
         stderr: "pipe",
+        stdout: "pipe",
       },
     );
     if (result.exitCode === 0) {
-      sockets.push(decode(result.stdout, "lsof stdout"));
-    } else if (result.exitCode !== 1) {
+      return [decode([...result.stdout], "lsof stdout")];
+    }
+    if (result.exitCode !== 1) {
       throw new Error(
-        `lsof failed (${result.exitCode}): ${decode(result.stderr, "lsof stderr")}`,
+        `lsof failed (${result.exitCode}): ${decode([...result.stderr], "lsof stderr")}`,
       );
     }
-  }
+    return [];
+  });
 }
 
 function collectProcessIds(
@@ -100,28 +177,10 @@ function collectProcessIds(
   while (frontier.length > 0) {
     const next: number[] = [];
     for (const parent of frontier) {
-      const result = Bun.spawnSync(["pgrep", "-P", String(parent)], {
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      if (result.exitCode !== 0 && result.exitCode !== 1) {
-        throw new Error(
-          `pgrep failed (${result.exitCode}): ${decode(result.stderr, "pgrep stderr")}`,
-        );
-      }
-      if (result.exitCode === 0) {
-        for (const line of decode(result.stdout, "pgrep stdout")
-          .trim()
-          .split("\n")) {
-          const child = Number(line);
-          if (
-            Number.isSafeInteger(child) &&
-            child > 0 &&
-            !collected.has(child)
-          ) {
-            collected.add(child);
-            next.push(child);
-          }
+      for (const child of childProcessIds(parent)) {
+        if (!collected.has(child)) {
+          collected.add(child);
+          next.push(child);
         }
       }
     }
@@ -129,8 +188,30 @@ function collectProcessIds(
   }
   const daemon =
     repository === undefined ? undefined : recordedDaemon(repository);
-  if (daemon !== undefined) collected.add(daemon);
-  return [...collected].sort((left, right) => left - right);
+  if (daemon !== undefined) {
+    collected.add(daemon);
+  }
+  return [...collected].toSorted((left, right) => left - right);
+}
+
+function childProcessIds(parent: number): number[] {
+  const result = Bun.spawnSync(["pgrep", "-P", String(parent)], {
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  if (result.exitCode !== 0 && result.exitCode !== 1) {
+    throw new Error(
+      `pgrep failed (${result.exitCode}): ${decode([...result.stderr], "pgrep stderr")}`,
+    );
+  }
+  if (result.exitCode === 1) {
+    return [];
+  }
+  return decode([...result.stdout], "pgrep stdout")
+    .trim()
+    .split("\n")
+    .map(Number)
+    .filter((processId) => Number.isSafeInteger(processId) && processId > 0);
 }
 
 function recordedDaemon(repository: string): number | undefined {
@@ -141,31 +222,48 @@ function recordedDaemon(repository: string): number | undefined {
       ),
     ).pid;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-    throw new Error(`invalid CodeGraph daemon record: ${String(error)}`);
+    if (hasErrorCode(error, "ENOENT")) {
+      return undefined;
+    }
+    throw new Error(`invalid CodeGraph daemon record: ${String(error)}`, {
+      cause: error,
+    });
   }
 }
 
-function decodeOutput(stdout: Buffer[], stderr: Buffer[]) {
+function decodeOutput(
+  stdout: readonly (readonly number[])[],
+  stderr: readonly (readonly number[])[],
+): { stderr: string; stdout: string } {
   return {
-    stdout: decode(Buffer.concat(stdout), "audited stdout"),
-    stderr: decode(Buffer.concat(stderr), "audited stderr"),
+    stderr: decode(stderr.flat(), "audited stderr"),
+    stdout: decode(stdout.flat(), "audited stdout"),
   };
 }
 
-function decode(bytes: Uint8Array, source: string): string {
+function decode(bytes: readonly number[], source: string): string {
   try {
-    return decoder.decode(bytes);
+    return decoder.decode(Uint8Array.from(bytes));
   } catch {
     throw new Error(`${source} returned invalid UTF-8`);
   }
 }
 
 function stopProcessGroup(processId: number | undefined): void {
-  if (processId === undefined) return;
+  if (processId === undefined) {
+    return;
+  }
   try {
     process.kill(-processId, "SIGKILL");
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+    if (!hasErrorCode(error, "ESRCH")) {
+      throw error;
+    }
   }
 }
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return z.object({ code: z.literal(code) }).safeParse(error).success;
+}
+
+export { NetworkViolationError, auditProcessNetwork };

--- a/tooling/codegraph/network-canary.ts
+++ b/tooling/codegraph/network-canary.ts
@@ -1,29 +1,44 @@
 #!/usr/bin/env bun
 
-import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import { createServer } from "node:net";
+import { spawn } from "node:child_process";
 
-const mode = process.argv[2];
-const file = fileURLToPath(import.meta.url);
+const childExitCode = 1;
+const file = import.meta.filename;
+const firstArgumentIndex = 2;
+const listeningPort = 0;
+const [mode] = process.argv.slice(firstArgumentIndex);
+const pauseMilliseconds = 1000;
 
 if (mode === "socket") {
   const server = createServer();
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-  await Bun.sleep(1_000);
-  await new Promise<void>((resolve, reject) =>
-    server.close((error) => (error === undefined ? resolve() : reject(error))),
-  );
+  await new Promise<void>((resolve) => {
+    server.listen(listeningPort, "127.0.0.1", resolve);
+  });
+  await Bun.sleep(pauseMilliseconds);
+  await new Promise<void>((resolve, reject) => {
+    server.close((error?: Readonly<Error>) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
 } else {
-  const child = spawn(
-    process.execPath,
-    [file, mode === "root" ? "child" : "socket"],
-    {
-      stdio: "ignore",
-    },
-  );
-  const status = await new Promise<number | null>((resolve) =>
-    child.once("exit", resolve),
-  );
-  if (status !== 0) process.exit(status ?? 1);
+  let childMode = "socket";
+  if (mode === "root") {
+    childMode = "child";
+  }
+  const child = spawn(process.execPath, [file, childMode], {
+    stdio: "ignore",
+  });
+  const status = await new Promise<number>((resolve) => {
+    child.once("exit", (exitCode) => {
+      resolve(exitCode ?? childExitCode);
+    });
+  });
+  if (status !== listeningPort) {
+    process.exit(status);
+  }
 }

--- a/tooling/dependabot-config.test.ts
+++ b/tooling/dependabot-config.test.ts
@@ -1,37 +1,42 @@
 import { expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { readFileSync } from "node:fs";
 import { z } from "zod";
 
+const cooldownDays = 3;
+const dependabotVersion = 2;
+const firstUpdateIndex = 0;
+const shorterCooldownDays = 2;
+
 const rootBunUpdate = {
-  "package-ecosystem": "bun",
+  cooldown: {
+    "default-days": cooldownDays,
+  },
   directory: "/",
+  "package-ecosystem": "bun",
   schedule: {
-    interval: "weekly",
     day: "monday",
+    interval: "weekly",
     time: "05:00",
     timezone: "Europe/Paris",
-  },
-  cooldown: {
-    "default-days": 3,
   },
 } as const;
 
 const rootBunUpdateSchema = z
   .object({
-    "package-ecosystem": z.literal("bun"),
-    directory: z.literal("/"),
-    schedule: z
-      .object({
-        interval: z.literal("weekly"),
-        day: z.literal("monday"),
-        time: z.literal("05:00"),
-        timezone: z.literal("Europe/Paris"),
-      })
-      .strict(),
     cooldown: z
       .object({
-        "default-days": z.number().int().min(3),
+        "default-days": z.number().int().min(cooldownDays),
+      })
+      .strict(),
+    directory: z.literal("/"),
+    "package-ecosystem": z.literal("bun"),
+    schedule: z
+      .object({
+        day: z.literal("monday"),
+        interval: z.literal("weekly"),
+        time: z.literal("05:00"),
+        timezone: z.literal("Europe/Paris"),
       })
       .strict(),
   })
@@ -39,8 +44,8 @@ const rootBunUpdateSchema = z
 
 const dependabotConfigSchema = z
   .object({
-    version: z.literal(2),
-    updates: z.array(rootBunUpdateSchema).length(1),
+    updates: z.array(rootBunUpdateSchema).length(firstUpdateIndex + 1),
+    version: z.literal(dependabotVersion),
   })
   .strict();
 
@@ -50,17 +55,30 @@ test("keeps every root Bun dependency eligible for weekly updates", () => {
     "utf8",
   );
   const config = dependabotConfigSchema.parse(Bun.YAML.parse(contents));
+  const firstUpdate = config.updates.at(firstUpdateIndex);
 
-  expect(config.updates[0]?.cooldown["default-days"]).toBeGreaterThanOrEqual(3);
+  if (firstUpdate === undefined) {
+    throw new Error("Dependabot root update is missing");
+  }
+  expect(firstUpdate.cooldown["default-days"]).toBeGreaterThanOrEqual(
+    cooldownDays,
+  );
 });
 
 test.each([
   ["a disabled pull request queue", { "open-pull-requests-limit": 0 }],
   ["an allow filter", { allow: [] }],
   ["an ignore filter", { ignore: [] }],
-  ["a cooldown shorter than three days", { cooldown: { "default-days": 2 } }],
-  ["a cooldown exclusion", { cooldown: { "default-days": 3, exclude: ["*"] } }],
-])("rejects %s", (_, contractOverride) => {
+  [
+    "a cooldown shorter than three days",
+    { cooldown: { "default-days": shorterCooldownDays } },
+  ],
+  [
+    "a cooldown exclusion",
+    { cooldown: { "default-days": cooldownDays, exclude: ["*"] } },
+  ],
+] as const)("rejects %s", (caseName, contractOverride) => {
+  expect(caseName).not.toBeEmpty();
   expect(() =>
     rootBunUpdateSchema.parse({ ...rootBunUpdate, ...contractOverride }),
   ).toThrow();

--- a/tooling/deployment-codex-wiring.test.ts
+++ b/tooling/deployment-codex-wiring.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { join } from "node:path";
 import {
   cleanupDeploymentFixtures,
   createDeploymentFixture,
@@ -7,6 +6,7 @@ import {
   project,
   runMake,
 } from "./deployment-test-support.ts";
+import { join } from "node:path";
 
 afterEach(cleanupDeploymentFixtures);
 
@@ -16,8 +16,8 @@ describe("deployment area: Bun and hook wiring", () => {
     const brewBin = join(fixture.home, "homebrew", "bin");
     for (const target of ["claude-code", "codex", "obsidian-retrieval-test"]) {
       const result = runMake(fixture, [target], {
-        repository: project,
         dryRun: true,
+        repository: project,
         variables: { BREW_BIN: brewBin },
       });
       expectSuccess(result);
@@ -33,10 +33,10 @@ describe("deployment area: Bun and hook wiring", () => {
     "%s entry point reconciles hooks once",
     (target, agent, deploysHandoff) => {
       const fixture = createDeploymentFixture(`hook-wiring-${target}`);
-      const expected = `\"${fixture.home}/.local/bin/arnes\" setup hooks --agent ${agent}`;
+      const expected = `"${fixture.home}/.local/bin/arnes" setup hooks --agent ${agent}`;
       const hook = runMake(fixture, [`${target}-hooks`], {
-        repository: project,
         dryRun: true,
+        repository: project,
       });
       expectSuccess(hook);
       expect(count(hook.stdout, expected)).toBe(1);
@@ -47,8 +47,8 @@ describe("deployment area: Bun and hook wiring", () => {
         );
       }
       const entry = runMake(fixture, [target], {
-        repository: project,
         dryRun: true,
+        repository: project,
       });
       expectSuccess(entry);
       expect(count(entry.stdout, expected)).toBe(1);
@@ -67,8 +67,8 @@ describe("deployment area: Hunspell wiring", () => {
     const revision = "f2ff99058268502bdcf4cad25c1ca2935ad8aa7d";
     const base = `https://raw.githubusercontent.com/LibreOffice/dictionaries/${revision}`;
     const result = runMake(fixture, ["hunspell"], {
-      repository: project,
       dryRun: true,
+      repository: project,
       variables: { BREW_BIN: fixture.bin },
     });
     expectSuccess(result);
@@ -96,12 +96,12 @@ describe("deployment area: Hunspell wiring", () => {
         "en_US.dic",
       ],
     ] as const) {
-      const expected = `\"${join(project, "tooling", "install-hunspell-dictionary")}\" \"${base}/${source}\" \"${checksum}\" \"${join(fixture.home, "Library", "Spelling", destination)}\"`;
+      const expected = `"${join(project, "tooling", "install-hunspell-dictionary")}" "${base}/${source}" "${checksum}" "${join(fixture.home, "Library", "Spelling", destination)}"`;
       expect(count(result.stdout, expected)).toBe(1);
     }
     const claude = runMake(fixture, ["claude-code"], {
-      repository: project,
       dryRun: true,
+      repository: project,
       variables: { BREW_BIN: fixture.bin },
     });
     expectSuccess(claude);

--- a/tooling/deployment-daily-routine.test.ts
+++ b/tooling/deployment-daily-routine.test.ts
@@ -7,7 +7,6 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
 import {
   cleanupDeploymentFixtures,
   createDeploymentFixture,
@@ -17,8 +16,12 @@ import {
   project,
   runMake,
 } from "./deployment-test-support.ts";
+import { join } from "node:path";
 
 afterEach(cleanupDeploymentFixtures);
+
+const fileModeMask = 0o777;
+const privateFileMode = 0o600;
 
 describe("deployment area: daily routine", () => {
   test("copies a private default once and preserves a local configuration", () => {
@@ -36,9 +39,9 @@ describe("deployment area: daily routine", () => {
         "utf8",
       ),
     );
-    expect(statSync(config).mode & 0o777).toBe(0o600);
+    expect(statSync(config).mode & fileModeMask).toBe(privateFileMode);
     writeFileSync(config, "local configuration\n");
-    chmodSync(config, 0o600);
+    chmodSync(config, privateFileMode);
     const before = fileIdentity(config);
     expectSuccess(runMake(fixture, [config], { repository: project }));
     expect(fileIdentity(config)).toEqual(before);

--- a/tooling/deployment-fish.test.ts
+++ b/tooling/deployment-fish.test.ts
@@ -1,6 +1,4 @@
-import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { afterEach, expect, setDefaultTimeout, test } from "bun:test";
 import {
   cleanupDeploymentFixtures,
   createDeploymentFixture,
@@ -9,76 +7,75 @@ import {
   linkTarget,
   runMake,
 } from "./deployment-test-support.ts";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
 
 afterEach(cleanupDeploymentFixtures);
-setDefaultTimeout(15_000);
+const deploymentTimeoutMilliseconds = 15_000;
+setDefaultTimeout(deploymentTimeoutMilliseconds);
 
-describe("deployment area: Fish bindings", () => {
-  test("installs through the real Make target and replays without invoking Fish", () => {
-    const fixture = createDeploymentFixture("fish-success");
-    const source = join(fixture.repository, "home", ".config", "fish");
-    const bindings = join(
-      fixture.home,
-      ".config",
-      "fish",
-      "functions",
-      "fzf_configure_bindings.fish",
-    );
-    const marker = join(fixture.root, "fish-called");
-    mkdirSync(join(fixture.home, ".config"), { recursive: true });
-    mkdirSync(source, { recursive: true });
-    installProvider(fixture, "fish");
-    const environment = {
-      PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
-      DEPLOYMENT_PROVIDER_MODE: "fish-success",
-      DEPLOYMENT_MARKER: marker,
-    };
+test("installs through the real Make target and replays without invoking Fish", () => {
+  const fixture = createDeploymentFixture("fish-success");
+  const source = join(fixture.repository, "home", ".config", "fish");
+  const bindings = join(
+    fixture.home,
+    ".config",
+    "fish",
+    "functions",
+    "fzf_configure_bindings.fish",
+  );
+  const marker = join(fixture.root, "fish-called");
+  mkdirSync(join(fixture.home, ".config"), { recursive: true });
+  mkdirSync(source, { recursive: true });
+  installProvider(fixture, "fish");
+  const environment = {
+    DEPLOYMENT_MARKER: marker,
+    DEPLOYMENT_PROVIDER_MODE: "fish-success",
+    PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+  };
 
-    expectSuccess(
-      runMake(fixture, [bindings], {
-        environment,
-        variables: { BREW_BIN: fixture.bin },
-      }),
-    );
-    expect(linkTarget(join(fixture.home, ".config", "fish"))).toBe(source);
-    expect(existsSync(bindings)).toBeTrue();
-    expect(readFileSync(marker, "utf8")).toBe(
-      "-c fisher install PatrickF1/fzf.fish\n",
-    );
-
-    rmSync(marker);
-    expectSuccess(
-      runMake(fixture, [bindings], {
-        environment,
-        variables: { BREW_BIN: fixture.bin },
-      }),
-    );
-    expect(existsSync(marker)).toBeFalse();
-  });
-
-  test("fails explicitly when Fish returns success without producing bindings", () => {
-    const fixture = createDeploymentFixture("fish-empty");
-    const source = join(fixture.repository, "home", ".config", "fish");
-    const bindings = join(
-      fixture.home,
-      ".config",
-      "fish",
-      "functions",
-      "fzf_configure_bindings.fish",
-    );
-    mkdirSync(join(fixture.home, ".config"), { recursive: true });
-    mkdirSync(source, { recursive: true });
-    installProvider(fixture, "fish");
-    const result = runMake(fixture, [bindings], {
-      environment: {
-        PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
-        DEPLOYMENT_PROVIDER_MODE: "fish-empty",
-      },
+  expectSuccess(
+    runMake(fixture, [bindings], {
+      environment,
       variables: { BREW_BIN: fixture.bin },
-    });
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain(
-      `Error: Fisher did not install ${bindings}`,
-    );
+    }),
+  );
+  expect(linkTarget(join(fixture.home, ".config", "fish"))).toBe(source);
+  expect(existsSync(bindings)).toBeTrue();
+  expect(readFileSync(marker, "utf8")).toBe(
+    "-c fisher install PatrickF1/fzf.fish\n",
+  );
+
+  rmSync(marker);
+  expectSuccess(
+    runMake(fixture, [bindings], {
+      environment,
+      variables: { BREW_BIN: fixture.bin },
+    }),
+  );
+  expect(existsSync(marker)).toBeFalse();
+});
+
+test("fails explicitly when Fish returns success without producing bindings", () => {
+  const fixture = createDeploymentFixture("fish-empty");
+  const source = join(fixture.repository, "home", ".config", "fish");
+  const bindings = join(
+    fixture.home,
+    ".config",
+    "fish",
+    "functions",
+    "fzf_configure_bindings.fish",
+  );
+  mkdirSync(join(fixture.home, ".config"), { recursive: true });
+  mkdirSync(source, { recursive: true });
+  installProvider(fixture, "fish");
+  const result = runMake(fixture, [bindings], {
+    environment: {
+      DEPLOYMENT_PROVIDER_MODE: "fish-empty",
+      PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+    },
+    variables: { BREW_BIN: fixture.bin },
   });
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain(`Error: Fisher did not install ${bindings}`);
 });

--- a/tooling/deployment-links.test.ts
+++ b/tooling/deployment-links.test.ts
@@ -1,14 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import {
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  symlinkSync,
-  unlinkSync,
-  utimesSync,
-  writeFileSync,
-} from "node:fs";
-import { join } from "node:path";
+import { afterEach, expect, test } from "bun:test";
 import {
   cleanupDeploymentFixtures,
   createDeploymentFixture,
@@ -21,45 +11,108 @@ import {
   requireCommand,
   runMake,
 } from "./deployment-test-support.ts";
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  symlinkSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
 
 afterEach(cleanupDeploymentFixtures);
 
-describe("deployment area: managed links", () => {
-  test("refuses existing directories without linking inside them", () => {
-    const fixture = createDeploymentFixture("existing-directory");
-    const source = join(fixture.repository, "home", ".config", "fish");
-    const destination = join(fixture.home, ".config", "fish");
-    mkdirSync(source, { recursive: true });
-    mkdirSync(destination, { recursive: true });
-    utimesSync(destination, new Date("2020-01-01"), new Date("2020-01-01"));
-    utimesSync(source, new Date("2021-01-01"), new Date("2021-01-01"));
+const deploymentTimeoutMilliseconds = 15_000;
+const extendedDeploymentTimeoutMilliseconds = 30_000;
+const userSkillDestinations = [
+  [".agents", "agent-instructions"],
+  ...[
+    "obsidian-retrieval",
+    "codegraph",
+    "enforcement-code",
+    "harness-reflection",
+    "handoff",
+    "issue-creation",
+    "linear-issue-spec",
+    "linear-sync",
+    "pr-fix",
+    "pr-verdict",
+    "requirements-clarification",
+    "skill-manager",
+    "workflow-automation",
+  ].map((slug) => [".claude", slug]),
+  ...[
+    "claude-developer",
+    "obsidian-retrieval",
+    "codegraph",
+    "enforcement-code",
+    "harness-reflection",
+    "issue-creation",
+    "linear-issue-spec",
+    "linear-sync",
+    "pr-fix",
+    "pr-verdict",
+    "requirements-clarification",
+    "skill-manager",
+    "workflow-automation",
+  ].map((slug) => [".cursor", slug]),
+  ...[
+    "claude-developer",
+    "obsidian-retrieval",
+    "codegraph",
+    "enforcement-code",
+    "harness-reflection",
+    "handoff",
+    "issue-creation",
+    "linear-issue-spec",
+    "linear-sync",
+    "pr-fix",
+    "pr-verdict",
+    "requirements-clarification",
+    "skill-manager",
+    "workflow-automation",
+  ].map((slug) => [".agents", slug] as const),
+] as const;
 
-    const result = runMake(fixture, [destination]);
+test("refuses existing directories without linking inside them", () => {
+  const fixture = createDeploymentFixture("existing-directory");
+  const source = join(fixture.repository, "home", ".config", "fish");
+  const destination = join(fixture.home, ".config", "fish");
+  mkdirSync(source, { recursive: true });
+  mkdirSync(destination, { recursive: true });
+  utimesSync(destination, new Date("2020-01-01"), new Date("2020-01-01"));
+  utimesSync(source, new Date("2021-01-01"), new Date("2021-01-01"));
 
-    expect(result.exitCode).not.toBe(0);
-    expect(readdirSync(destination)).toEqual([]);
-  });
+  const result = runMake(fixture, [destination]);
 
-  test("refuses a destination symlink to a directory without mutating it", () => {
-    const fixture = createDeploymentFixture("directory-link");
-    const source = join(fixture.repository, "home", ".config", "fish");
-    const destination = join(fixture.home, ".config", "fish");
-    const actual = join(fixture.root, "actual");
-    mkdirSync(source, { recursive: true });
-    mkdirSync(join(fixture.home, ".config"), { recursive: true });
-    mkdirSync(actual);
-    symlinkSync(actual, destination);
-    utimesSync(actual, new Date("2020-01-01"), new Date("2020-01-01"));
-    utimesSync(source, new Date("2021-01-01"), new Date("2021-01-01"));
+  expect(result.exitCode).not.toBe(0);
+  expect(readdirSync(destination)).toEqual([]);
+});
 
-    const result = runMake(fixture, [destination]);
+test("refuses a destination symlink to a directory without mutating it", () => {
+  const fixture = createDeploymentFixture("directory-link");
+  const source = join(fixture.repository, "home", ".config", "fish");
+  const destination = join(fixture.home, ".config", "fish");
+  const actual = join(fixture.root, "actual");
+  mkdirSync(source, { recursive: true });
+  mkdirSync(join(fixture.home, ".config"), { recursive: true });
+  mkdirSync(actual);
+  symlinkSync(actual, destination);
+  utimesSync(actual, new Date("2020-01-01"), new Date("2020-01-01"));
+  utimesSync(source, new Date("2021-01-01"), new Date("2021-01-01"));
 
-    expect(result.exitCode).not.toBe(0);
-    expect(linkTarget(destination)).toBe(actual);
-    expect(readdirSync(actual)).toEqual([]);
-  });
+  const result = runMake(fixture, [destination]);
 
-  test("deploys Starship and tmux links, replays idempotently, and preserves a wrong link", () => {
+  expect(result.exitCode).not.toBe(0);
+  expect(linkTarget(destination)).toBe(actual);
+  expect(readdirSync(actual)).toEqual([]);
+});
+
+test(
+  "deploys Starship and tmux links, replays idempotently, and preserves a wrong link",
+  () => {
     const fixture = createDeploymentFixture("starship");
     const tmux = join(fixture.home, ".config", "tmux", "tmux.conf");
     const starship = join(fixture.home, ".config", "starship.toml");
@@ -76,13 +129,13 @@ describe("deployment area: managed links", () => {
     installProvider(fixture, "ln");
     expectSuccess(
       runMake(fixture, [starship], {
-        repository: project,
         environment: {
-          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
-          DEPLOYMENT_PROVIDER_MODE: "ln",
           DEPLOYMENT_MARKER: marker,
+          DEPLOYMENT_PROVIDER_MODE: "ln",
           DEPLOYMENT_REAL_COMMAND: requireCommand("ln"),
+          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
         },
+        repository: project,
       }),
     );
     expect(pathExists(marker)).toBeFalse();
@@ -93,137 +146,91 @@ describe("deployment area: managed links", () => {
     symlinkSync(unexpected, starship);
     expectSuccess(runMake(fixture, [starship], { repository: project }));
     expect(linkTarget(starship)).toBe(unexpected);
-  }, 15_000);
+  },
+  deploymentTimeoutMilliseconds,
+);
+test("deploys shared instructions and skills, preserves local rules, and replays idempotently", () => {
+  const fixture = createDeploymentFixture("agent-instructions");
+  const claudeRule = join(
+    fixture.home,
+    ".claude",
+    "rules",
+    "agent-instructions.md",
+  );
+  const codexInstructions = join(fixture.home, ".codex", "AGENTS.md");
+  const codexSkill = join(
+    fixture.home,
+    ".agents",
+    "skills",
+    "agent-instructions",
+  );
+  expectSuccess(
+    runMake(fixture, [claudeRule, codexInstructions, codexSkill], {
+      repository: project,
+    }),
+  );
+  expect(
+    linkTarget(join(project, "harness", "rules", "agent-instructions.md")),
+  ).toBe("../skills/agent-instructions/references/maintenance.md");
+  expect(linkTarget(claudeRule)).toBe(
+    join(project, "harness", "rules", "agent-instructions.md"),
+  );
+  expect(linkTarget(codexSkill)).toBe(
+    join(project, "harness", "skills", "agent-instructions"),
+  );
+  const expected =
+    readFileSync(join(project, "harness", "AGENTS.md"), "utf8").replaceAll(
+      /^@.*\n/gmu,
+      "",
+    ) +
+    readFileSync(join(project, "harness", "SOUL.md"), "utf8") +
+    readFileSync(join(project, "harness", "USER.md"), "utf8");
+  expect(readFileSync(codexInstructions, "utf8")).toBe(expected);
+  const before = fileIdentity(codexInstructions);
+  expectSuccess(
+    runMake(fixture, [claudeRule, codexInstructions], {
+      repository: project,
+    }),
+  );
+  expect(fileIdentity(codexInstructions)).toEqual(before);
+  unlinkSync(claudeRule);
+  writeFileSync(claudeRule, "keep\n");
+  expectSuccess(runMake(fixture, [claudeRule], { repository: project }));
+  expect(readFileSync(claudeRule, "utf8")).toBe("keep\n");
 });
 
-describe("deployment area: agent instructions and skills", () => {
-  test("deploys shared instructions and skills, preserves local rules, and replays idempotently", () => {
-    const fixture = createDeploymentFixture("agent-instructions");
-    const claudeRule = join(
-      fixture.home,
-      ".claude",
-      "rules",
-      "agent-instructions.md",
-    );
-    const codexInstructions = join(fixture.home, ".codex", "AGENTS.md");
-    const codexSkill = join(
-      fixture.home,
-      ".agents",
-      "skills",
-      "agent-instructions",
-    );
-    expectSuccess(
-      runMake(fixture, [claudeRule, codexInstructions, codexSkill], {
-        repository: project,
-      }),
-    );
-    expect(
-      linkTarget(join(project, "harness", "rules", "agent-instructions.md")),
-    ).toBe("../skills/agent-instructions/references/maintenance.md");
-    expect(linkTarget(claudeRule)).toBe(
-      join(project, "harness", "rules", "agent-instructions.md"),
-    );
-    expect(linkTarget(codexSkill)).toBe(
-      join(project, "harness", "skills", "agent-instructions"),
-    );
-    const expected =
-      readFileSync(join(project, "harness", "AGENTS.md"), "utf8").replace(
-        /^@.*\n/gm,
-        "",
-      ) +
-      readFileSync(join(project, "harness", "SOUL.md"), "utf8") +
-      readFileSync(join(project, "harness", "USER.md"), "utf8");
-    expect(readFileSync(codexInstructions, "utf8")).toBe(expected);
-    const before = fileIdentity(codexInstructions);
-    expectSuccess(
-      runMake(fixture, [claudeRule, codexInstructions], {
-        repository: project,
-      }),
-    );
-    expect(fileIdentity(codexInstructions)).toEqual(before);
-    unlinkSync(claudeRule);
-    writeFileSync(claudeRule, "keep\n");
-    expectSuccess(runMake(fixture, [claudeRule], { repository: project }));
-    expect(readFileSync(claudeRule, "utf8")).toBe("keep\n");
-  });
-
-  test("deploys every public user skill from the shared collection", () => {
+test(
+  "deploys every public user skill from the shared collection",
+  () => {
     const fixture = createDeploymentFixture("user-skills");
-    const destinations = [
-      [".agents", "agent-instructions"],
-      ...[
-        "obsidian-retrieval",
-        "codegraph",
-        "enforcement-code",
-        "harness-reflection",
-        "handoff",
-        "issue-creation",
-        "linear-issue-spec",
-        "linear-sync",
-        "pr-fix",
-        "pr-verdict",
-        "requirements-clarification",
-        "skill-manager",
-        "workflow-automation",
-      ].map((slug) => [".claude", slug]),
-      ...[
-        "claude-developer",
-        "obsidian-retrieval",
-        "codegraph",
-        "enforcement-code",
-        "harness-reflection",
-        "issue-creation",
-        "linear-issue-spec",
-        "linear-sync",
-        "pr-fix",
-        "pr-verdict",
-        "requirements-clarification",
-        "skill-manager",
-        "workflow-automation",
-      ].map((slug) => [".cursor", slug]),
-      ...[
-        "claude-developer",
-        "obsidian-retrieval",
-        "codegraph",
-        "enforcement-code",
-        "harness-reflection",
-        "handoff",
-        "issue-creation",
-        "linear-issue-spec",
-        "linear-sync",
-        "pr-fix",
-        "pr-verdict",
-        "requirements-clarification",
-        "skill-manager",
-        "workflow-automation",
-      ].map((slug) => [".agents", slug]),
-    ] as const;
-    const destinationPaths = destinations.map(([owner, slug]) =>
-      join(fixture.home, owner, "skills", slug),
-    );
+    const destinationPaths: string[] = [];
+    for (const [owner, slug] of userSkillDestinations) {
+      destinationPaths.push(join(fixture.home, owner, "skills", slug));
+    }
     expectSuccess(runMake(fixture, destinationPaths, { repository: project }));
-    for (const [owner, slug] of destinations) {
+    for (const [owner, slug] of userSkillDestinations) {
       const destination = join(fixture.home, owner, "skills", slug);
       expect(linkTarget(destination)).toBe(
         join(project, "harness", "skills", slug),
       );
       expect(pathExists(join(project, ".agents", "skills", slug))).toBeFalse();
     }
-  }, 30_000);
+  },
+  extendedDeploymentTimeoutMilliseconds,
+);
 
-  test("agent aggregate targets include requirements clarification", () => {
-    const fixture = createDeploymentFixture("requirements-clarification");
-    for (const [target, destination] of [
-      ["claude-code", ".claude/skills/requirements-clarification"],
-      ["cursor", ".cursor/skills/requirements-clarification"],
-      ["codex", ".agents/skills/requirements-clarification"],
-    ] as const) {
-      const result = runMake(fixture, [target], {
-        repository: project,
-        dryRun: true,
-      });
-      expectSuccess(result);
-      expect(result.stdout).toContain(join(fixture.home, destination));
-    }
-  });
+test("agent aggregate targets include requirements clarification", () => {
+  const fixture = createDeploymentFixture("requirements-clarification");
+  for (const [target, destination] of [
+    ["claude-code", ".claude/skills/requirements-clarification"],
+    ["cursor", ".cursor/skills/requirements-clarification"],
+    ["codex", ".agents/skills/requirements-clarification"],
+  ] as const) {
+    const result = runMake(fixture, [target], {
+      dryRun: true,
+      repository: project,
+    });
+    expectSuccess(result);
+    expect(result.stdout).toContain(join(fixture.home, destination));
+  }
 });

--- a/tooling/deployment-test-provider.ts
+++ b/tooling/deployment-test-provider.ts
@@ -1,21 +1,30 @@
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { z } from "zod";
 
 const mode = process.env.DEPLOYMENT_PROVIDER_MODE;
+const argumentOffset = 2;
+const commandFailureExitCode = 128;
+const usageFailureExitCode = 64;
 
 if (mode === "ln") {
   appendFileSync(required("DEPLOYMENT_MARKER"), "called\n");
   forward(required("DEPLOYMENT_REAL_COMMAND"));
 } else if (mode === "git") {
-  const expected = JSON.parse(required("DEPLOYMENT_FAIL_ARGUMENTS"));
-  if (JSON.stringify(process.argv.slice(2)) === JSON.stringify(expected)) {
-    process.exit(128);
+  const expected = z
+    .array(z.string())
+    .parse(JSON.parse(required("DEPLOYMENT_FAIL_ARGUMENTS")));
+  if (
+    JSON.stringify(process.argv.slice(argumentOffset)) ===
+    JSON.stringify(expected)
+  ) {
+    process.exit(commandFailureExitCode);
   }
   forward(required("DEPLOYMENT_REAL_COMMAND"));
 } else if (mode === "fish-success") {
   writeFileSync(
     required("DEPLOYMENT_MARKER"),
-    `${process.argv.slice(2).join(" ")}\n`,
+    `${process.argv.slice(argumentOffset).join(" ")}\n`,
   );
   const functions = join(required("HOME"), ".config", "fish", "functions");
   mkdirSync(functions, { recursive: true });
@@ -26,21 +35,25 @@ if (mode === "ln") {
   process.stderr.write(
     `unknown deployment provider mode: ${mode ?? "missing"}\n`,
   );
-  process.exit(64);
+  process.exit(usageFailureExitCode);
 }
 
 function forward(command: string): never {
-  const result = Bun.spawnSync([command, ...process.argv.slice(2)], {
-    stdin: "inherit",
-    stdout: "inherit",
-    stderr: "inherit",
-  });
+  const result = Bun.spawnSync(
+    [command, ...process.argv.slice(argumentOffset)],
+    {
+      stderr: "inherit",
+      stdin: "inherit",
+      stdout: "inherit",
+    },
+  );
   process.exit(result.exitCode);
 }
 
 function required(name: string): string {
   const value = process.env[name];
-  if (value === undefined || value === "")
+  if (value === undefined || value === "") {
     throw new Error(`${name} is required`);
+  }
   return value;
 }

--- a/tooling/deployment-test-support.ts
+++ b/tooling/deployment-test-support.ts
@@ -8,17 +8,17 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-export type DeploymentFixture = Readonly<{
+type DeploymentFixture = Readonly<{
   root: string;
   home: string;
   repository: string;
   bin: string;
 }>;
 
-export type CommandResult = Readonly<{
+type CommandResult = Readonly<{
   exitCode: number;
   stdout: string;
   stderr: string;
@@ -28,14 +28,15 @@ const project = join(import.meta.dir, "..");
 const makefile = join(project, "Makefile");
 const provider = join(import.meta.dir, "deployment-test-provider.ts");
 const fixtures: string[] = [];
+const executableFileMode = 0o755;
 
-export function createDeploymentFixture(name: string): DeploymentFixture {
+function createDeploymentFixture(name: string): DeploymentFixture {
   const root = mkdtempSync(join(tmpdir(), `deployment-${name}-`));
   const fixture = {
-    root,
+    bin: join(root, "bin"),
     home: join(root, "home"),
     repository: join(root, "repository"),
-    bin: join(root, "bin"),
+    root,
   };
   fixtures.push(root);
   mkdirSync(fixture.home, { recursive: true });
@@ -44,18 +45,18 @@ export function createDeploymentFixture(name: string): DeploymentFixture {
   return fixture;
 }
 
-export function cleanupDeploymentFixtures(): void {
+function cleanupDeploymentFixtures(): void {
   for (const root of fixtures.splice(0)) {
-    rmSync(root, { recursive: true, force: true });
+    rmSync(root, { force: true, recursive: true });
   }
 }
 
-export function runMake(
+function runMake(
   fixture: DeploymentFixture,
   targets: readonly string[],
   options: Readonly<{
     repository?: string;
-    environment?: NodeJS.ProcessEnv;
+    environment?: Readonly<NodeJS.ProcessEnv>;
     variables?: Readonly<Record<string, string>>;
     dryRun?: boolean;
     cwd?: string;
@@ -71,7 +72,7 @@ export function runMake(
       makefile,
       `DOTFILES_PATH=${repository}`,
       ...Object.entries(options.variables ?? {}).map(
-        ([name, value]) => `${name}=${value}`,
+        ([name, value]: readonly [string, string]) => `${name}=${value}`,
       ),
       ...targets,
     ],
@@ -82,31 +83,28 @@ export function runMake(
         HOME: fixture.home,
         ...options.environment,
       },
-      stdout: "pipe",
       stderr: "pipe",
+      stdout: "pipe",
     },
   );
   return {
     exitCode: result.exitCode,
-    stdout: decode(result.stdout),
     stderr: decode(result.stderr),
+    stdout: decode(result.stdout),
   };
 }
 
-export function installProvider(
-  fixture: DeploymentFixture,
-  command: string,
-): string {
+function installProvider(fixture: DeploymentFixture, command: string): string {
   const executable = join(fixture.bin, command);
   writeFileSync(
     executable,
     `#!/usr/bin/env bun\nimport ${JSON.stringify(provider)};\n`,
   );
-  chmodSync(executable, 0o755);
+  chmodSync(executable, executableFileMode);
   return executable;
 }
 
-export function expectSuccess(result: CommandResult): void {
+function expectSuccess(result: CommandResult): void {
   if (result.exitCode !== 0) {
     throw new Error(
       `command failed (${result.exitCode})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
@@ -114,38 +112,58 @@ export function expectSuccess(result: CommandResult): void {
   }
 }
 
-export function linkTarget(path: string): string {
+function linkTarget(path: string): string {
   const metadata = lstatSync(path);
-  if (!metadata.isSymbolicLink()) throw new Error(`${path} is not a symlink`);
+  if (!metadata.isSymbolicLink()) {
+    throw new Error(`${path} is not a symlink`);
+  }
   return readlinkSync(path);
 }
 
-export function pathExists(path: string): boolean {
+function pathExists(path: string): boolean {
   try {
     lstatSync(path);
     return true;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
     throw error;
   }
 }
 
-export function fileIdentity(path: string): Readonly<{
+function fileIdentity(path: string): Readonly<{
   inode: number;
   content: string;
 }> {
   const metadata = lstatSync(path);
-  return { inode: metadata.ino, content: readFileSync(path, "utf8") };
+  return { content: readFileSync(path, "utf8"), inode: metadata.ino };
 }
 
-export function requireCommand(command: string): string {
+function requireCommand(command: string): string {
   const resolved = Bun.which(command);
-  if (resolved === null) throw new Error(`${command} is required`);
+  if (resolved === null) {
+    throw new Error(`${command} is required`);
+  }
   return resolved;
 }
 
-function decode(bytes: Uint8Array): string {
-  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+function decode(bytes: Readonly<ArrayLike<number>>): string {
+  return new TextDecoder("utf-8", { fatal: true }).decode(
+    Uint8Array.from(bytes),
+  );
 }
 
-export { project };
+export {
+  cleanupDeploymentFixtures,
+  createDeploymentFixture,
+  expectSuccess,
+  fileIdentity,
+  installProvider,
+  linkTarget,
+  pathExists,
+  project,
+  requireCommand,
+  runMake,
+};
+export type { CommandResult, DeploymentFixture };

--- a/tooling/deployment-xdg.test.ts
+++ b/tooling/deployment-xdg.test.ts
@@ -1,12 +1,4 @@
-import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import {
-  closeSync,
-  mkdirSync,
-  openSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { join } from "node:path";
+import { afterEach, expect, setDefaultTimeout, test } from "bun:test";
 import {
   cleanupDeploymentFixtures,
   createDeploymentFixture,
@@ -19,135 +11,141 @@ import {
   requireCommand,
   runMake,
 } from "./deployment-test-support.ts";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
 
 afterEach(cleanupDeploymentFixtures);
-setDefaultTimeout(15_000);
+const deploymentTimeoutMilliseconds = 15_000;
+setDefaultTimeout(deploymentTimeoutMilliseconds);
 
-describe("deployment area: XDG configuration", () => {
-  test("deploys XDG links while preserving obsolete user links", () => {
-    const fixture = createDeploymentFixture("xdg-links");
-    const legacy = [".wezterm.lua", ".tmux.conf", ".gitconfig.delta"];
-    for (const name of legacy) {
-      symlinkSync(join(project, "home", name), join(fixture.home, name));
-      expect(pathExists(join(project, "home", name))).toBeFalse();
-    }
-    const targets = xdgTargets(fixture.home);
-    expectSuccess(runMake(fixture, targets, { repository: project }));
-    expect(targets.map(linkTarget)).toEqual([
-      join(project, "home", ".config", "wezterm", "wezterm.lua"),
-      join(project, "home", ".config", "tmux", "tmux.conf"),
-      join(project, "home", ".config", "git", "config.delta"),
-    ]);
-    expect(legacy.map((name) => linkTarget(join(fixture.home, name)))).toEqual(
-      legacy.map((name) => join(project, "home", name)),
-    );
-  });
-
-  test("public targets wire their XDG destinations", () => {
-    const fixture = createDeploymentFixture("xdg-wiring");
-    const targets = xdgTargets(fixture.home);
-    for (const [name, expected] of [
-      ["wezterm", targets[0]],
-      ["tmux", targets[1]],
-      ["git-delta", targets[2]],
-    ] as const) {
-      const result = runMake(fixture, [name], {
-        repository: project,
-        dryRun: true,
-      });
-      expectSuccess(result);
-      expect(result.stdout).toContain(expected);
-    }
-  });
-
-  test("migrates Git includes exactly once and preserves unrelated values", () => {
-    const fixture = createDeploymentFixture("xdg-git");
-    prepareGitDeltaFixture(fixture);
-    expectSuccess(
-      runMake(fixture, xdgTargets(fixture.home), { repository: project }),
-    );
-    expectSuccess(runGitDelta(fixture));
-    expect(includePaths(fixture)).toEqual([
-      "~/.config/git/config.delta",
-      "~/.config/git/other.conf",
-      "~/xgitconfig.delta",
-    ]);
-    const config = join(fixture.home, ".gitconfig");
-    const links = xdgTargets(fixture.home);
-    const before = {
-      config: fileIdentity(config),
-      links: links.map(fileIdentity),
-    };
-    expectSuccess(runGitDelta(fixture));
-    expect({
-      config: fileIdentity(config),
-      links: links.map(fileIdentity),
-    }).toEqual(before);
-  });
-
-  test("rolls back a failed include addition", () => {
-    const fixture = createDeploymentFixture("xdg-add-failure");
-    prepareGitDeltaFixture(fixture);
-    git(fixture, [
-      "config",
-      "--file",
-      join(fixture.home, ".gitconfig"),
-      "--unset-all",
-      "include.path",
-      "^~/.config/git/config[.]delta$",
-    ]);
-    const config = join(fixture.home, ".gitconfig");
-    const before = fileIdentity(config);
-    const result = runGitDelta(fixture, [
-      "config",
-      "--global",
-      "--add",
-      "include.path",
-      "~/.config/git/config.delta",
-    ]);
-    expect(result.exitCode).not.toBe(0);
-    expect(fileIdentity(config)).toEqual(before);
-  });
-
-  test("preserves both includes when removal fails after addition", () => {
-    const fixture = createDeploymentFixture("xdg-remove-failure");
-    prepareGitDeltaFixture(fixture);
-    git(fixture, [
-      "config",
-      "--file",
-      join(fixture.home, ".gitconfig"),
-      "--unset-all",
-      "include.path",
-      "^~/.config/git/config[.]delta$",
-    ]);
-    const result = runGitDelta(fixture, [
-      "config",
-      "--global",
-      "--unset-all",
-      "include.path",
-      "^~/[.]gitconfig[.]delta$",
-    ]);
-    expect(result.exitCode).not.toBe(0);
-    expect(includePaths(fixture)).toContain("~/.config/git/config.delta");
-    expect(includePaths(fixture)).toContain("~/.gitconfig.delta");
-  });
-
-  test("does not mutate configuration when reading includes fails", () => {
-    const fixture = createDeploymentFixture("xdg-read-failure");
-    prepareGitDeltaFixture(fixture);
-    const config = join(fixture.home, ".gitconfig");
-    const before = fileIdentity(config);
-    const result = runGitDelta(fixture, [
-      "config",
-      "--global",
-      "--get-all",
-      "include.path",
-    ]);
-    expect(result.exitCode).not.toBe(0);
-    expect(fileIdentity(config)).toEqual(before);
-  });
+test("deploys XDG links while preserving obsolete user links", () => {
+  const fixture = createDeploymentFixture("xdg-links");
+  const legacy = [".wezterm.lua", ".tmux.conf", ".gitconfig.delta"];
+  for (const name of legacy) {
+    symlinkSync(join(project, "home", name), join(fixture.home, name));
+    expect(pathExists(join(project, "home", name))).toBeFalse();
+  }
+  const targets = xdgTargets(fixture.home);
+  expectSuccess(runMake(fixture, targets, { repository: project }));
+  expect(targets.map((target) => linkTarget(target))).toEqual([
+    join(project, "home", ".config", "wezterm", "wezterm.lua"),
+    join(project, "home", ".config", "tmux", "tmux.conf"),
+    join(project, "home", ".config", "git", "config.delta"),
+  ]);
+  expect(legacy.map((name) => linkTarget(join(fixture.home, name)))).toEqual(
+    legacy.map((name) => join(project, "home", name)),
+  );
 });
 
+test("public targets wire their XDG destinations", () => {
+  const fixture = createDeploymentFixture("xdg-wiring");
+  const targets = xdgTargets(fixture.home);
+  for (const [name, expected] of [
+    ["wezterm", targets[0]],
+    ["tmux", targets[1]],
+    ["git-delta", targets[2]],
+  ] as const) {
+    const result = runMake(fixture, [name], {
+      dryRun: true,
+      repository: project,
+    });
+    expectSuccess(result);
+    expect(result.stdout).toContain(expected);
+  }
+});
+
+test("migrates Git includes exactly once and preserves unrelated values", () => {
+  const fixture = createDeploymentFixture("xdg-git");
+  prepareGitDeltaFixture(fixture);
+  expectSuccess(
+    runMake(fixture, xdgTargets(fixture.home), { repository: project }),
+  );
+  expectSuccess(runGitDelta(fixture));
+  expect(includePaths(fixture)).toEqual([
+    "~/.config/git/config.delta",
+    "~/.config/git/other.conf",
+    "~/xgitconfig.delta",
+  ]);
+  const config = join(fixture.home, ".gitconfig");
+  const links = xdgTargets(fixture.home);
+  const before = {
+    config: fileIdentity(config),
+    links: links.map((link) => fileIdentity(link)),
+  };
+  expectSuccess(runGitDelta(fixture));
+  expect({
+    config: fileIdentity(config),
+    links: links.map((link) => fileIdentity(link)),
+  }).toEqual(before);
+});
+
+test("rolls back a failed include addition", () => {
+  const fixture = createDeploymentFixture("xdg-add-failure");
+  prepareGitDeltaFixture(fixture);
+  git(fixture, [
+    "config",
+    "--file",
+    join(fixture.home, ".gitconfig"),
+    "--unset-all",
+    "include.path",
+    "^~/.config/git/config[.]delta$",
+  ]);
+  const config = join(fixture.home, ".gitconfig");
+  const before = fileIdentity(config);
+  const result = runGitDelta(fixture, [
+    "config",
+    "--global",
+    "--add",
+    "include.path",
+    "~/.config/git/config.delta",
+  ]);
+  expect(result.exitCode).not.toBe(0);
+  expect(fileIdentity(config)).toEqual(before);
+});
+
+test("preserves both includes when removal fails after addition", () => {
+  const fixture = createDeploymentFixture("xdg-remove-failure");
+  prepareGitDeltaFixture(fixture);
+  git(fixture, [
+    "config",
+    "--file",
+    join(fixture.home, ".gitconfig"),
+    "--unset-all",
+    "include.path",
+    "^~/.config/git/config[.]delta$",
+  ]);
+  const result = runGitDelta(fixture, [
+    "config",
+    "--global",
+    "--unset-all",
+    "include.path",
+    "^~/[.]gitconfig[.]delta$",
+  ]);
+  expect(result.exitCode).not.toBe(0);
+  expect(includePaths(fixture)).toContain("~/.config/git/config.delta");
+  expect(includePaths(fixture)).toContain("~/.gitconfig.delta");
+});
+
+test("does not mutate configuration when reading includes fails", () => {
+  const fixture = createDeploymentFixture("xdg-read-failure");
+  prepareGitDeltaFixture(fixture);
+  const config = join(fixture.home, ".gitconfig");
+  const before = fileIdentity(config);
+  const result = runGitDelta(fixture, [
+    "config",
+    "--global",
+    "--get-all",
+    "include.path",
+  ]);
+  expect(result.exitCode).not.toBe(0);
+  expect(fileIdentity(config)).toEqual(before);
+});
 type Fixture = ReturnType<typeof createDeploymentFixture>;
 
 function prepareGitDeltaFixture(fixture: Fixture): void {
@@ -159,8 +157,9 @@ function prepareGitDeltaFixture(fixture: Fixture): void {
     [".wezterm.lua", join(project, "home", ".wezterm.lua")],
     [".tmux.conf", join(project, "home", ".tmux.conf")],
     [".gitconfig.delta", join(project, "home", ".gitconfig.delta")],
-  ] as const)
+  ] as const) {
     symlinkSync(source, join(fixture.home, name));
+  }
   const config = join(fixture.home, ".gitconfig");
   writeFileSync(config, "");
   for (const value of [
@@ -174,7 +173,10 @@ function prepareGitDeltaFixture(fixture: Fixture): void {
   }
 }
 
-function runGitDelta(fixture: Fixture, failure?: readonly string[]) {
+function runGitDelta(
+  fixture: Fixture,
+  failure?: readonly string[],
+): ReturnType<typeof runMake> {
   const environment: NodeJS.ProcessEnv = {};
   if (failure !== undefined) {
     installProvider(fixture, "git");
@@ -184,8 +186,8 @@ function runGitDelta(fixture: Fixture, failure?: readonly string[]) {
     environment.DEPLOYMENT_FAIL_ARGUMENTS = JSON.stringify(failure);
   }
   return runMake(fixture, ["git-delta"], {
-    repository: project,
     environment,
+    repository: project,
     variables: { BREW_BIN: fixture.bin },
   });
 }
@@ -202,7 +204,9 @@ function includePaths(fixture: Fixture): string[] {
     ],
     { stdout: "pipe" },
   );
-  if (result.exitCode !== 0) throw new Error("cannot read Git includes");
+  if (result.exitCode !== 0) {
+    throw new Error("cannot read Git includes");
+  }
   return result.stdout.toString().trim().split("\n");
 }
 
@@ -210,7 +214,9 @@ function git(fixture: Fixture, arguments_: readonly string[]): void {
   const result = Bun.spawnSync([requireCommand("git"), ...arguments_], {
     env: { ...process.env, HOME: fixture.home },
   });
-  if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr.toString());
+  }
 }
 
 function xdgTargets(home: string): [string, string, string] {

--- a/tooling/format-typescript-confinement.test.ts
+++ b/tooling/format-typescript-confinement.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { join, resolve } from "node:path";
 import {
   mkdir,
   mkdtemp,
@@ -7,38 +8,100 @@ import {
   symlink,
   writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
 import { formatTypeScriptPaths } from "./format-typescript.ts";
+import { tmpdir } from "node:os";
 
 const entrypoint = resolve(import.meta.dir, "format-typescript.ts");
 const temporaryDirectories: string[] = [];
+
+type CommandResult = Readonly<{
+  status: number;
+  stderr: string;
+  stdout: string;
+}>;
 
 afterEach(async () => {
   await Promise.all(
     temporaryDirectories
       .splice(0)
-      .map((directory) => rm(directory, { recursive: true, force: true })),
+      .map((directory) => rm(directory, { force: true, recursive: true })),
   );
 });
 
-async function run(command: string[], cwd: string) {
-  const process = Bun.spawn(command, { cwd, stdout: "pipe", stderr: "pipe" });
+async function run(
+  command: readonly string[],
+  cwd: string,
+): Promise<CommandResult> {
+  const process = Bun.spawn([...command], {
+    cwd,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
   const [status, stdout, stderr] = await Promise.all([
     process.exited,
     new Response(process.stdout).text(),
     new Response(process.stderr).text(),
   ]);
-  return { status, stdout, stderr };
+  return { status, stderr, stdout };
 }
 
-async function createRepository() {
+async function createRepository(): Promise<string> {
   const repository = await mkdtemp(
     join(tmpdir(), "format-typescript-confinement-"),
   );
   temporaryDirectories.push(repository);
-  expect((await run(["git", "init", "-q"], repository)).status).toBe(0);
+  const initialization = await run(["git", "init", "-q"], repository);
+  expect(initialization.status).toBe(0);
   return repository;
+}
+
+type ReplacementFixture = Readonly<{
+  externalDirectory: string;
+  movedDirectory: string;
+  repository: string;
+  trackedDirectory: string;
+}>;
+
+async function createReplacementFixture(): Promise<ReplacementFixture> {
+  const repository = await createRepository();
+  const trackedDirectory = join(repository, "tracked");
+  const movedDirectory = join(repository, "moved");
+  const externalDirectory = await mkdtemp(
+    join(tmpdir(), "format-typescript-external-"),
+  );
+  temporaryDirectories.push(externalDirectory);
+  await mkdir(trackedDirectory);
+  await writeFile(join(repository, "first.ts"), "export const first=1\n");
+  await writeFile(
+    join(trackedDirectory, "victim.ts"),
+    "export const victim=1\n",
+  );
+  await writeFile(
+    join(externalDirectory, "victim.ts"),
+    "export const outside=1\n",
+  );
+  return { externalDirectory, movedDirectory, repository, trackedDirectory };
+}
+
+function replaceDirectoryDuringFormatting(fixture: ReplacementFixture): void {
+  expect(
+    formatTypeScriptPaths(["first.ts", "tracked/victim.ts"], {
+      check: false,
+      formatSource: async (path) => {
+        if (path === "tracked/victim.ts") {
+          await rename(fixture.trackedDirectory, fixture.movedDirectory);
+          await symlink(
+            fixture.externalDirectory,
+            fixture.trackedDirectory,
+            "dir",
+          );
+        }
+        const name = path === "first.ts" ? "first" : "victim";
+        return { code: `export const ${name} = 1;\n`, errors: [] };
+      },
+      repositoryRoot: fixture.repository,
+    }),
+  ).rejects.toThrow("Git could not publish the TypeScript formatting patch");
 }
 
 describe("format-typescript confinement", () => {
@@ -51,9 +114,8 @@ describe("format-typescript confinement", () => {
       join(trackedDirectory, "victim.ts"),
       "export const victim=1\n",
     );
-    expect(
-      (await run(["git", "add", "tracked/victim.ts"], repository)).status,
-    ).toBe(0);
+    const addition = await run(["git", "add", "tracked/victim.ts"], repository);
+    expect(addition.status).toBe(0);
     await rename(trackedDirectory, internalTarget);
     await symlink("internal-target", trackedDirectory, "dir");
 
@@ -70,48 +132,16 @@ describe("format-typescript confinement", () => {
   });
 
   test("refuses publication when a directory path is replaced after formatting starts", async () => {
-    const repository = await createRepository();
-    const trackedDirectory = join(repository, "tracked");
-    const movedDirectory = join(repository, "moved");
-    const externalDirectory = await mkdtemp(
-      join(tmpdir(), "format-typescript-external-"),
-    );
-    temporaryDirectories.push(externalDirectory);
-    await mkdir(trackedDirectory);
-    await writeFile(join(repository, "first.ts"), "export const first=1\n");
-    await writeFile(
-      join(trackedDirectory, "victim.ts"),
-      "export const victim=1\n",
-    );
-    await writeFile(
-      join(externalDirectory, "victim.ts"),
-      "export const outside=1\n",
-    );
-
-    await expect(
-      formatTypeScriptPaths(
-        ["first.ts", "tracked/victim.ts"],
-        false,
-        async (path) => {
-          if (path === "tracked/victim.ts") {
-            await rename(trackedDirectory, movedDirectory);
-            await symlink(externalDirectory, trackedDirectory, "dir");
-          }
-          const name = path === "first.ts" ? "first" : "victim";
-          return { code: `export const ${name} = 1;\n`, errors: [] };
-        },
-        repository,
-      ),
-    ).rejects.toThrow("Git could not publish the TypeScript formatting patch");
-
-    expect(await Bun.file(join(externalDirectory, "victim.ts")).text()).toBe(
-      "export const outside=1\n",
-    );
-    expect(await Bun.file(join(repository, "first.ts")).text()).toBe(
+    const fixture = await createReplacementFixture();
+    replaceDirectoryDuringFormatting(fixture);
+    expect(
+      await Bun.file(join(fixture.externalDirectory, "victim.ts")).text(),
+    ).toBe("export const outside=1\n");
+    expect(await Bun.file(join(fixture.repository, "first.ts")).text()).toBe(
       "export const first=1\n",
     );
-    expect(await Bun.file(join(movedDirectory, "victim.ts")).text()).toBe(
-      "export const victim=1\n",
-    );
+    expect(
+      await Bun.file(join(fixture.movedDirectory, "victim.ts")).text(),
+    ).toBe("export const victim=1\n");
   });
 });

--- a/tooling/format-typescript.test.ts
+++ b/tooling/format-typescript.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
 import {
   chmod,
   link,
@@ -8,51 +8,73 @@ import {
   symlink,
   writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
 
 const entrypoint = resolve(import.meta.dir, "format-typescript.ts");
 const temporaryDirectories: string[] = [];
+const executableFileMode = 0o755;
+const unavailableCommandExitCode = 42;
+const invalidInvocationExitCode = 2;
+const trackedFiles = [
+  "-leading.ts",
+  ".hidden/future.ts",
+  "ignored/forced.tsx",
+  "types/future file.mts",
+  "types/future.cts",
+  "types/future.d.ts",
+];
+
+type CommandResult = Readonly<{
+  status: number;
+  stderr: string;
+  stdout: string;
+}>;
 
 afterEach(async () => {
   await Promise.all(
     temporaryDirectories
       .splice(0)
-      .map((directory) => rm(directory, { recursive: true, force: true })),
+      .map((directory) => rm(directory, { force: true, recursive: true })),
   );
 });
 
 async function run(
-  command: string[],
+  command: readonly string[],
   cwd: string,
-  environment: Record<string, string | undefined> = {},
-) {
-  const process = Bun.spawn(command, {
+  environment: Readonly<Record<string, string | undefined>> = {},
+): Promise<CommandResult> {
+  const process = Bun.spawn([...command], {
     cwd,
     env: { ...Bun.env, ...environment },
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   });
   const [status, stdout, stderr] = await Promise.all([
     process.exited,
     new Response(process.stdout).text(),
     new Response(process.stderr).text(),
   ]);
-  return { status, stdout, stderr };
+  return { status, stderr, stdout };
 }
 
 function runEntrypoint(
-  arguments_: string[],
+  commandArguments: readonly string[],
   cwd: string,
-  environment: Record<string, string | undefined> = {},
-) {
-  return run([process.execPath, entrypoint, ...arguments_], cwd, environment);
+  environment: Readonly<Record<string, string | undefined>> = {},
+): Promise<CommandResult> {
+  return run(
+    [process.execPath, entrypoint, ...commandArguments],
+    cwd,
+    environment,
+  );
 }
 
-async function createRepository() {
+async function createRepository(): Promise<string> {
   const repository = await mkdtemp(join(tmpdir(), "format-typescript-"));
   temporaryDirectories.push(repository);
-  expect((await run(["git", "init", "-q"], repository)).status).toBe(0);
+  const initialization = await run(["git", "init", "-q"], repository);
+  expect(initialization.status).toBe(0);
   return repository;
 }
 
@@ -60,150 +82,142 @@ async function createFakeCommand(
   directory: string,
   name: string,
   body: string,
-) {
+): Promise<void> {
   await mkdir(directory, { recursive: true });
   const path = join(directory, name);
   await writeFile(path, `#!/usr/bin/env bash\n${body}\n`);
-  await chmod(path, 0o755);
+  await chmod(path, executableFileMode);
 }
 
-describe("format-typescript entry point", () => {
-  test("passes every tracked TypeScript path to Oxfmt without including untracked files", async () => {
-    const repository = await createRepository();
-    const trackedFiles = [
-      "-leading.ts",
-      ".hidden/future.ts",
-      "ignored/forced.tsx",
-      "types/future file.mts",
-      "types/future.cts",
-      "types/future.d.ts",
-    ];
-    await Promise.all(
-      trackedFiles
-        .concat(["untracked.ts", "not-typescript.js"])
-        .map(async (file) => {
-          await mkdir(join(repository, file, ".."), { recursive: true });
-          await writeFile(join(repository, file), "export const value=1\n");
-        }),
-    );
-    await writeFile(join(repository, ".gitignore"), "ignored/\n");
-    expect(
-      (
-        await run(
-          ["git", "add", "--", ".gitignore", ...trackedFiles],
-          repository,
-        )
-      ).status,
-    ).not.toBe(0);
-    expect(
-      (
-        await run(
-          [
-            "git",
-            "add",
-            "--",
-            ".gitignore",
-            ...trackedFiles.filter((file) => !file.startsWith("ignored/")),
-          ],
-          repository,
-        )
-      ).status,
-    ).toBe(0);
-    expect(
-      (await run(["git", "add", "-f", "--", "ignored/forced.tsx"], repository))
-        .status,
-    ).toBe(0);
+test("passes every tracked TypeScript path to Oxfmt without including untracked files", async () => {
+  const repository = await createRepository();
+  await Promise.all(
+    [...trackedFiles, "untracked.ts", "not-typescript.js"].map(async (file) => {
+      await mkdir(join(repository, file, ".."), { recursive: true });
+      await writeFile(join(repository, file), "export const value=1\n");
+    }),
+  );
+  await writeFile(join(repository, ".gitignore"), "ignored/\n");
+  const rejectedIgnoredFile = await run(
+    ["git", "add", "--", ".gitignore", ...trackedFiles],
+    repository,
+  );
+  const trackedAddition = await run(
+    [
+      "git",
+      "add",
+      "--",
+      ".gitignore",
+      ...trackedFiles.filter((file) => !file.startsWith("ignored/")),
+    ],
+    repository,
+  );
+  const forcedAddition = await run(
+    ["git", "add", "-f", "--", "ignored/forced.tsx"],
+    repository,
+  );
+  expect(rejectedIgnoredFile.status).not.toBe(0);
+  expect(trackedAddition.status).toBe(0);
+  expect(forcedAddition.status).toBe(0);
 
-    expect((await runEntrypoint(["--check"], repository)).status).toBe(1);
-    expect((await runEntrypoint([], repository)).status).toBe(0);
-    expect((await runEntrypoint(["--check"], repository)).status).toBe(0);
-    for (const file of trackedFiles) {
-      expect(await Bun.file(join(repository, file)).text()).not.toContain(
-        "value=1",
-      );
-    }
-    expect(await Bun.file(join(repository, "untracked.ts")).text()).toBe(
-      "export const value=1\n",
+  const initialCheck = await runEntrypoint(["--check"], repository);
+  const formatting = await runEntrypoint([], repository);
+  const finalCheck = await runEntrypoint(["--check"], repository);
+  expect(initialCheck.status).toBe(1);
+  expect(formatting.status).toBe(0);
+  expect(finalCheck.status).toBe(0);
+  for (const file of trackedFiles) {
+    expect(await Bun.file(join(repository, file)).text()).not.toContain(
+      "value=1",
     );
+  }
+  expect(await Bun.file(join(repository, "untracked.ts")).text()).toBe(
+    "export const value=1\n",
+  );
+});
+
+test("fails closed when discovery is empty or unavailable", async () => {
+  const repository = await createRepository();
+  await writeFile(
+    join(repository, "not-typescript.js"),
+    "export const value = 1;\n",
+  );
+  const addition = await run(["git", "add", "not-typescript.js"], repository);
+  expect(addition.status).toBe(0);
+  const empty = await runEntrypoint(["--check"], repository);
+  expect(empty.status).toBe(1);
+  expect(empty.stderr).toContain("No tracked TypeScript files found");
+
+  const binaryDirectory = join(repository, "bin");
+  await createFakeCommand(
+    binaryDirectory,
+    "git",
+    `exit ${unavailableCommandExitCode}`,
+  );
+  const unavailable = await runEntrypoint(["--check"], repository, {
+    PATH: `${binaryDirectory}:${Bun.env.PATH}`,
   });
+  expect(unavailable.status).toBe(unavailableCommandExitCode);
+});
 
-  test("fails closed when discovery is empty or unavailable", async () => {
-    const repository = await createRepository();
-    await writeFile(
-      join(repository, "not-typescript.js"),
-      "export const value = 1;\n",
-    );
-    expect(
-      (await run(["git", "add", "not-typescript.js"], repository)).status,
-    ).toBe(0);
-    const empty = await runEntrypoint(["--check"], repository);
-    expect(empty.status).toBe(1);
-    expect(empty.stderr).toContain("No tracked TypeScript files found");
+test("refuses a tracked symlink before formatting its external target", async () => {
+  const repository = await createRepository();
+  const externalDirectory = await mkdtemp(
+    join(tmpdir(), "format-typescript-external-"),
+  );
+  temporaryDirectories.push(externalDirectory);
+  const externalTarget = join(externalDirectory, "outside.ts");
+  await writeFile(externalTarget, "export const outside=1\n");
+  await symlink(externalTarget, join(repository, "linked.ts"));
+  const addition = await run(["git", "add", "linked.ts"], repository);
+  expect(addition.status).toBe(0);
 
-    const binaryDirectory = join(repository, "bin");
-    await createFakeCommand(binaryDirectory, "git", "exit 42");
-    const unavailable = await runEntrypoint(["--check"], repository, {
-      PATH: `${binaryDirectory}:${Bun.env.PATH}`,
-    });
-    expect(unavailable.status).toBe(42);
+  const result = await runEntrypoint([], repository);
+  expect(result.status).not.toBe(0);
+  expect(await Bun.file(externalTarget).text()).toBe(
+    "export const outside=1\n",
+  );
+});
+
+test("refuses a tracked hard link before formatting its external inode", async () => {
+  const repository = await createRepository();
+  const externalDirectory = await mkdtemp(
+    join(tmpdir(), "format-typescript-external-"),
+  );
+  temporaryDirectories.push(externalDirectory);
+  const externalTarget = join(externalDirectory, "outside.ts");
+  await writeFile(externalTarget, "export const outside=1\n");
+  await link(externalTarget, join(repository, "linked.ts"));
+  const addition = await run(["git", "add", "linked.ts"], repository);
+  expect(addition.status).toBe(0);
+
+  const result = await runEntrypoint([], repository);
+  expect(result.status).not.toBe(0);
+  expect(await Bun.file(externalTarget).text()).toBe(
+    "export const outside=1\n",
+  );
+});
+
+test("rejects malformed Git path evidence", async () => {
+  const repository = await createRepository();
+  const binaryDirectory = join(repository, "bin");
+  await createFakeCommand(binaryDirectory, "git", String.raw`printf '\377\0'`);
+
+  const result = await runEntrypoint(["--check"], repository, {
+    PATH: `${binaryDirectory}:${Bun.env.PATH}`,
   });
+  expect(result.status).toBe(1);
+  expect(result.stderr).not.toBe("");
+});
 
-  test("refuses a tracked symlink before formatting its external target", async () => {
-    const repository = await createRepository();
-    const externalDirectory = await mkdtemp(
-      join(tmpdir(), "format-typescript-external-"),
-    );
-    temporaryDirectories.push(externalDirectory);
-    const externalTarget = join(externalDirectory, "outside.ts");
-    await writeFile(externalTarget, "export const outside=1\n");
-    await symlink(externalTarget, join(repository, "linked.ts"));
-    expect((await run(["git", "add", "linked.ts"], repository)).status).toBe(0);
+test("rejects unknown arguments and invalid TypeScript", async () => {
+  const repository = await createRepository();
+  const invalid = await runEntrypoint(["--write"], repository);
+  expect(invalid.status).toBe(invalidInvocationExitCode);
 
-    const result = await runEntrypoint([], repository);
-    expect(result.status).not.toBe(0);
-    expect(await Bun.file(externalTarget).text()).toBe(
-      "export const outside=1\n",
-    );
-  });
-
-  test("refuses a tracked hard link before formatting its external inode", async () => {
-    const repository = await createRepository();
-    const externalDirectory = await mkdtemp(
-      join(tmpdir(), "format-typescript-external-"),
-    );
-    temporaryDirectories.push(externalDirectory);
-    const externalTarget = join(externalDirectory, "outside.ts");
-    await writeFile(externalTarget, "export const outside=1\n");
-    await link(externalTarget, join(repository, "linked.ts"));
-    expect((await run(["git", "add", "linked.ts"], repository)).status).toBe(0);
-
-    const result = await runEntrypoint([], repository);
-    expect(result.status).not.toBe(0);
-    expect(await Bun.file(externalTarget).text()).toBe(
-      "export const outside=1\n",
-    );
-  });
-
-  test("rejects malformed Git path evidence", async () => {
-    const repository = await createRepository();
-    const binaryDirectory = join(repository, "bin");
-    await createFakeCommand(binaryDirectory, "git", "printf '\\377\\0'");
-
-    const result = await runEntrypoint(["--check"], repository, {
-      PATH: `${binaryDirectory}:${Bun.env.PATH}`,
-    });
-    expect(result.status).toBe(1);
-    expect(result.stderr).not.toBe("");
-  });
-
-  test("rejects unknown arguments and invalid TypeScript", async () => {
-    const repository = await createRepository();
-    const invalid = await runEntrypoint(["--write"], repository);
-    expect(invalid.status).toBe(2);
-
-    await writeFile(join(repository, "future.ts"), "export const = 1;\n");
-    expect((await run(["git", "add", "future.ts"], repository)).status).toBe(0);
-    const failed = await runEntrypoint(["--check"], repository);
-    expect(failed.status).not.toBe(0);
-  });
+  await writeFile(join(repository, "future.ts"), "export const = 1;\n");
+  const addition = await run(["git", "add", "future.ts"], repository);
+  expect(addition.status).toBe(0);
+  const failed = await runEntrypoint(["--check"], repository);
+  expect(failed.status).not.toBe(0);
 });

--- a/tooling/format-typescript.ts
+++ b/tooling/format-typescript.ts
@@ -1,3 +1,4 @@
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
   lstat,
   mkdir,
@@ -7,11 +8,10 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
-import { format, type FormatConfig } from "oxfmt";
-import { z } from "zod";
+import { format } from "oxfmt";
 import formatConfig from "../oxfmt.config.ts";
+import { tmpdir } from "node:os";
+import { z } from "zod";
 
 const invocationSchema = z.union([
   z.tuple([]),
@@ -32,16 +32,24 @@ const typescriptPathsSchema = z.array(typescriptPathSchema).min(1);
 type FormatSource = (
   fileName: string,
   sourceText: string,
-  options?: FormatConfig,
 ) => ReturnType<typeof format>;
 
-type FormattingChange = {
+type FormattingChange = Readonly<{
   path: string;
   source: string;
   formatted: string;
-};
+}>;
 
-function isOutside(root: string, path: string) {
+type FormatTypeScriptOptions = Readonly<{
+  check: boolean;
+  formatSource?: FormatSource;
+  repositoryRoot?: string;
+}>;
+
+const invalidInvocationExitCode = 2;
+const argumentOffset = 2;
+
+function isOutside(root: string, path: string): boolean {
   const pathFromRoot = relative(root, path);
   return (
     pathFromRoot === ".." ||
@@ -50,12 +58,14 @@ function isOutside(root: string, path: string) {
   );
 }
 
-async function findTrackedTypeScriptPaths() {
+async function findTrackedTypeScriptPaths(): Promise<
+  Readonly<{ paths: readonly string[] | undefined; status: number }>
+> {
   const git = Bun.spawn(
     ["git", "ls-files", "-z", "--", "*.ts", "*.tsx", "*.mts", "*.cts"],
     {
-      stdout: "pipe",
       stderr: "inherit",
+      stdout: "pipe",
     },
   );
   const [status, output] = await Promise.all([
@@ -63,7 +73,7 @@ async function findTrackedTypeScriptPaths() {
     new Response(git.stdout).arrayBuffer(),
   ]);
   if (status !== 0) {
-    return { status, paths: undefined };
+    return { paths: undefined, status };
   }
   const serializedPaths = new TextDecoder("utf-8", { fatal: true }).decode(
     output,
@@ -77,10 +87,10 @@ async function findTrackedTypeScriptPaths() {
   const paths = typescriptPathsSchema.parse(
     serializedPaths.slice(0, -1).split("\0"),
   );
-  return { status, paths };
+  return { paths, status };
 }
 
-async function readOwnedFile(root: string, path: string) {
+async function readOwnedFile(root: string, path: string): Promise<string> {
   const absolutePath = resolve(root, path);
   if (
     isOutside(root, absolutePath) ||
@@ -105,7 +115,9 @@ async function readOwnedFile(root: string, path: string) {
   }
 }
 
-async function createPatch(changes: FormattingChange[]) {
+async function createPatch(
+  changes: readonly FormattingChange[],
+): Promise<readonly number[]> {
   const temporaryRoot = await mkdtemp(join(tmpdir(), "dotfiles-oxfmt-"));
   try {
     for (const change of changes) {
@@ -133,7 +145,7 @@ async function createPatch(changes: FormattingChange[]) {
         "before",
         "after",
       ],
-      { cwd: temporaryRoot, stdout: "pipe", stderr: "inherit" },
+      { cwd: temporaryRoot, stderr: "inherit", stdout: "pipe" },
     );
     const [status, patch] = await Promise.all([
       diff.exited,
@@ -144,18 +156,21 @@ async function createPatch(changes: FormattingChange[]) {
         `Git could not build the TypeScript formatting patch (status ${status}).`,
       );
     }
-    return new Uint8Array(patch);
+    return [...new Uint8Array(patch)];
   } finally {
-    await rm(temporaryRoot, { recursive: true, force: true });
+    await rm(temporaryRoot, { force: true, recursive: true });
   }
 }
 
-async function applyPatch(root: string, patch: Uint8Array) {
+async function applyPatch(
+  root: string,
+  patch: readonly number[],
+): Promise<void> {
   const apply = Bun.spawn(["git", "apply", "-p2", "--whitespace=nowarn"], {
     cwd: root,
-    stdin: new Blob([patch]),
-    stdout: "inherit",
     stderr: "inherit",
+    stdin: new Blob([Uint8Array.from(patch)]),
+    stdout: "inherit",
   });
   const status = await apply.exited;
   if (status !== 0) {
@@ -165,24 +180,32 @@ async function applyPatch(root: string, patch: Uint8Array) {
   }
 }
 
-export async function formatTypeScriptPaths(
-  paths: string[],
-  check: boolean,
-  formatSource: FormatSource = format,
-  repositoryRoot: string = process.cwd(),
-) {
+async function formatTypeScriptPaths(
+  paths: readonly string[],
+  options: FormatTypeScriptOptions,
+): Promise<string[]> {
+  const {
+    check,
+    formatSource = (
+      fileName: string,
+      sourceText: string,
+    ): ReturnType<typeof format> => format(fileName, sourceText, formatConfig),
+    repositoryRoot = process.cwd(),
+  } = options;
   const root = await realpath(repositoryRoot);
   const changes: FormattingChange[] = [];
   for (const path of paths) {
     const source = await readOwnedFile(root, path);
-    const result = await formatSource(path, source, formatConfig);
+    const result = await formatSource(path, source);
     if (result.errors.length > 0) {
-      throw new Error(
-        `${path}: ${result.errors.map((error) => error.message).join("; ")}`,
-      );
+      const messages: string[] = [];
+      for (const error of result.errors) {
+        messages.push(error.message);
+      }
+      throw new Error(`${path}: ${messages.join("; ")}`);
     }
     if (result.code !== source) {
-      changes.push({ path, source, formatted: result.code });
+      changes.push({ formatted: result.code, path, source });
     }
   }
   if (!check && changes.length > 0) {
@@ -191,24 +214,26 @@ export async function formatTypeScriptPaths(
   return changes.map((change) => change.path);
 }
 
-async function main() {
-  const invocation = invocationSchema.safeParse(Bun.argv.slice(2));
+async function main(): Promise<number> {
+  const invocation = invocationSchema.safeParse(Bun.argv.slice(argumentOffset));
   if (!invocation.success) {
-    console.error("Usage: format-typescript [--check]");
-    return 2;
+    process.stderr.write("Usage: format-typescript [--check]\n");
+    return invalidInvocationExitCode;
   }
   const discovery = await findTrackedTypeScriptPaths();
   if (!discovery.paths) {
     return discovery.status;
   }
   const check = invocation.data.length === 1;
-  const different = await formatTypeScriptPaths(discovery.paths, check);
+  const different = await formatTypeScriptPaths(discovery.paths, { check });
   if (check && different.length > 0) {
-    console.error(`TypeScript formatting differs: ${different.join(", ")}`);
+    process.stderr.write(
+      `TypeScript formatting differs: ${different.join(", ")}\n`,
+    );
     return 1;
   }
-  console.log(
-    `${check ? "Checked" : "Formatted"} ${discovery.paths.length} TypeScript files.`,
+  process.stdout.write(
+    `${check ? "Checked" : "Formatted"} ${discovery.paths.length} TypeScript files.\n`,
   );
   return 0;
 }
@@ -217,7 +242,11 @@ if (import.meta.main) {
   try {
     process.exitCode = await main();
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
     process.exitCode = 1;
   }
 }
+
+export { formatTypeScriptPaths };

--- a/tooling/git-main-branch-cli.ts
+++ b/tooling/git-main-branch-cli.ts
@@ -1,10 +1,10 @@
 import {
+  type RepositoryEvidence,
   parseBitbucketIdentity,
   parseCloudContexts,
   parseProviderRepository,
   parseRemoteHead,
   reconcileProviderEvidence,
-  type RepositoryEvidence,
 } from "./git-main-branch-core.ts";
 
 type CommandResult = Readonly<{
@@ -16,31 +16,35 @@ type CommandResult = Readonly<{
 function run(command: string, arguments_: readonly string[]): CommandResult {
   try {
     const result = Bun.spawnSync([command, ...arguments_], {
-      stdout: "pipe",
       stderr: "pipe",
+      stdout: "pipe",
     });
     return {
       status: result.exitCode,
-      stdout: result.stdout.toString(),
       stderr: result.stderr.toString(),
+      stdout: result.stdout.toString(),
     };
   } catch (error) {
     return {
       status: 127,
-      stdout: "",
       stderr: `${command} is unavailable: ${String(error)}\n`,
+      stdout: "",
     };
   }
 }
 
 function fail(message: string, detail = "", status = 1): never {
-  if (detail !== "") process.stderr.write(detail);
+  if (detail !== "") {
+    process.stderr.write(detail);
+  }
   process.stderr.write(`git-main-branch: ${message}\n`);
   process.exit(status);
 }
 
 function exitWithDetail(detail: string, status: number): never {
-  if (detail !== "") process.stderr.write(detail);
+  if (detail !== "") {
+    process.stderr.write(detail);
+  }
   process.exit(status);
 }
 
@@ -48,34 +52,43 @@ function validateBranch(
   branch: string,
   gitArguments: readonly string[],
   source: string,
-) {
+): void {
   const result = run("git", [
     ...gitArguments,
     "check-ref-format",
     "--branch",
     branch,
   ]);
-  if (result.status !== 0)
+  if (result.status !== 0) {
     fail(
       `${source} returned an invalid branch ${JSON.stringify(branch)}`,
       result.stderr,
     );
+  }
 }
 
-function parseArguments(arguments_: readonly string[]) {
-  let strict = false;
+function parseArguments(arguments_: readonly string[]): Readonly<{
+  bitbucketCloud: boolean;
+  gitArguments: readonly string[];
+  strict: boolean;
+}> {
   let bitbucketCloud = false;
   let offset = 0;
+  let strict = false;
   while (offset < arguments_.length) {
-    if (arguments_[offset] === "--strict") strict = true;
-    else if (arguments_[offset] === "--bitbucket-cloud") bitbucketCloud = true;
-    else break;
+    if (arguments_[offset] === "--strict") {
+      strict = true;
+    } else if (arguments_[offset] === "--bitbucket-cloud") {
+      bitbucketCloud = true;
+    } else {
+      break;
+    }
     offset += 1;
   }
   return {
-    strict,
     bitbucketCloud,
     gitArguments: arguments_.slice(offset),
+    strict,
   } as const;
 }
 
@@ -85,7 +98,9 @@ function resolveGeneric(
 ): string {
   const repository = run("git", [...gitArguments, "rev-parse", "--git-dir"]);
   if (repository.status !== 0) {
-    if (strict) exitWithDetail(repository.stderr, 1);
+    if (strict) {
+      exitWithDetail(repository.stderr, 1);
+    }
     return "main";
   }
   for (const branch of ["main", "master", "trunk"] as const) {
@@ -96,9 +111,13 @@ function resolveGeneric(
       "--verify",
       `refs/heads/${branch}`,
     ]);
-    if (result.status === 0) return branch;
+    if (result.status === 0) {
+      return branch;
+    }
     if (result.status !== 1) {
-      if (strict) exitWithDetail(result.stderr, result.status);
+      if (strict) {
+        exitWithDetail(result.stderr, result.status);
+      }
       process.stderr.write(result.stderr);
     }
   }
@@ -111,7 +130,9 @@ function requireCommand(
   purpose: string,
 ): string {
   const result = run(command, arguments_);
-  if (result.status !== 0) fail(purpose, result.stderr);
+  if (result.status !== 0) {
+    fail(purpose, result.stderr);
+  }
   return result.stdout;
 }
 
@@ -124,11 +145,51 @@ function cloudContext(): string {
   try {
     return parseCloudContexts(contextOutput);
   } catch (error) {
-    fail(error instanceof Error ? error.message : String(error));
+    return fail(error instanceof Error ? error.message : String(error));
   }
 }
 
 type ProviderRepository = Readonly<{ uuid: string; branch: string }>;
+type RemoteEvidenceOptions = Readonly<{
+  gitArguments: readonly string[];
+  providerForIdentity: (identity: string) => ProviderRepository;
+}>;
+
+function parseProviderEvidence(
+  output: string,
+  identity: string,
+): ProviderRepository {
+  try {
+    return parseProviderRepository(output, identity);
+  } catch (error) {
+    return fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function remoteBranchFor(
+  remote: string,
+  output: string,
+  gitArguments: readonly string[],
+): string {
+  try {
+    const branch = parseRemoteHead(output);
+    validateBranch(branch, gitArguments, `remote ${remote}`);
+    return branch;
+  } catch (error) {
+    return fail(
+      `${remote}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function identityForRemote(remote: string, url: string): string {
+  try {
+    return parseBitbucketIdentity(url).identity;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return fail(`remote ${remote}: ${detail}`);
+  }
+}
 
 function providerRepository(
   identity: string,
@@ -140,12 +201,7 @@ function providerRepository(
     ["--context", context, "api", `/repositories/${identity}`, "--json"],
     `unable to query Bitbucket repository ${identity}`,
   );
-  let provider: ProviderRepository;
-  try {
-    provider = parseProviderRepository(output, identity);
-  } catch (error) {
-    fail(error instanceof Error ? error.message : String(error));
-  }
+  const provider = parseProviderEvidence(output, identity);
   validateBranch(
     provider.branch,
     gitArguments,
@@ -156,10 +212,9 @@ function providerRepository(
 
 function evidenceForRemote(
   remote: string,
-  context: string,
-  gitArguments: readonly string[],
-  providerCache: Map<string, ProviderRepository>,
+  options: RemoteEvidenceOptions,
 ): RepositoryEvidence[] {
+  const { gitArguments, providerForIdentity } = options;
   const urls = requireCommand(
     "git",
     [...gitArguments, "remote", "get-url", "--all", remote],
@@ -167,48 +222,34 @@ function evidenceForRemote(
   )
     .split("\n")
     .filter((url) => url !== "");
-  if (urls.length === 0) fail(`remote ${remote} has no fetch URL`);
+  if (urls.length === 0) {
+    fail(`remote ${remote} has no fetch URL`);
+  }
 
   const headOutput = requireCommand(
     "git",
     [...gitArguments, "ls-remote", "--symref", remote, "HEAD"],
     `unable to read remote HEAD for ${remote}`,
   );
-  let remoteBranch: string;
-  try {
-    remoteBranch = parseRemoteHead(headOutput);
-  } catch (error) {
-    fail(
-      `${remote}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-  validateBranch(remoteBranch, gitArguments, `remote ${remote}`);
+  const remoteBranch = remoteBranchFor(remote, headOutput, gitArguments);
 
   return urls.map((url) => {
-    let parsed: ReturnType<typeof parseBitbucketIdentity>;
-    try {
-      parsed = parseBitbucketIdentity(url);
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error);
-      fail(`remote ${remote}: ${detail}`);
-    }
-    const provider =
-      providerCache.get(parsed.identity) ??
-      providerRepository(parsed.identity, context, gitArguments);
-    providerCache.set(parsed.identity, provider);
+    const identity = identityForRemote(remote, url);
+    const provider = providerForIdentity(identity);
     return {
-      identity: parsed.identity,
+      identity,
+      providerBranch: provider.branch,
       remoteBranch,
       uuid: provider.uuid,
-      providerBranch: provider.branch,
     };
   });
 }
 
 function resolveBitbucketCloud(gitArguments: readonly string[]): string {
   const repository = run("git", [...gitArguments, "rev-parse", "--git-dir"]);
-  if (repository.status !== 0)
+  if (repository.status !== 0) {
     fail("unable to inspect the Git repository", repository.stderr);
+  }
 
   const remoteOutput = requireCommand(
     "git",
@@ -216,17 +257,28 @@ function resolveBitbucketCloud(gitArguments: readonly string[]): string {
     "unable to list Git remotes",
   );
   const remotes = remoteOutput.split("\n").filter((remote) => remote !== "");
-  if (remotes.length === 0) fail("no Git remote is configured");
+  if (remotes.length === 0) {
+    fail("no Git remote is configured");
+  }
 
   const context = cloudContext();
   const providerCache = new Map<string, ProviderRepository>();
+  const providerForIdentity = (identity: string): ProviderRepository => {
+    const cached = providerCache.get(identity);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const provider = providerRepository(identity, context, gitArguments);
+    providerCache.set(identity, provider);
+    return provider;
+  };
   const evidence = remotes.flatMap((remote) =>
-    evidenceForRemote(remote, context, gitArguments, providerCache),
+    evidenceForRemote(remote, { gitArguments, providerForIdentity }),
   );
   try {
     return reconcileProviderEvidence(evidence);
   } catch (error) {
-    fail(error instanceof Error ? error.message : String(error));
+    return fail(error instanceof Error ? error.message : String(error));
   }
 }
 

--- a/tooling/git-main-branch-core.test.ts
+++ b/tooling/git-main-branch-core.test.ts
@@ -16,8 +16,8 @@ describe("parseBitbucketIdentity", () => {
   ])("parses %s", (url, identity) => {
     expect(parseBitbucketIdentity(url)).toEqual({
       identity,
-      workspace: "acme",
       slug: "service",
+      workspace: "acme",
     });
   });
 
@@ -27,9 +27,9 @@ describe("parseBitbucketIdentity", () => {
     "https://bitbucket.org/acme/service/extra",
     "https://bitbucket.org/acme/%2Fservice",
     "ssh://someone@bitbucket.org/acme/service.git",
-  ])("rejects %s", (url) =>
-    expect(() => parseBitbucketIdentity(url)).toThrow(),
-  );
+  ])("rejects %s", (url) => {
+    expect(() => parseBitbucketIdentity(url)).toThrow();
+  });
 
   test("does not expose URL credentials in diagnostics", () => {
     const secret = "example-secret";
@@ -70,8 +70,8 @@ test("provider repositories require validated identity, UUID and branch", () => 
       "acme/service",
     ),
   ).toEqual({
-    uuid: "{11111111-1111-1111-1111-111111111111}",
     branch: "develop",
+    uuid: "{11111111-1111-1111-1111-111111111111}",
   });
   expect(() => parseProviderRepository("{}", "acme/service")).toThrow(
     "repository response",
@@ -104,15 +104,15 @@ test("reconciliation accepts equivalent evidence and refuses conflicts", () => {
     reconcileProviderEvidence([
       {
         identity: "acme/service",
+        providerBranch: "develop",
         remoteBranch: "develop",
         uuid: "{same}",
-        providerBranch: "develop",
       },
       {
         identity: "acme/service",
+        providerBranch: "develop",
         remoteBranch: "develop",
         uuid: "{same}",
-        providerBranch: "develop",
       },
     ]),
   ).toBe("develop");
@@ -120,15 +120,15 @@ test("reconciliation accepts equivalent evidence and refuses conflicts", () => {
     reconcileProviderEvidence([
       {
         identity: "acme/service",
+        providerBranch: "develop",
         remoteBranch: "develop",
         uuid: "{a}",
-        providerBranch: "develop",
       },
       {
         identity: "acme/other",
+        providerBranch: "develop",
         remoteBranch: "develop",
         uuid: "{b}",
-        providerBranch: "develop",
       },
     ]),
   ).toThrow("same repository");
@@ -136,9 +136,9 @@ test("reconciliation accepts equivalent evidence and refuses conflicts", () => {
     reconcileProviderEvidence([
       {
         identity: "acme/service",
+        providerBranch: "main",
         remoteBranch: "develop",
         uuid: "{a}",
-        providerBranch: "main",
       },
     ]),
   ).toThrow("disagrees");

--- a/tooling/git-main-branch-core.ts
+++ b/tooling/git-main-branch-core.ts
@@ -1,25 +1,26 @@
-export type BitbucketIdentity = Readonly<{
+type BitbucketIdentity = Readonly<{
   identity: string;
   workspace: string;
   slug: string;
 }>;
 
-export type RepositoryEvidence = Readonly<{
+type RepositoryEvidence = Readonly<{
   identity: string;
   remoteBranch: string;
   uuid: string;
   providerBranch: string;
 }>;
 
-const componentPattern = /^[A-Za-z0-9._-]+$/;
+const componentPattern = /^[A-Za-z0-9._-]+$/u;
 const uuidPattern =
-  /^\{[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}\}$/;
+  /^\{[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}\}$/u;
+const bitbucketPathComponentCount = 2;
 
 function identityFromPath(path: string): BitbucketIdentity {
-  const normalized = path.replace(/^\//, "").replace(/\.git$/, "");
+  const normalized = path.replace(/^\//u, "").replace(/\.git$/u, "");
   const components = normalized.split("/");
   if (
-    components.length !== 2 ||
+    components.length !== bitbucketPathComponentCount ||
     components.some((value) => !componentPattern.test(value))
   ) {
     throw new Error("unsupported Bitbucket Cloud fetch URL");
@@ -28,19 +29,33 @@ function identityFromPath(path: string): BitbucketIdentity {
   if (workspace === undefined || slug === undefined) {
     throw new Error("unsupported Bitbucket Cloud fetch URL");
   }
-  return { identity: `${workspace}/${slug}`, workspace, slug };
+  return { identity: `${workspace}/${slug}`, slug, workspace };
 }
 
-export function parseBitbucketIdentity(source: string): BitbucketIdentity {
-  const scp = /^git@bitbucket\.org:(.+)$/i.exec(source);
-  if (scp?.[1]) return identityFromPath(scp[1]);
-
-  let url: URL;
+function parseBitbucketUrl(source: string): URL {
   try {
-    url = new URL(source);
+    return new URL(source);
   } catch {
     throw new Error("unsupported Bitbucket Cloud fetch URL");
   }
+}
+
+function parseJson(input: string, errorMessage: string): unknown {
+  try {
+    return JSON.parse(input);
+  } catch {
+    throw new Error(errorMessage);
+  }
+}
+
+function parseBitbucketIdentity(source: string): BitbucketIdentity {
+  const scp = /^git@bitbucket\.org:(?<path>.+)$/iu.exec(source);
+  const scpPath = scp?.groups?.path;
+  if (scpPath !== undefined) {
+    return identityFromPath(scpPath);
+  }
+
+  const url = parseBitbucketUrl(source);
   const validHttps = url.protocol === "https:";
   const validSsh =
     url.protocol === "ssh:" && url.username === "git" && url.password === "";
@@ -61,25 +76,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function parseCloudContexts(input: string): string {
-  let value: unknown;
-  try {
-    value = JSON.parse(input);
-  } catch {
-    throw new Error("Bitbucket context list is not valid JSON");
-  }
-  if (!isRecord(value) || !Array.isArray(value.contexts))
+function parseCloudContexts(input: string): string {
+  const value = parseJson(input, "Bitbucket context list is not valid JSON");
+  if (!isRecord(value) || !Array.isArray(value.contexts)) {
     throw new Error("Bitbucket context list has an invalid shape");
+  }
   const contexts = value.contexts.filter(
-    (context): context is { name: string; host: string } =>
+    (context): context is Readonly<{ name: string; host: string }> =>
       isRecord(context) &&
       typeof context.name === "string" &&
       context.name.length > 0 &&
       typeof context.host === "string" &&
       context.host.length > 0,
   );
-  if (contexts.length !== value.contexts.length)
+  if (contexts.length !== value.contexts.length) {
     throw new Error("Bitbucket context list has an invalid shape");
+  }
   const cloudContexts = contexts.filter(
     ({ host }) => host === "api.bitbucket.org",
   );
@@ -88,24 +100,21 @@ export function parseCloudContexts(input: string): string {
       `expected exactly one Bitbucket Cloud context, found ${cloudContexts.length}`,
     );
   }
-  const context = cloudContexts[0];
-  if (context === undefined)
+  const [context] = cloudContexts;
+  if (context === undefined) {
     throw new Error("Bitbucket Cloud context is unavailable");
+  }
   return context.name;
 }
 
-export function parseProviderRepository(
+function parseProviderRepository(
   input: string,
   expectedIdentity: string,
-) {
-  let value: unknown;
-  try {
-    value = JSON.parse(input);
-  } catch {
-    throw new Error(
-      `Bitbucket repository response for ${expectedIdentity} is not valid JSON`,
-    );
-  }
+): Readonly<{ branch: string; uuid: string }> {
+  const value = parseJson(
+    input,
+    `Bitbucket repository response for ${expectedIdentity} is not valid JSON`,
+  );
   if (
     !isRecord(value) ||
     typeof value.uuid !== "string" ||
@@ -120,36 +129,44 @@ export function parseProviderRepository(
     );
   }
   return {
-    uuid: value.uuid,
     branch: value.mainbranch.name,
+    uuid: value.uuid,
   } as const;
 }
 
-export function parseRemoteHead(input: string): string {
+function parseRemoteHead(input: string): string {
   const branches = input
     .split("\n")
-    .map((line) => /^ref: refs\/heads\/(.+)\s+HEAD$/.exec(line)?.[1])
+    .map(
+      (line) =>
+        /^ref: refs\/heads\/(?<branch>.+)\s+HEAD$/u.exec(line)?.groups?.branch,
+    )
     .filter((branch): branch is string => branch !== undefined);
-  if (branches.length === 0)
+  if (branches.length === 0) {
     throw new Error("remote did not publish a symbolic HEAD branch");
-  if (branches.length !== 1)
+  }
+  if (branches.length !== 1) {
     throw new Error(
       `remote published exactly one symbolic HEAD is required, found ${branches.length}`,
     );
-  const branch = branches[0];
-  if (branch === undefined)
+  }
+  const [branch] = branches;
+  if (branch === undefined) {
     throw new Error("remote symbolic HEAD branch is unavailable");
+  }
   return branch;
 }
 
-export function reconcileProviderEvidence(
+function reconcileProviderEvidence(
   evidence: readonly RepositoryEvidence[],
 ): string {
-  if (evidence.length === 0)
+  if (evidence.length === 0) {
     throw new Error("no Bitbucket Cloud repository evidence was found");
+  }
   const uuids = new Set(evidence.map(({ uuid }) => uuid));
-  if (uuids.size !== 1)
+  if (uuids.size !== 1) {
     throw new Error("Bitbucket remotes do not identify the same repository");
+  }
   const providerBranches = new Set(
     evidence.map(({ providerBranch }) => providerBranch),
   );
@@ -159,12 +176,24 @@ export function reconcileProviderEvidence(
   if (providerBranches.size !== 1 || remoteBranches.size !== 1) {
     throw new Error("Bitbucket remotes do not agree on one primary branch");
   }
-  const providerBranch = evidence[0]?.providerBranch;
-  const remoteBranch = evidence[0]?.remoteBranch;
-  if (providerBranch === undefined || providerBranch !== remoteBranch) {
+  const [firstEvidence] = evidence;
+  if (firstEvidence === undefined) {
+    throw new Error("no Bitbucket Cloud repository evidence was found");
+  }
+  const { providerBranch, remoteBranch } = firstEvidence;
+  if (providerBranch !== remoteBranch) {
     throw new Error(
       `provider primary branch ${providerBranch ?? "<missing>"} disagrees with remote HEAD ${remoteBranch ?? "<missing>"}`,
     );
   }
   return providerBranch;
 }
+
+export {
+  parseBitbucketIdentity,
+  parseCloudContexts,
+  parseProviderRepository,
+  parseRemoteHead,
+  reconcileProviderEvidence,
+};
+export type { BitbucketIdentity, RepositoryEvidence };

--- a/tooling/git-main-branch-entry.test.ts
+++ b/tooling/git-main-branch-entry.test.ts
@@ -1,273 +1,266 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
 import { cleanup, run } from "./git-main-branch.test-support/harness.ts";
+import type { Fixture } from "./git-main-branch.test-support/harness.ts";
 
 afterEach(cleanup);
 
 const repository = {
-  uuid: "{11111111-1111-1111-1111-111111111111}",
   full_name: "acme/service",
   mainbranch: { name: "develop" },
+  uuid: "{11111111-1111-1111-1111-111111111111}",
 };
+const probeFailureExitCode = 42;
 
-describe("generic entrypoint compatibility", () => {
-  test.each([["main"], ["master"], ["trunk"]])(
-    "selects local %s",
-    async (branch) => {
-      const result = await run(
-        { localBranches: [branch] },
-        "-C",
-        "/repository",
-      );
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout.toString()).toBe(`${branch}\n`);
-    },
-  );
+test.each([["main"], ["master"], ["trunk"]])(
+  "selects local %s",
+  async (branch) => {
+    const result = await run({ localBranches: [branch] }, "-C", "/repository");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toBe(`${branch}\n`);
+  },
+);
 
-  test("keeps permissive fallback outside a repository", async () => {
-    const result = await run({ repository: false }, "-C", "/missing");
-    expect([
-      result.exitCode,
-      result.stdout.toString(),
-      result.stderr.toString(),
-    ]).toEqual([0, "main\n", ""]);
-  });
-
-  test("strict mode exposes repository and branch-probe failures", async () => {
-    const outside = await run(
-      {
-        repository: false,
-        failures: {
-          "git rev-parse --git-dir": { status: 128, stderr: "fatal: absent\n" },
-        },
-      },
-      "--strict",
-    );
-    expect([
-      outside.exitCode,
-      outside.stdout.toString(),
-      outside.stderr.toString(),
-    ]).toEqual([1, "", "fatal: absent\n"]);
-    const probe = await run({ showRefStatus: 42 }, "--strict");
-    expect([probe.exitCode, probe.stdout.toString()]).toEqual([42, ""]);
-  });
-
-  test("permissive fallback preserves branch-probe diagnostics", async () => {
-    const result = await run({
-      showRefStatus: 42,
-      showRefStderr: "fatal: probe\n",
-    });
-    expect([
-      result.exitCode,
-      result.stdout.toString(),
-      result.stderr.toString(),
-    ]).toEqual([0, "main\n", "fatal: probe\nfatal: probe\nfatal: probe\n"]);
-  });
+test("keeps permissive fallback outside a repository", async () => {
+  const result = await run({ repository: false }, "-C", "/missing");
+  expect([
+    result.exitCode,
+    result.stdout.toString(),
+    result.stderr.toString(),
+  ]).toEqual([0, "main\n", ""]);
 });
 
-describe("Bitbucket Cloud entrypoint", () => {
-  test("resolves a nonstandard branch despite stale local metadata", async () => {
-    const result = await run(
-      {
-        localBranches: ["main"],
-        remotes: {
-          origin: {
-            urls: ["git@bitbucket.org:acme/service.git"],
-            head: "develop",
-          },
-        },
-        repositories: { "acme/service": repository },
+test("strict mode exposes repository and branch-probe failures", async () => {
+  const outside = await run(
+    {
+      failures: {
+        "git rev-parse --git-dir": { status: 128, stderr: "fatal: absent\n" },
       },
-      "--bitbucket-cloud",
-      "-C",
-      "/repository",
-    );
-    expect([
-      result.exitCode,
-      result.stdout.toString(),
-      result.stderr.toString(),
-    ]).toEqual([0, "develop\n", ""]);
-  });
+      repository: false,
+    },
+    "--strict",
+  );
+  expect([
+    outside.exitCode,
+    outside.stdout.toString(),
+    outside.stderr.toString(),
+  ]).toEqual([1, "", "fatal: absent\n"]);
+  const probe = await run({ showRefStatus: probeFailureExitCode }, "--strict");
+  expect([probe.exitCode, probe.stdout.toString()]).toEqual([
+    probeFailureExitCode,
+    "",
+  ]);
+});
 
-  test("accepts equivalent remotes and URL forms", async () => {
-    const result = await run(
-      {
-        remotes: {
-          origin: {
-            urls: ["https://user@bitbucket.org/acme/service.git"],
-            head: "develop",
-          },
-          mirror: {
-            urls: ["ssh://git@bitbucket.org/acme/service.git"],
-            head: "develop",
-          },
-        },
-        repositories: { "acme/service": repository },
-      },
-      "--strict",
-      "--bitbucket-cloud",
-    );
-    expect([result.exitCode, result.stdout.toString()]).toEqual([
-      0,
-      "develop\n",
-    ]);
+test("permissive fallback preserves branch-probe diagnostics", async () => {
+  const result = await run({
+    showRefStatus: probeFailureExitCode,
+    showRefStderr: "fatal: probe\n",
   });
+  expect([
+    result.exitCode,
+    result.stdout.toString(),
+    result.stderr.toString(),
+  ]).toEqual([0, "main\n", "fatal: probe\nfatal: probe\nfatal: probe\n"]);
+});
+test("resolves a nonstandard branch despite stale local metadata", async () => {
+  const result = await run(
+    {
+      localBranches: ["main"],
+      remotes: {
+        origin: {
+          head: "develop",
+          urls: ["git@bitbucket.org:acme/service.git"],
+        },
+      },
+      repositories: { "acme/service": repository },
+    },
+    "--bitbucket-cloud",
+    "-C",
+    "/repository",
+  );
+  expect([
+    result.exitCode,
+    result.stdout.toString(),
+    result.stderr.toString(),
+  ]).toEqual([0, "develop\n", ""]);
+});
 
-  test.each([
-    ["no remote", { remotes: {} }],
-    [
-      "non-Bitbucket URL",
-      {
-        remotes: {
-          origin: {
-            urls: ["git@github.com:acme/service.git"],
-            head: "develop",
-          },
+test("accepts equivalent remotes and URL forms", async () => {
+  const result = await run(
+    {
+      remotes: {
+        mirror: {
+          head: "develop",
+          urls: ["ssh://git@bitbucket.org/acme/service.git"],
+        },
+        origin: {
+          head: "develop",
+          urls: ["https://user@bitbucket.org/acme/service.git"],
         },
       },
-    ],
-    [
-      "multiple contexts",
-      {
-        remotes: {
-          origin: {
-            urls: ["git@bitbucket.org:acme/service.git"],
-            head: "develop",
-          },
-        },
-        contexts: {
-          contexts: [
-            { name: "a", host: "api.bitbucket.org" },
-            { name: "b", host: "api.bitbucket.org" },
-          ],
-        },
-      },
-    ],
-    [
-      "missing remote HEAD",
-      { remotes: { origin: { urls: ["git@bitbucket.org:acme/service.git"] } } },
-    ],
-    [
-      "conflicting remotes",
-      {
-        remotes: {
-          origin: {
-            urls: ["git@bitbucket.org:acme/service.git"],
-            head: "develop",
-          },
-          mirror: {
-            urls: ["git@bitbucket.org:acme/other.git"],
-            head: "develop",
-          },
-        },
-        repositories: {
-          "acme/service": repository,
-          "acme/other": {
-            ...repository,
-            uuid: "{22222222-2222-2222-2222-222222222222}",
-            full_name: "acme/other",
-          },
+      repositories: { "acme/service": repository },
+    },
+    "--strict",
+    "--bitbucket-cloud",
+  );
+  expect([result.exitCode, result.stdout.toString()]).toEqual([0, "develop\n"]);
+});
+
+test.each([
+  ["no remote", { remotes: {} }],
+  [
+    "non-Bitbucket URL",
+    {
+      remotes: {
+        origin: {
+          head: "develop",
+          urls: ["git@github.com:acme/service.git"],
         },
       },
-    ],
-    [
-      "provider disagreement",
-      {
-        remotes: {
-          origin: {
-            urls: ["git@bitbucket.org:acme/service.git"],
-            head: "develop",
-          },
-        },
-        repositories: {
-          "acme/service": { ...repository, mainbranch: { name: "main" } },
+    },
+  ],
+  [
+    "multiple contexts",
+    {
+      contexts: {
+        contexts: [
+          { host: "api.bitbucket.org", name: "a" },
+          { host: "api.bitbucket.org", name: "b" },
+        ],
+      },
+      remotes: {
+        origin: {
+          head: "develop",
+          urls: ["git@bitbucket.org:acme/service.git"],
         },
       },
-    ],
-    [
-      "remote branch disagreement",
-      {
-        remotes: {
-          origin: {
-            urls: ["git@bitbucket.org:acme/service.git"],
-            head: "develop",
-          },
-          mirror: {
-            urls: ["git@bitbucket.org:acme/service.git"],
-            head: "main",
-          },
+    },
+  ],
+  [
+    "missing remote HEAD",
+    { remotes: { origin: { urls: ["git@bitbucket.org:acme/service.git"] } } },
+  ],
+  [
+    "conflicting remotes",
+    {
+      remotes: {
+        mirror: {
+          head: "develop",
+          urls: ["git@bitbucket.org:acme/other.git"],
         },
-        repositories: { "acme/service": repository },
-      },
-    ],
-    [
-      "malformed provider response",
-      {
-        remotes: {
-          origin: {
-            urls: ["git@bitbucket.org:acme/service.git"],
-            head: "develop",
-          },
+        origin: {
+          head: "develop",
+          urls: ["git@bitbucket.org:acme/service.git"],
         },
-        repositories: { "acme/service": { full_name: "acme/service" } },
       },
-    ],
-  ] as const)("fails closed on %s", async (_name, fixture) => {
+      repositories: {
+        "acme/other": {
+          ...repository,
+          full_name: "acme/other",
+          uuid: "{22222222-2222-2222-2222-222222222222}",
+        },
+        "acme/service": repository,
+      },
+    },
+  ],
+  [
+    "provider disagreement",
+    {
+      remotes: {
+        origin: {
+          head: "develop",
+          urls: ["git@bitbucket.org:acme/service.git"],
+        },
+      },
+      repositories: {
+        "acme/service": { ...repository, mainbranch: { name: "main" } },
+      },
+    },
+  ],
+  [
+    "remote branch disagreement",
+    {
+      remotes: {
+        mirror: {
+          head: "main",
+          urls: ["git@bitbucket.org:acme/service.git"],
+        },
+        origin: {
+          head: "develop",
+          urls: ["git@bitbucket.org:acme/service.git"],
+        },
+      },
+      repositories: { "acme/service": repository },
+    },
+  ],
+  [
+    "malformed provider response",
+    {
+      remotes: {
+        origin: {
+          head: "develop",
+          urls: ["git@bitbucket.org:acme/service.git"],
+        },
+      },
+      repositories: { "acme/service": { full_name: "acme/service" } },
+    },
+  ],
+] as const)(
+  "fails closed on %s",
+  async (...[_name, fixture]: readonly [string, Readonly<Fixture>]) => {
     const result = await run(fixture, "--bitbucket-cloud");
     expect(result.exitCode).not.toBe(0);
     expect(result.stdout.toString()).toBe("");
     expect(result.stderr.toString().trim().length).toBeGreaterThan(0);
-  });
+  },
+);
 
-  test("reports unavailable dependencies", async () => {
-    const gitMissing = await run(
-      {
-        failures: {
-          "git rev-parse --git-dir": { status: 127, stderr: "git missing\n" },
+test("reports unavailable dependencies", async () => {
+  const gitMissing = await run(
+    {
+      failures: {
+        "git rev-parse --git-dir": { status: 127, stderr: "git missing\n" },
+      },
+    },
+    "--bitbucket-cloud",
+  );
+  expect([gitMissing.exitCode, gitMissing.stdout.toString()]).toEqual([1, ""]);
+  expect(gitMissing.stderr.toString()).toContain("git missing");
+
+  const result = await run(
+    {
+      failures: {
+        "bkt context list --json": { status: 127, stderr: "bkt missing\n" },
+      },
+      remotes: {
+        origin: {
+          head: "develop",
+          urls: ["git@bitbucket.org:acme/service.git"],
         },
       },
-      "--bitbucket-cloud",
-    );
-    expect([gitMissing.exitCode, gitMissing.stdout.toString()]).toEqual([
-      1,
-      "",
-    ]);
-    expect(gitMissing.stderr.toString()).toContain("git missing");
+    },
+    "--bitbucket-cloud",
+  );
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout.toString()).toBe("");
+  expect(result.stderr.toString()).toContain("bkt missing");
+});
 
-    const result = await run(
-      {
-        remotes: {
-          origin: {
-            urls: ["git@bitbucket.org:acme/service.git"],
-            head: "develop",
-          },
-        },
-        failures: {
-          "bkt context list --json": { status: 127, stderr: "bkt missing\n" },
+test("redacts credentials from rejected fetch URLs", async () => {
+  const secret = "example-secret";
+  const result = await run(
+    {
+      remotes: {
+        origin: {
+          head: "develop",
+          urls: [`https://user:${secret}@bitbucket.org/acme/service/extra`],
         },
       },
-      "--bitbucket-cloud",
-    );
-    expect(result.exitCode).toBe(1);
-    expect(result.stdout.toString()).toBe("");
-    expect(result.stderr.toString()).toContain("bkt missing");
-  });
-
-  test("redacts credentials from rejected fetch URLs", async () => {
-    const secret = "example-secret";
-    const result = await run(
-      {
-        remotes: {
-          origin: {
-            urls: [`https://user:${secret}@bitbucket.org/acme/service/extra`],
-            head: "develop",
-          },
-        },
-      },
-      "--bitbucket-cloud",
-    );
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stdout.toString()).toBe("");
-    expect(result.stderr.toString()).not.toContain(secret);
-    expect(result.stderr.toString()).toContain("fetch URL");
-  });
+    },
+    "--bitbucket-cloud",
+  );
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stdout.toString()).toBe("");
+  expect(result.stderr.toString()).not.toContain(secret);
+  expect(result.stderr.toString()).toContain("fetch URL");
 });

--- a/tooling/git-main-branch.test-support/fake-command.ts
+++ b/tooling/git-main-branch.test-support/fake-command.ts
@@ -1,31 +1,50 @@
-type Fixture = {
-  repository?: boolean;
-  localBranches?: string[];
-  showRefStatus?: number;
-  showRefStderr?: string;
-  remotes?: Record<
-    string,
-    { urls: string[]; head?: string; headOutput?: string }
-  >;
-  contexts?: unknown;
-  repositories?: Record<string, unknown>;
-  failures?: Record<string, { status: number; stderr: string }>;
-};
+import { z } from "zod";
 
-const fixture = (await Bun.file(
-  process.env.FIXTURE_PATH ?? "",
-).json()) as Fixture;
-const command = process.argv[2];
-const arguments_ = process.argv.slice(3);
-const failure = fixture.failures?.[`${command} ${arguments_.join(" ")}`];
+const fixtureSchema = z
+  .object({
+    contexts: z.unknown().optional(),
+    failures: z
+      .record(z.string(), z.object({ status: z.number(), stderr: z.string() }))
+      .optional(),
+    localBranches: z.array(z.string()).optional(),
+    remotes: z
+      .record(
+        z.string(),
+        z.object({
+          head: z.string().optional(),
+          headOutput: z.string().optional(),
+          urls: z.array(z.string()),
+        }),
+      )
+      .optional(),
+    repositories: z.record(z.string(), z.unknown()).optional(),
+    repository: z.boolean().optional(),
+    showRefStatus: z.number().optional(),
+    showRefStderr: z.string().optional(),
+  })
+  .strict();
 
-if (failure) {
+const fixture = fixtureSchema.parse(
+  await Bun.file(process.env.FIXTURE_PATH ?? "").json(),
+);
+const commandArgumentIndex = 2;
+const commandOptionsIndex = 3;
+const repositoryFailureExitCode = 128;
+const missingRemoteExitCode = 2;
+const invalidContextExitCode = 3;
+const commandNotFoundExitCode = 127;
+const penultimateArgumentOffset = -2;
+const command = process.argv[commandArgumentIndex];
+const commandArguments = process.argv.slice(commandOptionsIndex);
+const failure = fixture.failures?.[`${command} ${commandArguments.join(" ")}`];
+
+if (failure !== undefined) {
   process.stderr.write(failure.stderr);
   process.exit(failure.status);
 }
 
 if (command === "git") {
-  const operation = arguments_.findIndex((value) =>
+  const operation = commandArguments.findIndex((value) =>
     [
       "rev-parse",
       "show-ref",
@@ -34,16 +53,23 @@ if (command === "git") {
       "check-ref-format",
     ].includes(value),
   );
-  const tail = arguments_.slice(operation);
-  if (tail[0] === "rev-parse")
-    process.exit(fixture.repository === false ? 128 : 0);
+  const tail = commandArguments.slice(operation);
+  if (tail[0] === "rev-parse") {
+    process.exit(fixture.repository === false ? repositoryFailureExitCode : 0);
+  }
   if (tail[0] === "show-ref") {
-    if (fixture.showRefStatus) {
-      if (fixture.showRefStderr) process.stderr.write(fixture.showRefStderr);
+    if (fixture.showRefStatus !== undefined) {
+      if (fixture.showRefStderr !== undefined) {
+        process.stderr.write(fixture.showRefStderr);
+      }
       process.exit(fixture.showRefStatus);
     }
     const branch = tail.at(-1)?.replace("refs/heads/", "");
-    process.exit(branch && fixture.localBranches?.includes(branch) ? 0 : 1);
+    process.exit(
+      branch !== undefined && fixture.localBranches?.includes(branch) === true
+        ? 0
+        : 1,
+    );
   }
   if (tail[0] === "remote" && tail.length === 1) {
     process.stdout.write(`${Object.keys(fixture.remotes ?? {}).join("\n")}\n`);
@@ -51,16 +77,20 @@ if (command === "git") {
   }
   if (tail[0] === "remote" && tail[1] === "get-url") {
     const remote = fixture.remotes?.[tail.at(-1) ?? ""];
-    if (!remote) process.exit(2);
+    if (!remote) {
+      process.exit(missingRemoteExitCode);
+    }
     process.stdout.write(`${remote.urls.join("\n")}\n`);
     process.exit(0);
   }
   if (tail[0] === "ls-remote") {
-    const remote = fixture.remotes?.[tail.at(-2) ?? ""];
-    if (!remote) process.exit(2);
+    const remote = fixture.remotes?.[tail.at(penultimateArgumentOffset) ?? ""];
+    if (!remote) {
+      process.exit(missingRemoteExitCode);
+    }
     process.stdout.write(
       remote.headOutput ??
-        (remote.head
+        (remote.head !== undefined && remote.head !== ""
           ? `ref: refs/heads/${remote.head}\tHEAD\nabc\tHEAD\n`
           : ""),
     );
@@ -69,32 +99,40 @@ if (command === "git") {
   if (tail[0] === "check-ref-format") {
     const branch = tail.at(-1);
     process.exit(
-      branch && !branch.startsWith("-") && !branch.includes("..") ? 0 : 1,
+      branch !== undefined &&
+        branch !== "" &&
+        !branch.startsWith("-") &&
+        !branch.includes("..")
+        ? 0
+        : 1,
     );
   }
 }
 
-if (command === "bkt" && arguments_.includes("context")) {
+if (command === "bkt" && commandArguments.includes("context")) {
   process.stdout.write(
     JSON.stringify(
       fixture.contexts ?? {
-        contexts: [{ name: "cloud", host: "api.bitbucket.org" }],
+        contexts: [{ host: "api.bitbucket.org", name: "cloud" }],
       },
     ),
   );
   process.exit(0);
 }
 
-if (command === "bkt" && arguments_.includes("api")) {
-  if (arguments_[0] !== "--context" || arguments_[1] !== "cloud")
-    process.exit(3);
-  const identity = arguments_
+if (command === "bkt" && commandArguments.includes("api")) {
+  if (commandArguments[0] !== "--context" || commandArguments[1] !== "cloud") {
+    process.exit(invalidContextExitCode);
+  }
+  const identity = commandArguments
     .find((value) => value.startsWith("/repositories/"))
     ?.replace("/repositories/", "");
   const response = fixture.repositories?.[identity ?? ""];
-  if (!response) process.exit(2);
+  if (response === undefined) {
+    process.exit(missingRemoteExitCode);
+  }
   process.stdout.write(JSON.stringify(response));
   process.exit(0);
 }
 
-process.exit(127);
+process.exit(commandNotFoundExitCode);

--- a/tooling/git-main-branch.test-support/harness.ts
+++ b/tooling/git-main-branch.test-support/harness.ts
@@ -1,8 +1,8 @@
 import { chmod, mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
 
-export type Fixture = {
+interface Fixture {
   repository?: boolean;
   localBranches?: readonly string[];
   showRefStatus?: number;
@@ -10,25 +10,41 @@ export type Fixture = {
   remotes?: Readonly<
     Record<
       string,
-      { urls: readonly string[]; head?: string; headOutput?: string }
+      Readonly<{
+        urls: readonly string[];
+        head?: string;
+        headOutput?: string;
+      }>
     >
   >;
   contexts?: unknown;
   repositories?: Readonly<Record<string, unknown>>;
-  failures?: Readonly<Record<string, { status: number; stderr: string }>>;
-};
+  failures?: Readonly<
+    Record<string, Readonly<{ status: number; stderr: string }>>
+  >;
+}
+
+type CommandResult = Readonly<{
+  exitCode: number;
+  stderr: Uint8Array;
+  stdout: Uint8Array;
+}>;
 
 const entrypoint = join(import.meta.dir, "..", "git-main-branch");
 const fakeCommand = join(import.meta.dir, "fake-command.ts");
 const temporaryDirectories: string[] = [];
+const executableFileMode = 0o755;
 
-export async function cleanup(): Promise<void> {
+async function cleanup(): Promise<void> {
   await Promise.all(
     temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })),
   );
 }
 
-export async function run(fixture: Fixture, ...arguments_: string[]) {
+async function run(
+  fixture: Readonly<Fixture>,
+  ...commandArguments: readonly string[]
+): Promise<CommandResult> {
   const root = await mkdtemp(join(tmpdir(), "git-main-branch-"));
   temporaryDirectories.push(root);
   const bin = join(root, "bin");
@@ -40,16 +56,19 @@ export async function run(fixture: Fixture, ...arguments_: string[]) {
       executable,
       `#!/bin/sh\nexec "${process.execPath}" "${fakeCommand}" ${command} "$@"\n`,
     );
-    await chmod(executable, 0o755);
+    await chmod(executable, executableFileMode);
   }
-  return Bun.spawnSync([entrypoint, ...arguments_], {
+  return Bun.spawnSync([entrypoint, ...commandArguments], {
     cwd: root,
     env: {
       ...process.env,
       FIXTURE_PATH: join(root, "fixture.json"),
       PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
     },
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   });
 }
+
+export { cleanup, run };
+export type { Fixture };

--- a/tooling/install-hunspell-dictionary-error.ts
+++ b/tooling/install-hunspell-dictionary-error.ts
@@ -1,8 +1,9 @@
 export class DictionaryInstallationError extends Error {
-  constructor(
-    message: string,
-    readonly exitCode = 1,
-  ) {
+  public readonly exitCode: number;
+
+  public constructor(message: string, exitCode = 1) {
     super(message);
+    this.exitCode = exitCode;
+    this.name = "DictionaryInstallationError";
   }
 }

--- a/tooling/install-hunspell-dictionary-failures.test.ts
+++ b/tooling/install-hunspell-dictionary-failures.test.ts
@@ -1,12 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import {
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { join } from "node:path";
+import { afterEach, expect, test } from "bun:test";
 import {
   cleanupFixtures,
   createFixture,
@@ -17,190 +9,191 @@ import {
   temporaryFiles,
   url,
 } from "./install-hunspell-dictionary-test-support.ts";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
 
 const content = "dictionary\n";
 const checksum = sha256(content);
 const servers: ReturnType<typeof Bun.serve>[] = [];
+const usageFailureExitCode = 64;
 
-afterEach(() => {
-  for (const server of servers.splice(0)) server.stop(true);
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await server.stop(true);
+  }
   cleanupFixtures();
 });
 
 function trackedServer(
-  fetch: (request: Request) => Response | Promise<Response>,
-) {
+  fetch: (request: Readonly<{ url: string }>) => Response | Promise<Response>,
+): ReturnType<typeof Bun.serve> {
   const server = serve(fetch);
   servers.push(server);
   return server;
 }
 
-describe("install-hunspell-dictionary failures", () => {
-  test.each([
-    [[], "missing source URL"],
-    [["https://example.test/file"], "missing SHA-256 checksum"],
-    [["https://example.test/file", checksum], "missing destination path"],
-  ])("rejects missing command arguments", async (arguments_, diagnostic) => {
-    const installation = await runArguments(createFixture(), arguments_);
+test.each([
+  [[], "missing source URL"],
+  [["https://example.test/file"], "missing SHA-256 checksum"],
+  [["https://example.test/file", checksum], "missing destination path"],
+])(
+  "rejects missing command arguments",
+  async (
+    ...[commandArguments, diagnostic]: readonly [readonly string[], string]
+  ) => {
+    const installation = await runArguments(createFixture(), commandArguments);
 
     expect(installation.exitCode).toBe(1);
     expect(installation.stdout).toBe("");
     expect(installation.stderr).toContain(diagnostic);
+  },
+);
+
+test("rejects an invalid checksum before download", async () => {
+  const fixture = createFixture();
+  let requests = 0;
+  const server = trackedServer(() => {
+    requests += 1;
+    return new Response(content);
   });
+  const installation = await runInstaller(fixture, url(server), "not-a-sha");
 
-  test("rejects an invalid checksum before download", async () => {
-    const fixture = createFixture();
-    let requests = 0;
-    const server = trackedServer(() => {
-      requests++;
-      return new Response(content);
-    });
+  expect(installation.exitCode).toBe(usageFailureExitCode);
+  expect(installation.stdout).toBe("");
+  expect(installation.stderr).toContain("Invalid SHA-256 checksum");
+  expect(requests).toBe(0);
+  expect(temporaryFiles(fixture)).toEqual([]);
+});
 
-    const installation = await runInstaller(fixture, url(server), "not-a-sha");
+test("removes temporary content after checksum mismatch", async () => {
+  const fixture = createFixture();
+  const server = trackedServer(() => new Response("corrupted\n"));
+  const installation = await runInstaller(fixture, url(server), checksum);
 
-    expect(installation.exitCode).toBe(64);
-    expect(installation.stdout).toBe("");
-    expect(installation.stderr).toContain("Invalid SHA-256 checksum");
-    expect(requests).toBe(0);
-    expect(temporaryFiles(fixture)).toEqual([]);
-  });
+  expect(installation.exitCode).toBe(1);
+  expect(installation.stderr).toContain("SHA-256 mismatch");
+  expect(Bun.file(fixture.destination).size).toBe(0);
+  expect(temporaryFiles(fixture)).toEqual([]);
+});
 
-  test("removes temporary content after checksum mismatch", async () => {
-    const fixture = createFixture();
-    const server = trackedServer(() => new Response("corrupted\n"));
-
-    const installation = await runInstaller(fixture, url(server), checksum);
-
-    expect(installation.exitCode).toBe(1);
-    expect(installation.stderr).toContain("SHA-256 mismatch");
-    expect(Bun.file(fixture.destination).size).toBe(0);
-    expect(temporaryFiles(fixture)).toEqual([]);
-  });
-
-  test("removes temporary content after a network failure", async () => {
-    const fixture = createFixture();
-    const server = trackedServer(
-      () => new Response("unavailable", { status: 503 }),
-    );
-
-    const installation = await runInstaller(fixture, url(server), checksum);
-
-    expect(installation.exitCode).not.toBe(0);
-    expect(installation.stderr).toContain("Dictionary download failed");
-    expect(Bun.file(fixture.destination).size).toBe(0);
-    expect(temporaryFiles(fixture)).toEqual([]);
-  });
-
-  test("leaves an existing divergent file unchanged", async () => {
-    const fixture = createFixture();
-    mkdirSync(fixture.spelling, { recursive: true });
-    writeFileSync(fixture.destination, "local dictionary\n");
-    const server = trackedServer(() => new Response(content));
-
-    const installation = await runInstaller(fixture, url(server), checksum);
-
-    expect(installation.exitCode).toBe(1);
-    expect(installation.stderr).toContain(
-      "Refusing to replace existing dictionary",
-    );
-    expect(readFileSync(fixture.destination, "utf8")).toBe(
-      "local dictionary\n",
-    );
-  });
-
-  test("does not follow an existing destination symlink", async () => {
-    const fixture = createFixture();
-    mkdirSync(fixture.spelling, { recursive: true });
-    const victim = join(fixture.root, "victim");
-    writeFileSync(victim, "keep\n");
-    symlinkSync(victim, fixture.destination);
-    const server = trackedServer(() => new Response(content));
-
-    const installation = await runInstaller(fixture, url(server), checksum);
-
-    expect(installation.exitCode).toBe(1);
-    expect(installation.stderr).toContain("non-regular dictionary destination");
-    expect(readFileSync(victim, "utf8")).toBe("keep\n");
-  });
-
-  test("refuses an existing destination FIFO without waiting for a writer", async () => {
-    const fixture = createFixture();
-    mkdirSync(fixture.spelling, { recursive: true });
-    expect(
-      Bun.spawnSync([["mk", "fifo"].join(""), fixture.destination]).exitCode,
-    ).toBe(0);
-    const server = trackedServer(() => new Response(content));
-
-    const installation = await runInstaller(fixture, url(server), checksum);
-
-    expect(installation.exitCode).toBe(1);
-    expect(installation.stderr).toContain("non-regular dictionary destination");
-  });
-
-  test.each(["Library", "Library/Spelling"])(
-    "does not install through the %s directory symlink",
-    async (symlinkPath) => {
-      const fixture = createFixture();
-      const target = join(fixture.root, "outside");
-      mkdirSync(target);
-      if (symlinkPath === "Library/Spelling") {
-        mkdirSync(join(fixture.home, "Library"));
-      }
-      symlinkSync(target, join(fixture.home, symlinkPath));
-      const server = trackedServer(() => new Response(content));
-
-      const installation = await runInstaller(fixture, url(server), checksum);
-
-      expect(installation.exitCode).toBe(1);
-      expect(installation.stderr).toContain("non-regular dictionary directory");
-      expect(Bun.file(join(target, "fr.aff")).size).toBe(0);
-    },
+test("removes temporary content after a network failure", async () => {
+  const fixture = createFixture();
+  const server = trackedServer(
+    () => new Response("unavailable", { status: 503 }),
   );
+  const installation = await runInstaller(fixture, url(server), checksum);
 
-  test("does not install through a symlinked home directory", async () => {
+  expect(installation.exitCode).not.toBe(0);
+  expect(installation.stderr).toContain("Dictionary download failed");
+  expect(Bun.file(fixture.destination).size).toBe(0);
+  expect(temporaryFiles(fixture)).toEqual([]);
+});
+
+test("leaves an existing divergent file unchanged", async () => {
+  const fixture = createFixture();
+  mkdirSync(fixture.spelling, { recursive: true });
+  writeFileSync(fixture.destination, "local dictionary\n");
+  const server = trackedServer(() => new Response(content));
+  const installation = await runInstaller(fixture, url(server), checksum);
+
+  expect(installation.exitCode).toBe(1);
+  expect(installation.stderr).toContain(
+    "Refusing to replace existing dictionary",
+  );
+  expect(readFileSync(fixture.destination, "utf8")).toBe("local dictionary\n");
+});
+
+test("does not follow an existing destination symlink", async () => {
+  const fixture = createFixture();
+  mkdirSync(fixture.spelling, { recursive: true });
+  const victim = join(fixture.root, "victim");
+  writeFileSync(victim, "keep\n");
+  symlinkSync(victim, fixture.destination);
+  const server = trackedServer(() => new Response(content));
+  const installation = await runInstaller(fixture, url(server), checksum);
+
+  expect(installation.exitCode).toBe(1);
+  expect(installation.stderr).toContain("non-regular dictionary destination");
+  expect(readFileSync(victim, "utf8")).toBe("keep\n");
+});
+
+test("refuses an existing destination FIFO without waiting for a writer", async () => {
+  const fixture = createFixture();
+  mkdirSync(fixture.spelling, { recursive: true });
+  expect(
+    Bun.spawnSync([["mk", "fifo"].join(""), fixture.destination]).exitCode,
+  ).toBe(0);
+  const server = trackedServer(() => new Response(content));
+  const installation = await runInstaller(fixture, url(server), checksum);
+
+  expect(installation.exitCode).toBe(1);
+  expect(installation.stderr).toContain("non-regular dictionary destination");
+});
+
+test.each(["Library", "Library/Spelling"])(
+  "does not install through the %s directory symlink",
+  async (symlinkPath) => {
     const fixture = createFixture();
-    const actualHome = join(fixture.root, "actual-home");
-    renameSync(fixture.home, actualHome);
-    symlinkSync(actualHome, fixture.home);
+    const target = join(fixture.root, "outside");
+    mkdirSync(target);
+    if (symlinkPath === "Library/Spelling") {
+      mkdirSync(join(fixture.home, "Library"));
+    }
+    symlinkSync(target, join(fixture.home, symlinkPath));
     const server = trackedServer(() => new Response(content));
-
     const installation = await runInstaller(fixture, url(server), checksum);
 
     expect(installation.exitCode).toBe(1);
-    expect(installation.stderr).toContain("non-regular home directory");
-    expect(
-      Bun.file(join(actualHome, "Library", "Spelling", "fr.aff")).size,
-    ).toBe(0);
+    expect(installation.stderr).toContain("non-regular dictionary directory");
+    expect(Bun.file(join(target, "fr.aff")).size).toBe(0);
+  },
+);
+
+test("does not install through a symlinked home directory", async () => {
+  const fixture = createFixture();
+  const actualHome = join(fixture.root, "actual-home");
+  renameSync(fixture.home, actualHome);
+  symlinkSync(actualHome, fixture.home);
+  const server = trackedServer(() => new Response(content));
+  const installation = await runInstaller(fixture, url(server), checksum);
+
+  expect(installation.exitCode).toBe(1);
+  expect(installation.stderr).toContain("non-regular home directory");
+  expect(Bun.file(join(actualHome, "Library", "Spelling", "fr.aff")).size).toBe(
+    0,
+  );
+});
+
+test("rejects a destination outside the spelling directory", async () => {
+  const fixture = createFixture();
+  const outside = join(fixture.home, "fr.aff");
+  const server = trackedServer(() => new Response(content));
+  const installation = await runArguments(fixture, [
+    url(server),
+    checksum,
+    outside,
+  ]);
+
+  expect(installation.exitCode).toBe(1);
+  expect(installation.stderr).toContain("outside");
+  expect(Bun.file(outside).size).toBe(0);
+});
+
+test("cleans up when publication loses to a directory", async () => {
+  const fixture = createFixture();
+  const server = trackedServer(() => {
+    mkdirSync(fixture.destination);
+    return new Response(content);
   });
+  const installation = await runInstaller(fixture, url(server), checksum);
 
-  test("rejects a destination outside the spelling directory", async () => {
-    const fixture = createFixture();
-    const outside = join(fixture.home, "fr.aff");
-    const server = trackedServer(() => new Response(content));
-
-    const installation = await runInstaller(
-      fixture,
-      url(server),
-      checksum,
-      outside,
-    );
-
-    expect(installation.exitCode).toBe(1);
-    expect(installation.stderr).toContain("outside");
-    expect(Bun.file(outside).size).toBe(0);
-  });
-
-  test("cleans up when publication loses to a directory", async () => {
-    const fixture = createFixture();
-    const server = trackedServer(() => {
-      mkdirSync(fixture.destination);
-      return new Response(content);
-    });
-
-    const installation = await runInstaller(fixture, url(server), checksum);
-
-    expect(installation.exitCode).toBe(1);
-    expect(installation.stderr).toContain("concurrent dictionary destination");
-    expect(temporaryFiles(fixture)).toEqual([]);
-  });
+  expect(installation.exitCode).toBe(1);
+  expect(installation.stderr).toContain("concurrent dictionary destination");
+  expect(temporaryFiles(fixture)).toEqual([]);
 });

--- a/tooling/install-hunspell-dictionary-files.ts
+++ b/tooling/install-hunspell-dictionary-files.ts
@@ -1,21 +1,30 @@
-import { createHash, randomUUID } from "node:crypto";
-import { constants, type BigIntStats } from "node:fs";
+import { type BigIntStats, constants } from "node:fs";
 import {
+  type FileHandle,
   link,
   lstat,
   mkdir,
   open,
   unlink,
-  type FileHandle,
 } from "node:fs/promises";
-import { join } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
 import { DictionaryInstallationError } from "./install-hunspell-dictionary-error.ts";
+import { join } from "node:path";
 
 type DirectoryIdentity = Readonly<{
   device: bigint;
   inode: bigint;
   path: string;
 }>;
+
+type DictionaryPublication = Readonly<{
+  content: Readonly<ArrayLike<number>>;
+  destination: string;
+  expectedChecksum: string;
+}>;
+
+const privateFileMode = 0o600;
+const publicFileMode = 0o644;
 
 function hasCode(error: unknown, code: string): boolean {
   return error instanceof Error && "code" in error && error.code === code;
@@ -25,15 +34,15 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function sha256(content: Uint8Array): string {
-  return createHash("sha256").update(content).digest("hex");
+function sha256(content: Readonly<ArrayLike<number>>): string {
+  return createHash("sha256").update(Uint8Array.from(content)).digest("hex");
 }
 
 async function inspectDirectory(
   path: string,
   label: "home" | "dictionary",
 ): Promise<DirectoryIdentity> {
-  let status: BigIntStats | undefined;
+  let status: BigIntStats | undefined = undefined;
   try {
     status = await lstat(path, { bigint: true });
   } catch (error) {
@@ -62,7 +71,9 @@ async function ensureDirectory(path: string): Promise<DirectoryIdentity> {
   try {
     await mkdir(path);
   } catch (error) {
-    if (!hasCode(error, "EEXIST")) throw error;
+    if (!hasCode(error, "EEXIST")) {
+      throw error;
+    }
   }
   return inspectDirectory(path, "dictionary");
 }
@@ -79,14 +90,21 @@ async function assertDirectoryIdentity(
 }
 
 async function readRegularFile(path: string): Promise<Uint8Array | undefined> {
-  let file: FileHandle;
+  let file: FileHandle | undefined = undefined;
   try {
     file = await open(
       path,
       constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
     );
   } catch (error) {
-    if (hasCode(error, "ENOENT")) return undefined;
+    if (hasCode(error, "ENOENT")) {
+      return undefined;
+    }
+    throw new DictionaryInstallationError(
+      `Refusing non-regular dictionary destination: ${path}`,
+    );
+  }
+  if (file === undefined) {
     throw new DictionaryInstallationError(
       `Refusing non-regular dictionary destination: ${path}`,
     );
@@ -99,34 +117,42 @@ async function readRegularFile(path: string): Promise<Uint8Array | undefined> {
       );
     }
     const content = await file.readFile();
-    let after: BigIntStats | undefined;
-    try {
-      after = await lstat(path, { bigint: true });
-    } catch (error) {
-      if (!hasCode(error, "ENOENT")) {
-        throw new DictionaryInstallationError(
-          `Cannot inspect dictionary destination ${path}: ${errorMessage(error)}`,
-        );
-      }
-    }
-    if (
-      after === undefined ||
-      after.isSymbolicLink() ||
-      !after.isFile() ||
-      after.dev !== before.dev ||
-      after.ino !== before.ino
-    ) {
-      throw new DictionaryInstallationError(
-        `Refusing replaced dictionary destination: ${path}`,
-      );
-    }
+    await assertFileIdentity(path, before.dev, before.ino);
     return content;
   } finally {
     await file.close();
   }
 }
 
-export async function prepareSpellingDirectory(
+async function assertFileIdentity(
+  path: string,
+  expectedDevice: bigint,
+  expectedInode: bigint,
+): Promise<void> {
+  let after: BigIntStats | undefined = undefined;
+  try {
+    after = await lstat(path, { bigint: true });
+  } catch (error) {
+    if (!hasCode(error, "ENOENT")) {
+      throw new DictionaryInstallationError(
+        `Cannot inspect dictionary destination ${path}: ${errorMessage(error)}`,
+      );
+    }
+  }
+  if (
+    after === undefined ||
+    after.isSymbolicLink() ||
+    !after.isFile() ||
+    after.dev !== expectedDevice ||
+    after.ino !== expectedInode
+  ) {
+    throw new DictionaryInstallationError(
+      `Refusing replaced dictionary destination: ${path}`,
+    );
+  }
+}
+
+async function prepareSpellingDirectory(
   home: string,
 ): Promise<readonly DirectoryIdentity[]> {
   const homeIdentity = await inspectDirectory(home, "home");
@@ -137,13 +163,15 @@ export async function prepareSpellingDirectory(
   return [homeIdentity, libraryIdentity, spellingIdentity];
 }
 
-export async function assertDirectories(
+async function assertDirectories(
   identities: readonly DirectoryIdentity[],
 ): Promise<void> {
-  for (const identity of identities) await assertDirectoryIdentity(identity);
+  for (const identity of identities) {
+    await assertDirectoryIdentity(identity);
+  }
 }
 
-export async function existingDictionaryMatches(
+async function existingDictionaryMatches(
   destination: string,
   expectedChecksum: string,
 ): Promise<boolean | undefined> {
@@ -155,13 +183,13 @@ export async function existingDictionaryMatches(
 
 async function writeTemporary(
   temporary: string,
-  content: Uint8Array,
+  content: Readonly<ArrayLike<number>>,
 ): Promise<void> {
-  const file = await open(temporary, "wx", 0o600);
+  const file = await open(temporary, "wx", privateFileMode);
   try {
-    await file.writeFile(content);
+    await file.writeFile(Uint8Array.from(content));
     await file.sync();
-    await file.chmod(0o644);
+    await file.chmod(publicFileMode);
   } finally {
     await file.close();
   }
@@ -169,10 +197,10 @@ async function writeTemporary(
 
 async function linkVerifiedTemporary(
   temporary: string,
-  destination: string,
-  expectedChecksum: string,
+  publication: DictionaryPublication,
   directories: readonly DirectoryIdentity[],
 ): Promise<void> {
+  const { destination, expectedChecksum } = publication;
   await assertDirectories(directories);
   try {
     await link(temporary, destination);
@@ -182,7 +210,7 @@ async function linkVerifiedTemporary(
         `Dictionary publication failed: ${destination}: ${errorMessage(error)}`,
       );
     }
-    let concurrentMatch: boolean | undefined;
+    let concurrentMatch: boolean | undefined = undefined;
     try {
       concurrentMatch = await existingDictionaryMatches(
         destination,
@@ -193,7 +221,9 @@ async function linkVerifiedTemporary(
         `Refusing to replace concurrent dictionary destination: ${destination}: ${errorMessage(inspectionError)}`,
       );
     }
-    if (concurrentMatch === true) return;
+    if (concurrentMatch === true) {
+      return;
+    }
     throw new DictionaryInstallationError(
       `Refusing to replace concurrent dictionary destination: ${destination}`,
     );
@@ -219,12 +249,11 @@ async function removeTemporary(temporary: string): Promise<void> {
   }
 }
 
-export async function publishDictionary(
-  destination: string,
-  content: Uint8Array,
-  expectedChecksum: string,
+async function publishDictionary(
+  publication: DictionaryPublication,
   directories: readonly DirectoryIdentity[],
 ): Promise<void> {
+  const { content } = publication;
   const spellingDirectory = directories.at(-1);
   if (spellingDirectory === undefined) {
     throw new DictionaryInstallationError("Missing spelling directory");
@@ -235,13 +264,15 @@ export async function publishDictionary(
   );
   try {
     await writeTemporary(temporary, content);
-    await linkVerifiedTemporary(
-      temporary,
-      destination,
-      expectedChecksum,
-      directories,
-    );
+    await linkVerifiedTemporary(temporary, publication, directories);
   } finally {
     await removeTemporary(temporary);
   }
 }
+
+export {
+  assertDirectories,
+  existingDictionaryMatches,
+  prepareSpellingDirectory,
+  publishDictionary,
+};

--- a/tooling/install-hunspell-dictionary-test-support.ts
+++ b/tooling/install-hunspell-dictionary-test-support.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { dirname, join } from "node:path";
 import {
   mkdirSync,
   mkdtempSync,
@@ -6,21 +6,27 @@ import {
   rmSync,
   symlinkSync,
 } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
 
 const entryPoint = join(import.meta.dir, "install-hunspell-dictionary");
 const fixtures: Fixture[] = [];
 
-export type Fixture = Readonly<{
+type Fixture = Readonly<{
   root: string;
   home: string;
   spelling: string;
   destination: string;
-  environment: NodeJS.ProcessEnv;
+  environment: Readonly<NodeJS.ProcessEnv>;
 }>;
 
-export function createFixture(): Fixture {
+type RunResult = Readonly<{
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}>;
+
+function createFixture(): Fixture {
   const root = mkdtempSync(join(tmpdir(), "hunspell-dictionary-"));
   const home = join(root, "home");
   const binaries = join(root, "bin");
@@ -28,62 +34,69 @@ export function createFixture(): Fixture {
   mkdirSync(binaries);
   symlinkSync(process.execPath, join(binaries, "bun"));
   const fixture = {
-    root,
-    home,
-    spelling: join(home, "Library", "Spelling"),
     destination: join(home, "Library", "Spelling", "fr.aff"),
     environment: {
       ...process.env,
       HOME: home,
       PATH: `${binaries}:${process.env.PATH ?? ""}`,
     },
+    home,
+    root,
+    spelling: join(home, "Library", "Spelling"),
   };
   fixtures.push(fixture);
   return fixture;
 }
 
-export async function runInstaller(
+function runInstaller(
   fixture: Fixture,
-  url: string,
+  sourceUrl: string,
   checksum: string,
-  destination = fixture.destination,
-) {
-  return runArguments(fixture, [url, checksum, destination]);
+): Promise<RunResult> {
+  return runArguments(fixture, [sourceUrl, checksum, fixture.destination]);
 }
 
-export async function runArguments(
+async function runArguments(
   fixture: Fixture,
   arguments_: readonly string[],
-) {
+): Promise<RunResult> {
   const process = Bun.spawn([entryPoint, ...arguments_], {
     cwd: dirname(import.meta.dir),
     env: fixture.environment,
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   });
   const [exitCode, stdout, stderr] = await Promise.all([
     process.exited,
     new Response(process.stdout).text(),
     new Response(process.stderr).text(),
   ]);
-  return { exitCode, stdout, stderr };
+  return { exitCode, stderr, stdout };
 }
 
-export function serve(
-  fetch: (request: Request) => Response | Promise<Response>,
-) {
-  return Bun.serve({ hostname: "127.0.0.1", port: 0, fetch });
+function serve(
+  fetch: (request: Readonly<{ url: string }>) => Response | Promise<Response>,
+): ReturnType<typeof Bun.serve> {
+  return Bun.serve({ fetch, hostname: "127.0.0.1", port: 0 });
 }
 
-export function url(server: ReturnType<typeof Bun.serve>, path = "/file") {
+function url(
+  server: Readonly<{ port: number | undefined }>,
+  path = "/file",
+): string {
+  if (server.port === undefined) {
+    throw new Error("test server has no assigned port");
+  }
   return `http://127.0.0.1:${server.port}${path}`;
 }
 
-export function sha256(content: string | Uint8Array): string {
-  return createHash("sha256").update(content).digest("hex");
+function sha256(content: string | Readonly<ArrayLike<number>>): string {
+  const hashContent =
+    typeof content === "string" ? content : Uint8Array.from(content);
+  return createHash("sha256").update(hashContent).digest("hex");
 }
 
-export function temporaryFiles(fixture: Fixture): string[] {
+function temporaryFiles(fixture: Fixture): string[] {
   try {
     return readdirSync(fixture.spelling).filter((name) =>
       name.startsWith(".hunspell-dictionary."),
@@ -93,8 +106,20 @@ export function temporaryFiles(fixture: Fixture): string[] {
   }
 }
 
-export function cleanupFixtures(): void {
+function cleanupFixtures(): void {
   for (const fixture of fixtures.splice(0)) {
     rmSync(fixture.root, { force: true, recursive: true });
   }
 }
+
+export {
+  cleanupFixtures,
+  createFixture,
+  runArguments,
+  runInstaller,
+  serve,
+  sha256,
+  temporaryFiles,
+  url,
+};
+export type { Fixture, RunResult };

--- a/tooling/install-hunspell-dictionary-wiring.test.ts
+++ b/tooling/install-hunspell-dictionary-wiring.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
 
 const repository = dirname(import.meta.dir);
+const deploymentPlatformCount = 2;
 
 describe("Hunspell dictionary gates", () => {
   test("runs dictionary behavior on both deployment platforms", () => {
@@ -12,8 +13,8 @@ describe("Hunspell dictionary gates", () => {
     );
 
     expect(
-      workflow.match(/      - tooling\/install-hunspell-dictionary\*/g),
-    ).toHaveLength(2);
+      workflow.match(/ {6}- tooling\/install-hunspell-dictionary\*/gu),
+    ).toHaveLength(deploymentPlatformCount);
     expect(workflow).toContain("os: [macos-latest, ubuntu-latest]");
     expect(workflow).toContain(
       "bun test tooling/install-hunspell-dictionary.test.ts tooling/install-hunspell-dictionary-failures.test.ts",

--- a/tooling/install-hunspell-dictionary.test.ts
+++ b/tooling/install-hunspell-dictionary.test.ts
@@ -1,11 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import {
-  lstatSync,
-  mkdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { afterEach, expect, test } from "bun:test";
 import {
   cleanupFixtures,
   createFixture,
@@ -15,17 +8,30 @@ import {
   temporaryFiles,
   url,
 } from "./install-hunspell-dictionary-test-support.ts";
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 
 const content = "SET UTF-8\nTRY abcdef\n";
 const checksum = sha256(content);
 const servers: ReturnType<typeof Bun.serve>[] = [];
+const fileModeMask = 0o777;
+const publishedFileMode = 0o644;
+const privateFileMode = 0o600;
+const concurrentRequestCount = 2;
 
-afterEach(() => {
-  for (const server of servers.splice(0)) server.stop(true);
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await server.stop(true);
+  }
   cleanupFixtures();
 });
 
-function contentServer(onRequest?: () => void) {
+function contentServer(onRequest?: () => void): ReturnType<typeof Bun.serve> {
   const server = serve(() => {
     onRequest?.();
     return new Response(content);
@@ -34,129 +40,132 @@ function contentServer(onRequest?: () => void) {
   return server;
 }
 
-describe("install-hunspell-dictionary entry point", () => {
-  test("publishes verified content with the expected mode", async () => {
-    const fixture = createFixture();
-    const server = contentServer();
+test("publishes verified content with the expected mode", async () => {
+  const fixture = createFixture();
+  const server = contentServer();
+  const installation = await runInstaller(fixture, url(server), checksum);
 
-    const installation = await runInstaller(fixture, url(server), checksum);
+  expect(installation).toEqual({ exitCode: 0, stderr: "", stdout: "" });
+  expect(readFileSync(fixture.destination, "utf8")).toBe(content);
+  expect(statSync(fixture.destination).mode & fileModeMask).toBe(
+    publishedFileMode,
+  );
+  expect(temporaryFiles(fixture)).toEqual([]);
+});
 
-    expect(installation).toEqual({ exitCode: 0, stdout: "", stderr: "" });
-    expect(readFileSync(fixture.destination, "utf8")).toBe(content);
-    expect(statSync(fixture.destination).mode & 0o777).toBe(0o644);
-    expect(temporaryFiles(fixture)).toEqual([]);
+test("leaves an existing correct file unchanged without downloading", async () => {
+  const fixture = createFixture();
+  mkdirSync(fixture.spelling, { recursive: true });
+  writeFileSync(fixture.destination, content, { mode: privateFileMode });
+  const before = statSync(fixture.destination);
+  let requests = 0;
+  const server = contentServer(() => {
+    requests += 1;
   });
+  const replay = await runInstaller(fixture, url(server), checksum);
+  const after = statSync(fixture.destination);
 
-  test("leaves an existing correct file unchanged without downloading", async () => {
-    const fixture = createFixture();
-    mkdirSync(fixture.spelling, { recursive: true });
-    writeFileSync(fixture.destination, content, { mode: 0o600 });
-    const before = statSync(fixture.destination);
-    let requests = 0;
-    const server = contentServer(() => requests++);
-
-    const replay = await runInstaller(fixture, url(server), checksum);
-    const after = statSync(fixture.destination);
-
-    expect(replay).toEqual({ exitCode: 0, stdout: "", stderr: "" });
-    expect(requests).toBe(0);
-    expect({
-      inode: after.ino,
-      mode: after.mode,
-      mtime: after.mtimeMs,
-    }).toEqual({
-      inode: before.ino,
-      mode: before.mode,
-      mtime: before.mtimeMs,
-    });
+  expect(replay).toEqual({ exitCode: 0, stderr: "", stdout: "" });
+  expect(requests).toBe(0);
+  expect({
+    inode: after.ino,
+    mode: after.mode,
+    mtime: after.mtimeMs,
+  }).toEqual({
+    inode: before.ino,
+    mode: before.mode,
+    mtime: before.mtimeMs,
   });
+});
 
-  test("accepts concurrent publication of the same verified content", async () => {
-    const fixture = createFixture();
-    let releaseResponses: (() => void) | undefined;
-    const responsesReleased = new Promise<void>((resolve) => {
-      releaseResponses = resolve;
-    });
-    let requests = 0;
-    const bothRequested = Promise.withResolvers<void>();
-    const server = serve(async () => {
-      requests++;
-      if (requests === 2) bothRequested.resolve();
-      await responsesReleased;
-      return new Response(content);
-    });
-    servers.push(server);
-
-    const first = runInstaller(fixture, url(server), checksum);
-    const second = runInstaller(fixture, url(server), checksum);
-    await bothRequested.promise;
-    releaseResponses?.();
-    const results = await Promise.all([first, second]);
-
-    expect(results.map(({ exitCode }) => exitCode)).toEqual([0, 0]);
-    expect(readFileSync(fixture.destination, "utf8")).toBe(content);
-    expect(temporaryFiles(fixture)).toEqual([]);
+test("accepts concurrent publication of the same verified content", async () => {
+  const fixture = createFixture();
+  const responsesReleased = Promise.withResolvers<undefined>();
+  let requests = 0;
+  const bothRequested = Promise.withResolvers<undefined>();
+  const server = serve(async () => {
+    requests += 1;
+    if (requests === concurrentRequestCount) {
+      bothRequested.resolve();
+    }
+    await responsesReleased.promise;
+    return new Response(content);
   });
+  servers.push(server);
 
-  test("refuses concurrent verified content that loses publication", async () => {
-    const fixture = createFixture();
-    mkdirSync(fixture.spelling, { recursive: true });
-    const firstContent = "first dictionary\n";
-    const secondContent = "second dictionary\n";
-    let releaseResponses: (() => void) | undefined;
-    const responsesReleased = new Promise<void>((resolve) => {
-      releaseResponses = resolve;
-    });
-    let requests = 0;
-    const bothRequested = Promise.withResolvers<void>();
-    const server = serve(async (request) => {
-      requests++;
-      if (requests === 2) bothRequested.resolve();
-      await responsesReleased;
-      return new Response(
-        request.url.endsWith("/first") ? firstContent : secondContent,
-      );
-    });
-    servers.push(server);
+  const first = runInstaller(fixture, url(server), checksum);
+  const second = runInstaller(fixture, url(server), checksum);
+  await bothRequested.promise;
+  responsesReleased.resolve();
+  const results = await Promise.all([first, second]);
 
-    const first = runInstaller(
-      fixture,
-      url(server, "/first"),
-      sha256(firstContent),
+  expect(results.map(({ exitCode }) => exitCode)).toEqual([0, 0]);
+  expect(readFileSync(fixture.destination, "utf8")).toBe(content);
+  expect(temporaryFiles(fixture)).toEqual([]);
+});
+
+test("refuses concurrent verified content that loses publication", async () => {
+  const fixture = createFixture();
+  mkdirSync(fixture.spelling, { recursive: true });
+  const firstContent = "first dictionary\n";
+  const secondContent = "second dictionary\n";
+  const responsesReleased = Promise.withResolvers<undefined>();
+  let requests = 0;
+  const bothRequested = Promise.withResolvers<undefined>();
+  const server = serve(async (request) => {
+    requests += 1;
+    if (requests === concurrentRequestCount) {
+      bothRequested.resolve();
+    }
+    await responsesReleased.promise;
+    return new Response(
+      request.url.endsWith("/first") ? firstContent : secondContent,
     );
-    const second = runInstaller(
-      fixture,
-      url(server, "/second"),
-      sha256(secondContent),
-    );
-    await bothRequested.promise;
-    releaseResponses?.();
-    const results = await Promise.all([first, second]);
-
-    expect(results.map(({ exitCode }) => exitCode).sort()).toEqual([0, 1]);
-    expect([firstContent, secondContent]).toContain(
-      readFileSync(fixture.destination, "utf8"),
-    );
-    expect(temporaryFiles(fixture)).toEqual([]);
   });
+  servers.push(server);
 
-  test("does not expose a partial destination while downloading", async () => {
-    const fixture = createFixture();
-    const requested = Promise.withResolvers<void>();
-    const response = Promise.withResolvers<void>();
-    const server = serve(async () => {
-      requested.resolve();
-      await response.promise;
-      return new Response(content);
-    });
-    servers.push(server);
+  const first = runInstaller(
+    fixture,
+    url(server, "/first"),
+    sha256(firstContent),
+  );
+  const second = runInstaller(
+    fixture,
+    url(server, "/second"),
+    sha256(secondContent),
+  );
+  await bothRequested.promise;
+  responsesReleased.resolve();
+  const results = await Promise.all([first, second]);
 
-    const installation = runInstaller(fixture, url(server), checksum);
-    await requested.promise;
-    expect(() => lstatSync(fixture.destination)).toThrow();
-    response.resolve();
+  expect(
+    results
+      .map(({ exitCode }) => exitCode)
+      .toSorted((left, right) => left - right),
+  ).toEqual([0, 1]);
+  expect([firstContent, secondContent]).toContain(
+    readFileSync(fixture.destination, "utf8"),
+  );
+  expect(temporaryFiles(fixture)).toEqual([]);
+});
 
-    expect((await installation).exitCode).toBe(0);
-    expect(readFileSync(fixture.destination, "utf8")).toBe(content);
+test("does not expose a partial destination while downloading", async () => {
+  const fixture = createFixture();
+  const requested = Promise.withResolvers<undefined>();
+  const response = Promise.withResolvers<undefined>();
+  const server = serve(async () => {
+    requested.resolve();
+    await response.promise;
+    return new Response(content);
   });
+  servers.push(server);
+
+  const installation = runInstaller(fixture, url(server), checksum);
+  await requested.promise;
+  expect(() => lstatSync(fixture.destination)).toThrow();
+  response.resolve();
+
+  const installationResult = await installation;
+  expect(installationResult.exitCode).toBe(0);
+  expect(readFileSync(fixture.destination, "utf8")).toBe(content);
 });

--- a/tooling/install-hunspell-dictionary.ts
+++ b/tooling/install-hunspell-dictionary.ts
@@ -1,12 +1,12 @@
-import { createHash } from "node:crypto";
-import { dirname, join } from "node:path";
-import { DictionaryInstallationError } from "./install-hunspell-dictionary-error.ts";
 import {
   assertDirectories,
   existingDictionaryMatches,
   prepareSpellingDirectory,
   publishDictionary,
 } from "./install-hunspell-dictionary-files.ts";
+import { dirname, join } from "node:path";
+import { DictionaryInstallationError } from "./install-hunspell-dictionary-error.ts";
+import { createHash } from "node:crypto";
 
 type Installation = Readonly<{
   destination: string;
@@ -15,13 +15,14 @@ type Installation = Readonly<{
   url: string;
 }>;
 
+const sha256HexLength = 64;
+const usageFailureExitCode = 64;
+
 function parseInstallation(
-  arguments_: readonly string[],
-  environment: NodeJS.ProcessEnv,
+  commandArguments: readonly string[],
+  environment: Readonly<NodeJS.ProcessEnv>,
 ): Installation {
-  const url = arguments_[0];
-  const expectedChecksum = arguments_[1];
-  const destination = arguments_[2];
+  const [url, expectedChecksum, destination] = commandArguments;
   if (url === undefined || url === "") {
     throw new DictionaryInstallationError("missing source URL");
   }
@@ -31,10 +32,13 @@ function parseInstallation(
   if (destination === undefined || destination === "") {
     throw new DictionaryInstallationError("missing destination path");
   }
-  if (!/^[0-9a-f]{64}$/.test(expectedChecksum)) {
+  if (
+    expectedChecksum.length !== sha256HexLength ||
+    !/^[0-9a-f]+$/u.test(expectedChecksum)
+  ) {
     throw new DictionaryInstallationError(
       `Invalid SHA-256 checksum: ${expectedChecksum}`,
-      64,
+      usageFailureExitCode,
     );
   }
   const home = environment.HOME;
@@ -51,12 +55,7 @@ function parseInstallation(
 }
 
 async function download(url: string): Promise<Uint8Array> {
-  let response: Response;
-  try {
-    response = await fetch(url);
-  } catch {
-    throw new DictionaryInstallationError(`Dictionary download failed: ${url}`);
-  }
+  const response = await requestDictionary(url);
   if (!response.ok) {
     throw new DictionaryInstallationError(
       `Dictionary download failed with HTTP ${response.status}: ${url}`,
@@ -69,12 +68,22 @@ async function download(url: string): Promise<Uint8Array> {
   }
 }
 
+async function requestDictionary(url: string): Promise<Response> {
+  try {
+    return await fetch(url);
+  } catch {
+    throw new DictionaryInstallationError(`Dictionary download failed: ${url}`);
+  }
+}
+
 function verifyChecksum(
-  content: Uint8Array,
+  content: Readonly<ArrayLike<number>>,
   expectedChecksum: string,
   url: string,
 ): void {
-  const actualChecksum = createHash("sha256").update(content).digest("hex");
+  const actualChecksum = createHash("sha256")
+    .update(Uint8Array.from(content))
+    .digest("hex");
   if (actualChecksum !== expectedChecksum) {
     throw new DictionaryInstallationError(`SHA-256 mismatch for ${url}`);
   }
@@ -87,7 +96,9 @@ async function install(installation: Installation): Promise<void> {
     installation.expectedChecksum,
   );
   await assertDirectories(directories);
-  if (existingMatch === true) return;
+  if (existingMatch === true) {
+    return;
+  }
   if (existingMatch === false) {
     throw new DictionaryInstallationError(
       `Refusing to replace existing dictionary: ${installation.destination}`,
@@ -96,19 +107,21 @@ async function install(installation: Installation): Promise<void> {
   const content = await download(installation.url);
   verifyChecksum(content, installation.expectedChecksum, installation.url);
   await publishDictionary(
-    installation.destination,
-    content,
-    installation.expectedChecksum,
+    {
+      content,
+      destination: installation.destination,
+      expectedChecksum: installation.expectedChecksum,
+    },
     directories,
   );
 }
 
 export async function runDictionaryInstallation(
-  arguments_: readonly string[],
-  environment: NodeJS.ProcessEnv,
+  commandArguments: readonly string[],
+  environment: Readonly<NodeJS.ProcessEnv>,
 ): Promise<number> {
   try {
-    await install(parseInstallation(arguments_, environment));
+    await install(parseInstallation(commandArguments, environment));
     return 0;
   } catch (error) {
     const failure =

--- a/tooling/lint-typescript-contract.test.ts
+++ b/tooling/lint-typescript-contract.test.ts
@@ -1,0 +1,258 @@
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { z } from "zod";
+
+const SUCCESS = 0;
+const MAXIMUM_STATEMENTS = 20;
+const repositoryRoot = resolve(import.meta.dir, "..");
+const configuredRules = {
+  "eslint/func-style": ["error", "declaration", { allowArrowFunctions: true }],
+  "eslint/max-statements": ["error", MAXIMUM_STATEMENTS],
+  "eslint/no-await-in-loop": "off",
+  "eslint/no-bitwise": "off",
+  "eslint/no-duplicate-imports": ["error", { allowSeparateTypeImports: true }],
+  "eslint/no-magic-numbers": [
+    "error",
+    {
+      enforceConst: true,
+      ignore: [-1, 0, 1],
+      ignoreArrayIndexes: true,
+      ignoreNumericLiteralTypes: true,
+      ignoreTypeIndexes: true,
+    },
+  ],
+  "eslint/no-ternary": "off",
+  "eslint/no-undefined": "off",
+  "eslint/no-use-before-define": [
+    "error",
+    { classes: true, functions: false, variables: true },
+  ],
+  "eslint/one-var": ["error", "never"],
+  "eslint/sort-keys": "off",
+  "import/consistent-type-specifier-style": [
+    "error",
+    "prefer-top-level-if-only-type-imports",
+  ],
+  "import/no-named-export": "off",
+  "import/no-nodejs-modules": "off",
+  "import/no-relative-parent-imports": "off",
+  "import/prefer-default-export": "off",
+  "node/no-process-env": "off",
+  "node/no-sync": "off",
+  "node/no-top-level-await": "off",
+  "oxc/no-async-await": "off",
+  "oxc/no-optional-chaining": "off",
+  "oxc/no-rest-spread-properties": "off",
+  "promise/avoid-new": "off",
+  "typescript/parameter-properties": [
+    "error",
+    { prefer: "parameter-property" },
+  ],
+  "typescript/promise-function-async": "off",
+  "unicorn/consistent-function-scoping": [
+    "error",
+    { checkArrowFunctions: false },
+  ],
+  "unicorn/import-style": [
+    "error",
+    {
+      styles: { "node:path": { default: false, named: true } },
+    },
+  ],
+  "unicorn/max-nested-calls": ["error", { max: 5 }],
+  "unicorn/no-array-reduce": "off",
+  "unicorn/no-null": "off",
+  "unicorn/no-process-exit": "off",
+  "unicorn/number-literal-case": "off",
+} as const;
+const configuredOverrides = [
+  {
+    files: ["tooling/scrapling-container.ts"],
+    rules: { "eslint/no-control-regex": "off" },
+  },
+  {
+    files: ["oxfmt.config.ts"],
+    rules: { "import/no-default-export": "off" },
+  },
+] as const;
+const ruleSettingSchema = z.union([
+  z.literal("off"),
+  z.literal("error"),
+  z.tuple([z.literal("error"), z.unknown()]).rest(z.unknown()),
+]);
+const packageSchema = z.looseObject({
+  devDependencies: z.looseObject({
+    oxlint: z.string().regex(/^\d+\.\d+\.\d+$/u),
+    "oxlint-tsgolint": z.string().regex(/^\d+\.\d+\.\d+$/u),
+  }),
+  scripts: z
+    .object({
+      "format:typescript": z.literal("bun tooling/format-typescript.ts"),
+      "format:typescript:check": z.literal(
+        "bun tooling/format-typescript.ts --check",
+      ),
+      lint: z.literal("bun tooling/lint-typescript.ts"),
+      test: z.literal("bun test"),
+      typecheck: z.literal("tsc --noEmit"),
+    })
+    .strict(),
+});
+const configSchema = z
+  .object({
+    $schema: z.literal("./node_modules/oxlint/configuration_schema.json"),
+    categories: z
+      .object({
+        correctness: z.literal("error"),
+        pedantic: z.literal("error"),
+        perf: z.literal("error"),
+        restriction: z.literal("error"),
+        style: z.literal("error"),
+        suspicious: z.literal("error"),
+      })
+      .strict(),
+    options: z
+      .object({ maxWarnings: z.literal(SUCCESS), typeAware: z.literal(true) })
+      .strict(),
+    overrides: z.array(
+      z
+        .object({
+          files: z.array(z.string()).min(1),
+          rules: z.record(z.string(), z.literal("off")),
+        })
+        .strict(),
+    ),
+    plugins: z.tuple([
+      z.literal("eslint"),
+      z.literal("import"),
+      z.literal("node"),
+      z.literal("promise"),
+      z.literal("typescript"),
+      z.literal("unicorn"),
+      z.literal("oxc"),
+    ]),
+    rules: z.record(z.string(), ruleSettingSchema),
+  })
+  .strict();
+const checkoutStepSchema = z
+  .object({ uses: z.literal("actions/checkout@v5") })
+  .strict();
+const setupBunStepSchema = z
+  .object({
+    uses: z.literal("oven-sh/setup-bun@v2"),
+    with: z.object({ "bun-version-file": z.literal("package.json") }).strict(),
+  })
+  .strict();
+const installStepSchema = z
+  .object({
+    run: z.literal(
+      "bun --config=/dev/null --no-env-file install --frozen-lockfile --ignore-scripts",
+    ),
+  })
+  .strict();
+const gateJobSchema = (name: string, command: string): z.ZodType =>
+  z
+    .object({
+      name: z.literal(name),
+      "runs-on": z.literal("ubuntu-latest"),
+      steps: z.tuple([
+        checkoutStepSchema,
+        setupBunStepSchema,
+        installStepSchema,
+        z.object({ run: z.literal(command) }).strict(),
+      ]),
+    })
+    .strict();
+const testJobSchema = z
+  .object({
+    name: z.literal("Bun tests"),
+    "runs-on": z.literal("ubuntu-latest"),
+    steps: z.tuple([
+      checkoutStepSchema,
+      setupBunStepSchema,
+      installStepSchema,
+      z
+        .object({
+          run: z.literal("bun --config=/dev/null --no-env-file test"),
+          env: z.object({ SCRAPLING_DOCKER_SMOKE: z.literal("1") }).strict(),
+        })
+        .strict(),
+    ]),
+  })
+  .strict();
+const workflowSchema = z
+  .object({
+    name: z.literal("TypeScript"),
+    on: z.tuple([z.literal("push"), z.literal("pull_request")]),
+    jobs: z
+      .object({
+        lint: gateJobSchema(
+          "TypeScript lint",
+          "bun --config=/dev/null --no-env-file tooling/lint-typescript.ts",
+        ),
+        test: testJobSchema,
+        typecheck: gateJobSchema(
+          "TypeScript types",
+          "bun --config=/dev/null --no-env-file run typecheck",
+        ),
+      })
+      .strict(),
+  })
+  .strict();
+
+test("pins the strict type-aware Oxlint contract", async (): Promise<void> => {
+  const packageJson = packageSchema.parse(
+    await Bun.file(resolve(repositoryRoot, "package.json")).json(),
+  );
+  const config = configSchema.parse(
+    await Bun.file(resolve(repositoryRoot, ".oxlintrc.json")).json(),
+  );
+  const lockfile = await Bun.file(resolve(repositoryRoot, "bun.lock")).text();
+
+  expect(packageJson.devDependencies.oxlint).not.toContain("^");
+  expect(packageJson.devDependencies["oxlint-tsgolint"]).not.toContain("^");
+  expect(
+    packageSchema.safeParse({
+      ...packageJson,
+      scripts: { ...packageJson.scripts, prelint: "exit 0" },
+    }).success,
+  ).toBeFalse();
+  expect(config.rules).toEqual(configSchema.shape.rules.parse(configuredRules));
+  expect(config.overrides).toEqual(
+    configSchema.shape.overrides.parse(configuredOverrides),
+  );
+  expect(
+    configSchema.safeParse({ ...config, ignorePatterns: ["tooling/**"] })
+      .success,
+  ).toBeFalse();
+  expect(lockfile).toContain('"oxlint": "1.80.0"');
+  expect(lockfile).toContain('"oxlint-tsgolint": "7.0.2001"');
+});
+
+test("runs Oxlint and TypeScript as independent Ubuntu gates", async (): Promise<void> => {
+  const workflow = await Bun.file(
+    resolve(repositoryRoot, ".github/workflows/test-typescript.yml"),
+  ).text();
+  const parsedWorkflow = Bun.YAML.parse(workflow);
+
+  expect(workflowSchema.safeParse(parsedWorkflow).success).toBeTrue();
+  for (const bypass of [
+    workflow.replace(
+      "run: bun --config=/dev/null --no-env-file tooling/lint-typescript.ts",
+      "run: bun --config=/dev/null --no-env-file tooling/lint-typescript.ts || true",
+    ),
+    workflow.replace(
+      "name: TypeScript lint",
+      "name: TypeScript lint\n    continue-on-error: true",
+    ),
+    workflow.replace(
+      "name: TypeScript lint",
+      "name: TypeScript lint\n    if: false",
+    ),
+    workflow.replace("name: Bun tests", "name: Bun tests\n    if: false"),
+    `defaults:\n  run:\n    shell: "true {0}"\n${workflow}`,
+  ]) {
+    expect(
+      workflowSchema.safeParse(Bun.YAML.parse(bypass)).success,
+    ).toBeFalse();
+  }
+});

--- a/tooling/lint-typescript-mutating-test-provider.ts
+++ b/tooling/lint-typescript-mutating-test-provider.ts
@@ -1,0 +1,8 @@
+import { resolve } from "node:path";
+
+const source = resolve(process.cwd(), "source.ts");
+const directive = ["// oxlint", "-disable-next-line"].join("");
+await Bun.write(
+  source,
+  `${directive} typescript/no-floating-promises\nPromise.resolve();\n`,
+);

--- a/tooling/lint-typescript.test.ts
+++ b/tooling/lint-typescript.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, expect, test } from "bun:test";
+import { dirname, join, resolve } from "node:path";
+import {
+  findTrackedTypeScriptPaths,
+  lintTrackedTypeScript,
+} from "./lint-typescript.ts";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+const FAILURE = 1;
+const EXPECTED_MASKED_DIAGNOSTICS = 2;
+const SUCCESS = 0;
+const oxlint = resolve(import.meta.dir, "../node_modules/.bin/oxlint");
+const repositoryRoot = resolve(import.meta.dir, "..");
+const temporaryDirectories: string[] = [];
+
+afterEach(async (): Promise<void> => {
+  await Promise.all(
+    temporaryDirectories.splice(SUCCESS).map(async (directory) => {
+      await rm(directory, { force: true, recursive: true });
+    }),
+  );
+});
+
+async function run(command: readonly string[], cwd: string): Promise<number> {
+  const child = Bun.spawn([...command], {
+    cwd,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const status = await child.exited;
+  return status;
+}
+
+async function createRepository(): Promise<string> {
+  const repository = await mkdtemp(join(tmpdir(), "oxlint-contract-"));
+  temporaryDirectories.push(repository);
+  expect(await run(["git", "init", "-q"], repository)).toBe(SUCCESS);
+  const sourceConfig = join(repositoryRoot, ".oxlintrc.json");
+  await Promise.all([
+    symlink(
+      join(repositoryRoot, "node_modules"),
+      join(repository, "node_modules"),
+      "dir",
+    ),
+    Bun.write(join(repository, ".oxlintrc.json"), Bun.file(sourceConfig)),
+    writeFile(
+      join(repository, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: { lib: ["ESNext"], strict: true },
+        include: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
+      }),
+    ),
+  ]);
+  return repository;
+}
+
+async function rejectionMessage(
+  promise: Readonly<Promise<unknown>>,
+): Promise<string> {
+  try {
+    await promise;
+    return "Promise resolved unexpectedly.";
+  } catch (error) {
+    return error instanceof Error ? error.message : "Unknown rejection.";
+  }
+}
+
+function assertLintSuccess(
+  result: Readonly<{ status: number; stderr: string; stdout: string }>,
+): void {
+  if (result.status !== SUCCESS) {
+    throw new Error(`${result.stdout}\n${result.stderr}`);
+  }
+}
+
+test("discovers every tracked TypeScript extension", async (): Promise<void> => {
+  const repository = await createRepository();
+  const trackedFiles = [
+    "-leading.ts",
+    ".hidden/future.tsx",
+    "ignored/forced.mts",
+    "types/future file.cts",
+    "types/future.d.ts",
+  ];
+  await Promise.all(
+    [...trackedFiles, "untracked.ts"].map(async (file) => {
+      const target = join(repository, file);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, 'export const value = "valid";\n');
+    }),
+  );
+  await writeFile(join(repository, ".gitignore"), "ignored/\n");
+  expect(
+    await run(
+      [
+        "git",
+        "add",
+        "--",
+        ".gitignore",
+        ...trackedFiles.filter((file) => !file.startsWith("ignored/")),
+      ],
+      repository,
+    ),
+  ).toBe(SUCCESS);
+  expect(
+    await run(["git", "add", "-f", "--", "ignored/forced.mts"], repository),
+  ).toBe(SUCCESS);
+
+  expect(await findTrackedTypeScriptPaths(repository)).toEqual(
+    trackedFiles.toSorted(),
+  );
+});
+
+test("fails closed when tracked TypeScript discovery is empty or unavailable", async (): Promise<void> => {
+  const emptyRepository = await createRepository();
+  const nonRepository = await mkdtemp(join(tmpdir(), "oxlint-no-git-"));
+  temporaryDirectories.push(nonRepository);
+
+  const emptyError = await rejectionMessage(
+    findTrackedTypeScriptPaths(emptyRepository),
+  );
+  const unavailableError = await rejectionMessage(
+    findTrackedTypeScriptPaths(nonRepository),
+  );
+  expect(emptyError).toContain("empty or malformed");
+  expect(unavailableError).toContain("Git could not list");
+});
+
+test("rejects syntax-only and type-aware defects", async (): Promise<void> => {
+  const repository = await createRepository();
+  const source = join(repository, "source.ts");
+  await writeFile(source, 'export const value = "valid";\n');
+  expect(await run(["git", "add", "source.ts"], repository)).toBe(SUCCESS);
+  const validResult = await lintTrackedTypeScript(repository, oxlint);
+  assertLintSuccess(validResult);
+
+  await writeFile(source, "export const = FAILURE;\n");
+  const syntaxFailure = await lintTrackedTypeScript(repository, oxlint);
+  expect(syntaxFailure.status).toBe(FAILURE);
+
+  await writeFile(
+    source,
+    'Promise.resolve();\nexport const value = "invalid";\n',
+  );
+  const typeAwareFailure = await lintTrackedTypeScript(repository, oxlint);
+  const diagnostics = `${typeAwareFailure.stdout}\n${typeAwareFailure.stderr}`;
+  expect(typeAwareFailure.status).toBe(FAILURE);
+  expect(diagnostics).toContain("typescript(no-floating-promises)");
+});
+
+test("does not let ignore files or nested configurations mask defects", async (): Promise<void> => {
+  const repository = await createRepository();
+  const ignoredSource = join(repository, "ignored.ts");
+  const nestedDirectory = join(repository, "nested");
+  const nestedSource = join(nestedDirectory, "source.ts");
+  await mkdir(nestedDirectory);
+  await Promise.all([
+    writeFile(join(repository, ".eslintignore"), "ignored.ts\n"),
+    writeFile(ignoredSource, "Promise.resolve();\n"),
+    writeFile(
+      join(nestedDirectory, ".oxlintrc.json"),
+      JSON.stringify({ categories: { correctness: "off" } }),
+    ),
+    writeFile(nestedSource, "Promise.resolve();\n"),
+  ]);
+  expect(
+    await run(
+      [
+        "git",
+        "add",
+        ".eslintignore",
+        "ignored.ts",
+        "nested/.oxlintrc.json",
+        "nested/source.ts",
+      ],
+      repository,
+    ),
+  ).toBe(SUCCESS);
+
+  const result = await lintTrackedTypeScript(repository, oxlint);
+  const diagnostics = `${result.stdout}\n${result.stderr}`;
+  expect(result.status).toBe(FAILURE);
+  expect(
+    diagnostics.match(/typescript\(no-floating-promises\)/gu),
+  ).toHaveLength(EXPECTED_MASKED_DIAGNOSTICS);
+});
+
+test("rejects inline lint suppression directives", async (): Promise<void> => {
+  const repository = await createRepository();
+  const source = join(repository, "source.ts");
+  const directive = [
+    "/* oxlint",
+    "-disable typescript/no-floating-promises promise/catch-or-return */",
+  ].join("");
+  await writeFile(source, `${directive}\nPromise.resolve();\n`);
+  expect(await run(["git", "add", "source.ts"], repository)).toBe(SUCCESS);
+
+  const message = await rejectionMessage(
+    lintTrackedTypeScript(repository, oxlint),
+  );
+  expect(message).toContain("lint suppression directive");
+});

--- a/tooling/lint-typescript.test.ts
+++ b/tooling/lint-typescript.test.ts
@@ -4,7 +4,7 @@ import {
   findTrackedTypeScriptPaths,
   lintTrackedTypeScript,
 } from "./lint-typescript.ts";
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { link, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
 const FAILURE = 1;
@@ -13,6 +13,8 @@ const SUCCESS = 0;
 const oxlint = resolve(import.meta.dir, "../node_modules/.bin/oxlint");
 const repositoryRoot = resolve(import.meta.dir, "..");
 const temporaryDirectories: string[] = [];
+
+type LinkFile = (existingPath: string, newPath: string) => Promise<void>;
 
 afterEach(async (): Promise<void> => {
   await Promise.all(
@@ -64,6 +66,18 @@ async function rejectionMessage(
   } catch (error) {
     return error instanceof Error ? error.message : "Unknown rejection.";
   }
+}
+
+async function rejectionForTrackedLink(createLink: LinkFile): Promise<string> {
+  const repository = await createRepository();
+  const externalDirectory = await mkdtemp(join(tmpdir(), "oxlint-external-"));
+  temporaryDirectories.push(externalDirectory);
+  const externalSource = join(externalDirectory, "external.ts");
+  const linkedSource = join(repository, "linked.ts");
+  await writeFile(externalSource, 'export const value = "external";\n');
+  await createLink(externalSource, linkedSource);
+  expect(await run(["git", "add", "linked.ts"], repository)).toBe(SUCCESS);
+  return rejectionMessage(lintTrackedTypeScript(repository, oxlint));
 }
 
 function assertLintSuccess(
@@ -200,4 +214,13 @@ test("rejects inline lint suppression directives", async (): Promise<void> => {
     lintTrackedTypeScript(repository, oxlint),
   );
   expect(message).toContain("lint suppression directive");
+});
+
+test("refuses tracked TypeScript files not owned by the repository", async (): Promise<void> => {
+  const [symbolicLinkMessage, hardLinkMessage] = await Promise.all([
+    rejectionForTrackedLink(symlink),
+    rejectionForTrackedLink(link),
+  ]);
+  expect(symbolicLinkMessage).toContain("not confined to the repository");
+  expect(hardLinkMessage).toContain("not an owned regular file");
 });

--- a/tooling/lint-typescript.test.ts
+++ b/tooling/lint-typescript.test.ts
@@ -12,6 +12,10 @@ const EXPECTED_MASKED_DIAGNOSTICS = 2;
 const SUCCESS = 0;
 const oxlint = resolve(import.meta.dir, "../node_modules/.bin/oxlint");
 const repositoryRoot = resolve(import.meta.dir, "..");
+const mutatingLinter = resolve(
+  import.meta.dir,
+  "lint-typescript-mutating-test-provider.ts",
+);
 const temporaryDirectories: string[] = [];
 
 type LinkFile = (existingPath: string, newPath: string) => Promise<void>;
@@ -223,4 +227,19 @@ test("refuses tracked TypeScript files not owned by the repository", async (): P
   ]);
   expect(symbolicLinkMessage).toContain("not confined to the repository");
   expect(hardLinkMessage).toContain("not an owned regular file");
+});
+
+test("fails when a tracked source changes while lint runs", async (): Promise<void> => {
+  const repository = await createRepository();
+  const source = join(repository, "source.ts");
+  await writeFile(source, 'export const value = "valid";\n');
+  expect(await run(["git", "add", "source.ts"], repository)).toBe(SUCCESS);
+
+  const message = await rejectionMessage(
+    lintTrackedTypeScript(repository, process.execPath, [
+      process.execPath,
+      mutatingLinter,
+    ]),
+  );
+  expect(message).toContain("contains a lint suppression directive");
 });

--- a/tooling/lint-typescript.ts
+++ b/tooling/lint-typescript.ts
@@ -21,6 +21,8 @@ const typescriptPathSchema = z
   );
 const typescriptPathsSchema = z.array(typescriptPathSchema).min(FAILURE);
 
+type TypeScriptSource = Readonly<{ contents: string; path: string }>;
+
 const isOutside = (root: string, path: string): boolean => {
   const pathFromRoot = relative(root, path);
   return (
@@ -53,13 +55,13 @@ const assertOwnedTrackedFile = async (
   return absolutePath;
 };
 
-const rejectSuppressionDirectives = async (
+const readTrackedSources = (
   repositoryRoot: string,
   paths: readonly string[],
-): Promise<void> => {
+): Promise<readonly TypeScriptSource[]> => {
   const suppressionDirective =
     /(?:\/\/|\/\*)\s*(?:eslint|oxlint)-disable(?:-next-line|-line)?\b/u;
-  await Promise.all(
+  return Promise.all(
     paths.map(async (candidate) => {
       const ownedPath = await assertOwnedTrackedFile(repositoryRoot, candidate);
       const contents = new TextDecoder("utf-8", { fatal: true }).decode(
@@ -68,6 +70,7 @@ const rejectSuppressionDirectives = async (
       if (suppressionDirective.test(contents)) {
         throw new Error(`${candidate} contains a lint suppression directive.`);
       }
+      return { contents, path: candidate };
     }),
   );
 };
@@ -98,17 +101,39 @@ const findTrackedTypeScriptPaths = async (
   );
 };
 
+const assertSourcesUnchanged = async (
+  repositoryRoot: string,
+  sources: readonly TypeScriptSource[],
+): Promise<void> => {
+  const currentPaths = await findTrackedTypeScriptPaths(repositoryRoot);
+  if (
+    currentPaths.length !== sources.length ||
+    currentPaths.some((path, index) => path !== sources[index]?.path)
+  ) {
+    throw new Error("Tracked TypeScript paths changed while lint ran.");
+  }
+  const currentSources = await readTrackedSources(repositoryRoot, currentPaths);
+  if (
+    currentSources.some(
+      (source, index) => source.contents !== sources[index]?.contents,
+    )
+  ) {
+    throw new Error("Tracked TypeScript contents changed while lint ran.");
+  }
+};
+
 const lintTrackedTypeScript = async (
   repositoryRoot: string,
   oxlint: string,
+  commandPrefix: readonly string[] = [oxlint],
 ): Promise<Readonly<{ status: number; stderr: string; stdout: string }>> => {
   await access(oxlint);
   const paths = await findTrackedTypeScriptPaths(repositoryRoot);
-  await rejectSuppressionDirectives(repositoryRoot, paths);
+  const sources = await readTrackedSources(repositoryRoot, paths);
   const configuration = resolve(repositoryRoot, ".oxlintrc.json");
   const lint = Bun.spawn(
     [
-      oxlint,
+      ...commandPrefix,
       "--config",
       configuration,
       "--disable-nested-config",
@@ -128,6 +153,7 @@ const lintTrackedTypeScript = async (
     new Response(lint.stderr).text(),
     new Response(lint.stdout).text(),
   ]);
+  await assertSourcesUnchanged(repositoryRoot, sources);
   return { status, stderr, stdout };
 };
 

--- a/tooling/lint-typescript.ts
+++ b/tooling/lint-typescript.ts
@@ -1,0 +1,128 @@
+import { access, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { z } from "zod";
+
+const EXPECTED_ARGUMENT_COUNT = 2;
+const FAILURE = 1;
+const FIRST_CHARACTER = 0;
+const LAST_CHARACTER = -1;
+const SUCCESS = 0;
+const USAGE_ERROR = 2;
+const typescriptPathSchema = z
+  .string()
+  .min(FAILURE)
+  .refine(
+    (candidate) =>
+      [".ts", ".tsx", ".mts", ".cts"].some((extension) =>
+        candidate.endsWith(extension),
+      ),
+    "unsupported TypeScript path",
+  );
+const typescriptPathsSchema = z.array(typescriptPathSchema).min(FAILURE);
+
+const rejectSuppressionDirectives = async (
+  repositoryRoot: string,
+  paths: readonly string[],
+): Promise<void> => {
+  const suppressionDirective =
+    /(?:\/\/|\/\*)\s*(?:eslint|oxlint)-disable(?:-next-line|-line)?\b/u;
+  await Promise.all(
+    paths.map(async (candidate) => {
+      const contents = new TextDecoder("utf-8", { fatal: true }).decode(
+        await readFile(resolve(repositoryRoot, candidate)),
+      );
+      if (suppressionDirective.test(contents)) {
+        throw new Error(`${candidate} contains a lint suppression directive.`);
+      }
+    }),
+  );
+};
+
+const findTrackedTypeScriptPaths = async (
+  repositoryRoot: string,
+): Promise<readonly string[]> => {
+  const git = Bun.spawn(
+    ["git", "ls-files", "-z", "--", "*.ts", "*.tsx", "*.mts", "*.cts"],
+    { cwd: repositoryRoot, stderr: "inherit", stdout: "pipe" },
+  );
+  const [status, output] = await Promise.all([
+    git.exited,
+    new Response(git.stdout).arrayBuffer(),
+  ]);
+  if (status !== SUCCESS) {
+    throw new Error(`Git could not list tracked TypeScript files (${status}).`);
+  }
+
+  const serializedPaths = new TextDecoder("utf-8", { fatal: true }).decode(
+    output,
+  );
+  if (!serializedPaths.endsWith("\0")) {
+    throw new Error("Git returned an empty or malformed TypeScript path list.");
+  }
+  return typescriptPathsSchema.parse(
+    serializedPaths.slice(FIRST_CHARACTER, LAST_CHARACTER).split("\0"),
+  );
+};
+
+const lintTrackedTypeScript = async (
+  repositoryRoot: string,
+  oxlint: string,
+): Promise<Readonly<{ status: number; stderr: string; stdout: string }>> => {
+  await access(oxlint);
+  const paths = await findTrackedTypeScriptPaths(repositoryRoot);
+  await rejectSuppressionDirectives(repositoryRoot, paths);
+  const configuration = resolve(repositoryRoot, ".oxlintrc.json");
+  const lint = Bun.spawn(
+    [
+      oxlint,
+      "--config",
+      configuration,
+      "--disable-nested-config",
+      "--deny-warnings",
+      "--no-ignore",
+      "--",
+      ...paths,
+    ],
+    {
+      cwd: repositoryRoot,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const [status, stderr, stdout] = await Promise.all([
+    lint.exited,
+    new Response(lint.stderr).text(),
+    new Response(lint.stdout).text(),
+  ]);
+  return { status, stderr, stdout };
+};
+
+const errorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Unknown lint failure.";
+};
+const main = async (): Promise<number> => {
+  if (Bun.argv.length !== EXPECTED_ARGUMENT_COUNT) {
+    process.stderr.write("Usage: lint-typescript\n");
+    return USAGE_ERROR;
+  }
+  const repositoryRoot = resolve(import.meta.dir, "..");
+  const oxlint = resolve(repositoryRoot, "node_modules/.bin/oxlint");
+  const result = await lintTrackedTypeScript(repositoryRoot, oxlint);
+  process.stderr.write(result.stderr);
+  process.stdout.write(result.stdout);
+  return result.status;
+};
+
+if (import.meta.main) {
+  try {
+    process.exitCode = await main();
+  } catch (error) {
+    process.stderr.write(`${errorMessage(error)}\n`);
+    process.exitCode = FAILURE;
+  }
+}
+
+export { findTrackedTypeScriptPaths, lintTrackedTypeScript };

--- a/tooling/lint-typescript.ts
+++ b/tooling/lint-typescript.ts
@@ -1,11 +1,12 @@
-import { access, readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { access, lstat, readFile, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 
 const EXPECTED_ARGUMENT_COUNT = 2;
 const FAILURE = 1;
 const FIRST_CHARACTER = 0;
 const LAST_CHARACTER = -1;
+const OWNED_LINK_COUNT = 1;
 const SUCCESS = 0;
 const USAGE_ERROR = 2;
 const typescriptPathSchema = z
@@ -20,6 +21,38 @@ const typescriptPathSchema = z
   );
 const typescriptPathsSchema = z.array(typescriptPathSchema).min(FAILURE);
 
+const isOutside = (root: string, path: string): boolean => {
+  const pathFromRoot = relative(root, path);
+  return (
+    pathFromRoot === ".." ||
+    pathFromRoot.startsWith(`..${sep}`) ||
+    isAbsolute(pathFromRoot)
+  );
+};
+
+const assertOwnedTrackedFile = async (
+  repositoryRoot: string,
+  candidate: string,
+): Promise<string> => {
+  const canonicalRoot = await realpath(repositoryRoot);
+  const absolutePath = resolve(canonicalRoot, candidate);
+  if (
+    isOutside(canonicalRoot, absolutePath) ||
+    (await realpath(absolutePath)) !== absolutePath
+  ) {
+    throw new Error(
+      `${candidate}: tracked TypeScript path is not confined to the repository.`,
+    );
+  }
+  const metadata = await lstat(absolutePath);
+  if (!metadata.isFile() || metadata.nlink !== OWNED_LINK_COUNT) {
+    throw new Error(
+      `${candidate}: tracked TypeScript path is not an owned regular file.`,
+    );
+  }
+  return absolutePath;
+};
+
 const rejectSuppressionDirectives = async (
   repositoryRoot: string,
   paths: readonly string[],
@@ -28,8 +61,9 @@ const rejectSuppressionDirectives = async (
     /(?:\/\/|\/\*)\s*(?:eslint|oxlint)-disable(?:-next-line|-line)?\b/u;
   await Promise.all(
     paths.map(async (candidate) => {
+      const ownedPath = await assertOwnedTrackedFile(repositoryRoot, candidate);
       const contents = new TextDecoder("utf-8", { fatal: true }).decode(
-        await readFile(resolve(repositoryRoot, candidate)),
+        await readFile(ownedPath),
       );
       if (suppressionDirective.test(contents)) {
         throw new Error(`${candidate} contains a lint suppression directive.`);

--- a/tooling/obsidian-retrieval/contract.test.ts
+++ b/tooling/obsidian-retrieval/contract.test.ts
@@ -1,221 +1,222 @@
-import { describe, expect, test } from "bun:test";
-import { mkdtemp, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
-import { z } from "zod";
 import {
+  type ContractSources,
   loadContractSources,
   validateContract,
-  type ContractSources,
 } from "./contract.ts";
+import { expect, test } from "bun:test";
+import { join, resolve } from "node:path";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { z } from "zod";
 
 const repositoryRoot = resolve(import.meta.dir, "../..");
-
 const mutate = (
   sources: ContractSources,
   field: "skill" | "reference" | "userInstructions",
   transform: (value: string) => string,
 ): ContractSources => ({ ...sources, [field]: transform(sources[field]) });
 
-describe("Obsidian retrieval contract", () => {
-  test("declares the pinned Bun version", async () => {
-    const packageDocument = z
-      .object({ packageManager: z.string() })
-      .parse(await Bun.file(join(repositoryRoot, "package.json")).json());
+test("declares the pinned Bun version", async () => {
+  const packageDocument = z
+    .object({ packageManager: z.string() })
+    .parse(await Bun.file(join(repositoryRoot, "package.json")).json());
 
-    expect(packageDocument.packageManager).toBe("bun@1.4.0");
-  });
+  expect(packageDocument.packageManager).toBe("bun@1.4.0");
+});
 
-  test("accepts the repository skill", async () => {
-    const sources = await loadContractSources(repositoryRoot);
+test("accepts the repository skill", async () => {
+  const sources = await loadContractSources(repositoryRoot);
 
-    expect(validateContract(sources)).toEqual([]);
-  });
+  expect(validateContract(sources)).toEqual([]);
+});
 
-  test("requires the configured default Obsidian corpus", async () => {
-    const sources = await loadContractSources(repositoryRoot);
+test("requires the configured default Obsidian corpus", async () => {
+  const sources = await loadContractSources(repositoryRoot);
 
-    expect(
-      validateContract(
-        mutate(sources, "userInstructions", (value) =>
-          value.replace(/(- \*\*Default Obsidian corpus:\*\* )`[^`]+`/, "$1``"),
+  expect(
+    validateContract(
+      mutate(sources, "userInstructions", (value) =>
+        value.replace(
+          /(?<prefix>- \*\*Default Obsidian corpus:\*\* )`[^`]+`/u,
+          "$<prefix>``",
         ),
       ),
-    ).not.toEqual([]);
-  });
+    ),
+  ).not.toEqual([]);
+});
 
-  test("rejects a relative default Obsidian corpus", async () => {
-    const sources = await loadContractSources(repositoryRoot);
+test("rejects a relative default Obsidian corpus", async () => {
+  const sources = await loadContractSources(repositoryRoot);
 
-    expect(
-      validateContract(
-        mutate(sources, "userInstructions", (value) =>
-          value.replace(
-            /(- \*\*Default Obsidian corpus:\*\* )`\/[^`]+`/,
-            "$1`relative/vault`",
-          ),
+  expect(
+    validateContract(
+      mutate(sources, "userInstructions", (value) =>
+        value.replace(
+          /(?<prefix>- \*\*Default Obsidian corpus:\*\* )`\/[^`]+`/u,
+          "$<prefix>`relative/vault`",
         ),
       ),
-    ).not.toEqual([]);
-  });
+    ),
+  ).not.toEqual([]);
+});
 
-  test("requires default-corpus fallback guidance", async () => {
-    const sources = await loadContractSources(repositoryRoot);
+test("requires default-corpus fallback guidance", async () => {
+  const sources = await loadContractSources(repositoryRoot);
 
-    expect(
-      validateContract(
-        mutate(sources, "skill", (value) =>
-          value.replaceAll("configured default Obsidian corpus", ""),
-        ),
+  expect(
+    validateContract(
+      mutate(sources, "skill", (value) =>
+        value.replaceAll("configured default Obsidian corpus", ""),
       ),
-    ).not.toEqual([]);
-  });
+    ),
+  ).not.toEqual([]);
+});
 
-  test.each([
-    [
-      "adds a mutator to the allowlist",
-      (value: string) => value.replace("`read`,", "`read`, `create`,"),
-    ],
-    [
-      "duplicates an allowed command",
-      (value: string) => value.replace("`read`,", "`read`, `read`,"),
-    ],
-    [
-      "adds a second allowlist",
-      (value: string) => `${value}\n## Read-only allowlist\n\n\`vaults\`\n`,
-    ],
-    [
-      "exposes a backticked mutator",
-      (value: string) => `${value}\nAllowed command: \`eval\`.\n`,
-    ],
-    [
-      "invokes a mutator",
-      (value: string) => `${value}\nRun obsidian property:set.\n`,
-    ],
-  ])("rejects a reference that %s", async (_name, transform) => {
-    const sources = await loadContractSources(repositoryRoot);
+test.each([
+  [
+    "adds a mutator to the allowlist",
+    (value: string): string => value.replace("`read`,", "`read`, `create`,"),
+  ],
+  [
+    "duplicates an allowed command",
+    (value: string): string => value.replace("`read`,", "`read`, `read`,"),
+  ],
+  [
+    "adds a second allowlist",
+    (value: string): string =>
+      `${value}\n## Read-only allowlist\n\n\`vaults\`\n`,
+  ],
+  [
+    "exposes a backticked mutator",
+    (value: string): string => `${value}\nAllowed command: \`eval\`.\n`,
+  ],
+  [
+    "invokes a mutator",
+    (value: string): string => `${value}\nRun obsidian property:set.\n`,
+  ],
+])("rejects a reference that %s", async (_name, transform) => {
+  const sources = await loadContractSources(repositoryRoot);
 
-    expect(
-      validateContract(mutate(sources, "reference", transform)),
-    ).not.toEqual([]);
-  });
+  expect(validateContract(mutate(sources, "reference", transform))).not.toEqual(
+    [],
+  );
+});
 
-  test.each([
-    "Use create to add a note.",
-    "Use\ncreate to add a note.",
-    "Use\neval to inspect the vault.",
-    "Use\nopen to display the active note.",
-    "Invoke task to update a checkbox.",
-  ])("rejects positive dangerous guidance: %s", async (guidance) => {
-    const sources = await loadContractSources(repositoryRoot);
+test.each([
+  "Use create to add a note.",
+  "Use\ncreate to add a note.",
+  "Use\neval to inspect the vault.",
+  "Use\nopen to display the active note.",
+  "Invoke task to update a checkbox.",
+])("rejects positive dangerous guidance: %s", async (guidance) => {
+  const sources = await loadContractSources(repositoryRoot);
 
-    expect(
-      validateContract(
-        mutate(sources, "skill", (value) => `${value}\n\n${guidance}\n`),
+  expect(
+    validateContract(
+      mutate(sources, "skill", (value) => `${value}\n\n${guidance}\n`),
+    ),
+  ).not.toEqual([]);
+});
+
+test("rejects positive dangerous guidance in the reference", async () => {
+  const sources = await loadContractSources(repositoryRoot);
+
+  expect(
+    validateContract(
+      mutate(
+        sources,
+        "reference",
+        (value) => `${value}\n\nUse create to add a note.\n`,
       ),
-    ).not.toEqual([]);
-  });
+    ),
+  ).not.toEqual([]);
+});
 
-  test("rejects positive dangerous guidance in the reference", async () => {
-    const sources = await loadContractSources(repositoryRoot);
+test.each([
+  "Must not create notes.",
+  "Refuse to delete notes.",
+  "Write the answer with citations.",
+])("accepts non-mutating guidance: %s", async (guidance) => {
+  const sources = await loadContractSources(repositoryRoot);
 
-    expect(
-      validateContract(
-        mutate(
-          sources,
-          "reference",
-          (value) => `${value}\n\nUse create to add a note.\n`,
-        ),
-      ),
-    ).not.toEqual([]);
-  });
+  expect(
+    validateContract(
+      mutate(sources, "skill", (value) => `${value}\n\n${guidance}\n`),
+    ),
+  ).toEqual([]);
+});
 
-  test.each([
-    "Must not create notes.",
-    "Refuse to delete notes.",
-    "Write the answer with citations.",
-  ])("accepts non-mutating guidance: %s", async (guidance) => {
-    const sources = await loadContractSources(repositoryRoot);
+test("rejects malformed evaluation data", async () => {
+  const sources = await loadContractSources(repositoryRoot);
 
-    expect(
-      validateContract(
-        mutate(sources, "skill", (value) => `${value}\n\n${guidance}\n`),
-      ),
-    ).toEqual([]);
-  });
+  expect(
+    validateContract({
+      ...sources,
+      evaluations: { skill: "obsidian-retrieval" },
+    }),
+  ).not.toEqual([]);
+});
 
-  test("rejects malformed evaluation data", async () => {
-    const sources = await loadContractSources(repositoryRoot);
+test("rejects unknown evaluation fields", async () => {
+  const sources = await loadContractSources(repositoryRoot);
+  const evaluations = JSON.parse(
+    JSON.stringify(sources.evaluations).replace(
+      '"reason":',
+      '"unexpected":true,"reason":',
+    ),
+  ) as unknown;
 
-    expect(
-      validateContract({
-        ...sources,
-        evaluations: { skill: "obsidian-retrieval" },
-      }),
-    ).not.toEqual([]);
-  });
+  expect(validateContract({ ...sources, evaluations })).not.toEqual([]);
+});
 
-  test("rejects unknown evaluation fields", async () => {
-    const sources = await loadContractSources(repositoryRoot);
-    const evaluations = JSON.parse(
-      JSON.stringify(sources.evaluations).replace(
-        '"reason":',
-        '"unexpected":true,"reason":',
-      ),
-    ) as unknown;
+test("runs the real command entry point", async () => {
+  const process = Bun.spawn(
+    [Bun.which("bun") ?? "bun", "run", join(import.meta.dir, "contract.ts")],
+    {
+      cwd: repositoryRoot,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
 
-    expect(validateContract({ ...sources, evaluations })).not.toEqual([]);
-  });
+  expect(await process.exited).toBe(0);
+  expect(await new Response(process.stdout).text()).toContain(
+    "Obsidian retrieval contract passed",
+  );
+});
 
-  test("runs the real command entry point", async () => {
-    const process = Bun.spawn(
-      [Bun.which("bun") ?? "bun", "run", join(import.meta.dir, "contract.ts")],
-      {
-        cwd: repositoryRoot,
-        stderr: "pipe",
-        stdout: "pipe",
-      },
-    );
+test("the command fails closed when an input is missing", async () => {
+  const root = await mkdtemp(join(tmpdir(), "obsidian-contract-"));
+  await writeFile(join(root, "SKILL.md"), "incomplete", "utf8");
+  const process = Bun.spawn(
+    [
+      Bun.which("bun") ?? "bun",
+      "run",
+      join(import.meta.dir, "contract.ts"),
+      root,
+    ],
+    { stderr: "pipe", stdout: "pipe" },
+  );
 
-    expect(await process.exited).toBe(0);
-    expect(await new Response(process.stdout).text()).toContain(
-      "Obsidian retrieval contract passed",
-    );
-  });
+  expect(await process.exited).not.toBe(0);
+  expect(await new Response(process.stderr).text()).toContain(
+    "unable to read contract inputs",
+  );
+});
 
-  test("the command fails closed when an input is missing", async () => {
-    const root = await mkdtemp(join(tmpdir(), "obsidian-contract-"));
-    await writeFile(join(root, "SKILL.md"), "incomplete", "utf8");
-    const process = Bun.spawn(
-      [
-        Bun.which("bun") ?? "bun",
-        "run",
-        join(import.meta.dir, "contract.ts"),
-        root,
-      ],
-      { stderr: "pipe", stdout: "pipe" },
-    );
+test("the command rejects an empty repository root", async () => {
+  const process = Bun.spawn(
+    [
+      Bun.which("bun") ?? "bun",
+      "run",
+      join(import.meta.dir, "contract.ts"),
+      "",
+    ],
+    { stderr: "pipe", stdout: "pipe" },
+  );
 
-    expect(await process.exited).not.toBe(0);
-    expect(await new Response(process.stderr).text()).toContain(
-      "unable to read contract inputs",
-    );
-  });
-
-  test("the command rejects an empty repository root", async () => {
-    const process = Bun.spawn(
-      [
-        Bun.which("bun") ?? "bun",
-        "run",
-        join(import.meta.dir, "contract.ts"),
-        "",
-      ],
-      { stderr: "pipe", stdout: "pipe" },
-    );
-
-    expect(await process.exited).not.toBe(0);
-    expect(await new Response(process.stderr).text()).toContain(
-      "repository root",
-    );
-  });
+  expect(await process.exited).not.toBe(0);
+  expect(await new Response(process.stderr).text()).toContain(
+    "repository root",
+  );
 });

--- a/tooling/obsidian-retrieval/contract.ts
+++ b/tooling/obsidian-retrieval/contract.ts
@@ -1,9 +1,9 @@
 import { resolve } from "node:path";
-import { z } from "zod";
 import { validateDefaultCorpus } from "./default-corpus-contract.ts";
 import { validateEvaluations } from "./evaluation-contract.ts";
+import { z } from "zod";
 
-export type ContractSources = Readonly<{
+type ContractSources = Readonly<{
   skill: string;
   reference: string;
   userInstructions: string;
@@ -29,7 +29,6 @@ const expectedCommands = new Set([
   "tasks",
   "vault",
 ]);
-
 const unsafeCommands = new Set(
   `append base:create bookmark command create daily:append daily:prepend delete dev:cdp dev:console
   dev:css dev:debug dev:dom dev:errors dev:mobile dev:screenshot devtools eval history:open
@@ -38,10 +37,9 @@ const unsafeCommands = new Set(
   publish:remove random reload rename restart search:open snippet:disable snippet:enable sync:open
   sync:restore tab:open task template:insert theme theme:install theme:set theme:uninstall unique
   vault:open vaults web workspace:delete workspace:load workspace:save`.split(
-    /\s+/,
+    /\s+/u,
   ),
 );
-
 const dangerousGuidance = new Set([
   "append",
   "base:create",
@@ -70,12 +68,10 @@ const dangerousGuidance = new Set([
   "workspace:delete",
   "workspace:save",
 ]);
-
 const unsafeCommandPattern = [...unsafeCommands]
-  .sort((left, right) => right.length - left.length)
-  .map((command) => command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  .toSorted((left, right) => right.length - left.length)
+  .map((command) => command.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`))
   .join("|");
-
 const requiredSkillPhrases = [
   "explicit corpus input",
   "configured default Obsidian corpus",
@@ -94,115 +90,151 @@ const requiredSkillPhrases = [
   "Never write, create, append, prepend, move, rename, or delete vault content",
   "references/obsidian-cli.md",
 ];
-
 const allowedReferenceTokens = new Set([
   ...expectedCommands,
   ".base",
   "obsidian vault info=path",
   "obsidian version",
 ]);
-
 const repositoryRootSchema = z
   .string()
   .min(1, "repository root must not be empty");
-
-const sameSet = (values: string[], expected: Set<string>): boolean =>
-  values.length === expected.size &&
+const matchesExpectedCommands = (values: readonly string[]): boolean =>
+  values.length === expectedCommands.size &&
   new Set(values).size === values.length &&
-  values.every((value) => expected.has(value));
-
-const backtickedTokens = (text: string): string[] =>
-  [...text.matchAll(/`([^`]+)`/g)].flatMap((match) =>
-    match[1] === undefined ? [] : [match[1]],
-  );
-
-const allowlistSection = (reference: string): string | undefined => {
-  const headings = [...reference.matchAll(/^## .+$/gm)];
-  const matches = headings.filter(
-    (match) => match[0] === "## Read-only allowlist",
-  );
-  if (matches.length !== 1 || matches[0]?.index === undefined) return undefined;
-  const start = matches[0].index + matches[0][0].length;
-  const next = headings.find(
-    (match) => match.index !== undefined && match.index > start,
-  );
-  return reference.slice(start, next?.index ?? reference.length);
+  values.every((value) => expectedCommands.has(value));
+const backtickedTokens = (text: string): string[] => {
+  const tokens: string[] = [];
+  for (const match of text.matchAll(/`(?<token>[^`]+)`/gu)) {
+    if (match.groups?.token !== undefined) {
+      tokens.push(match.groups.token);
+    }
+  }
+  return tokens;
 };
-
+const allowlistSection = (reference: string): string | undefined => {
+  const headings = [...reference.matchAll(/^## .+$/gmu)];
+  const matches: RegExpExecArray[] = [];
+  for (const heading of headings) {
+    if (heading[0] === "## Read-only allowlist") {
+      matches.push(heading);
+    }
+  }
+  const [allowlistHeading] = matches;
+  if (matches.length !== 1 || allowlistHeading?.index === undefined) {
+    return undefined;
+  }
+  const start = allowlistHeading.index + allowlistHeading[0].length;
+  let nextIndex: number | undefined = undefined;
+  for (const heading of headings) {
+    if (heading.index !== undefined && heading.index > start) {
+      nextIndex = heading.index;
+      break;
+    }
+  }
+  return reference.slice(start, nextIndex ?? reference.length);
+};
 const positiveDangerousGuidance = (skill: string): string[] => {
-  const sentences = skill.replace(/\s+/g, " ").split(/(?<=[.!?])\s+/);
-  return sentences.flatMap((sentence) => {
+  const sentences = skill.replaceAll(/\s+/gu, " ").split(/(?<=[.!?])\s+/u);
+  const findings: string[] = [];
+  for (const sentence of sentences) {
     const normalizedSentence = sentence.toLowerCase();
-    const tokens = normalizedSentence.match(/[a-z]+(?::[a-z]+)*/g) ?? [];
+    const tokens = normalizedSentence.match(/[a-z]+(?::[a-z]+)*/gu) ?? [];
     const dangerous = tokens.filter((token) => dangerousGuidance.has(token));
     const positiveDangerous = dangerous.filter((token) => {
       const index = normalizedSentence.indexOf(token);
       const prefix = sentence.slice(0, index);
-      return !/\b(?:do not|does not|must not|never|refuse to|without)\b/i.test(
+      return !/\b(?:do not|does not|must not|never|refuse to|without)\b/iu.test(
         prefix,
       );
     });
     const imperativePattern = new RegExp(
       `\\b(?:allow(?:ed)?|permit(?:ted)?|run|use|invoke|expose)\\s+(?:the\\s+)?(?:command\\s+)?(${unsafeCommandPattern})(?![\\w:])`,
-      "gi",
+      "giu",
     );
-    const imperativeDangerous = [
-      ...sentence.matchAll(imperativePattern),
-    ].flatMap((match) => {
+    findings.push(...positiveDangerous);
+    for (const match of sentence.matchAll(imperativePattern)) {
       const prefix = sentence.slice(0, match.index);
-      return /\b(?:do not|does not|must not|never|refuse to|without)\b/i.test(
-        prefix,
-      ) || match[1] === undefined
-        ? []
-        : [match[1]];
-    });
-    return [...positiveDangerous, ...imperativeDangerous];
-  });
+      const negated =
+        /\b(?:do not|does not|must not|never|refuse to|without)\b/iu.test(
+          prefix,
+        );
+      if (!negated && match[1] !== undefined) {
+        findings.push(match[1]);
+      }
+    }
+  }
+  return findings;
 };
 
-export const validateContract = ({
-  skill,
-  reference,
-  userInstructions,
-  evaluations,
-}: ContractSources): string[] => {
+function validateSkill(skill: string): string[] {
   const errors: string[] = [];
-  const normalizedSkill = skill.replace(/\s+/g, " ");
+  const normalizedSkill = skill.replaceAll(/\s+/gu, " ");
   for (const phrase of requiredSkillPhrases) {
-    if (!normalizedSkill.includes(phrase.replace(/\s+/g, " ")))
+    if (!normalizedSkill.includes(phrase.replaceAll(/\s+/gu, " "))) {
       errors.push(`SKILL.md is missing: ${phrase}`);
+    }
   }
+  return errors;
+}
+
+function validateAllowlist(reference: string): string[] {
+  const errors: string[] = [];
   const section = allowlistSection(reference);
   if (section === undefined) {
     errors.push("the read-only allowlist must occur exactly once");
   } else {
     const commands = backtickedTokens(section);
-    if (!sameSet(commands, expectedCommands))
+    if (!matchesExpectedCommands(commands)) {
       errors.push("the read-only allowlist does not match the canonical set");
-    if (commands.some((command) => unsafeCommands.has(command)))
+    }
+    if (commands.some((command) => unsafeCommands.has(command))) {
       errors.push("the read-only allowlist contains an unsafe command");
+    }
   }
+  return errors;
+}
+
+function validateReference(skill: string, reference: string): string[] {
+  const errors = validateAllowlist(reference);
   const unexpectedTokens = backtickedTokens(reference).filter(
     (token) => !allowedReferenceTokens.has(token),
   );
-  if (unexpectedTokens.length > 0)
+  if (unexpectedTokens.length > 0) {
     errors.push(`unexpected reference tokens: ${unexpectedTokens.join(", ")}`);
-  const invocations = [
-    ...`${skill}\n${reference}`.matchAll(/\bobsidian\s+([a-z][a-z:-]*)/g),
-  ]
-    .flatMap((match) => (match[1] === undefined ? [] : [match[1]]))
-    .filter((command) => command !== "version" && command !== "vault");
-  if (invocations.length > 0)
+  }
+  const invocations: string[] = [];
+  for (const match of `${skill}\n${reference}`.matchAll(
+    /\bobsidian\s+(?<command>[a-z][a-z:-]*)/gu,
+  )) {
+    const command = match.groups?.command;
+    if (command !== undefined && command !== "version" && command !== "vault") {
+      invocations.push(command);
+    }
+  }
+  if (invocations.length > 0) {
     errors.push(`unsafe Obsidian invocations: ${invocations.join(", ")}`);
+  }
   const dangerous = positiveDangerousGuidance(`${skill}\n${reference}`);
-  if (dangerous.length > 0)
+  if (dangerous.length > 0) {
     errors.push(`positive dangerous guidance: ${dangerous.join(", ")}`);
-  errors.push(...validateDefaultCorpus(userInstructions));
-  errors.push(...validateEvaluations(evaluations));
+  }
   return errors;
-};
+}
 
-export const loadContractSources = async (
+const validateContract = ({
+  skill,
+  reference,
+  userInstructions,
+  evaluations,
+}: ContractSources): string[] => [
+  ...validateSkill(skill),
+  ...validateReference(skill, reference),
+  ...validateDefaultCorpus(userInstructions),
+  ...validateEvaluations(evaluations),
+];
+
+const loadContractSources = async (
   repositoryRoot: string,
 ): Promise<ContractSources> => {
   const skillRoot = resolve(
@@ -218,14 +250,15 @@ export const loadContractSources = async (
         Bun.file(resolve(skillRoot, "evals/trigger-queries.json")).text(),
       ]);
     return {
-      skill,
-      reference,
-      userInstructions,
       evaluations: JSON.parse(evaluationsText) as unknown,
+      reference,
+      skill,
+      userInstructions,
     };
   } catch (error) {
     throw new Error(
       `unable to read contract inputs: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
 };
@@ -237,10 +270,17 @@ if (import.meta.main) {
         ? process.cwd()
         : repositoryRootSchema.parse(process.argv[2]);
     const errors = validateContract(await loadContractSources(repositoryRoot));
-    if (errors.length > 0) throw new Error(errors.join("\n"));
-    console.log("Obsidian retrieval contract passed");
+    if (errors.length > 0) {
+      throw new Error(errors.join("\n"));
+    }
+    process.stdout.write("Obsidian retrieval contract passed\n");
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
     process.exitCode = 1;
   }
 }
+
+export { loadContractSources, validateContract };
+export type { ContractSources };

--- a/tooling/obsidian-retrieval/default-corpus-contract.ts
+++ b/tooling/obsidian-retrieval/default-corpus-contract.ts
@@ -3,12 +3,13 @@ import { isAbsolute } from "node:path";
 export const validateDefaultCorpus = (userInstructions: string): string[] => {
   const matches = [
     ...userInstructions.matchAll(
-      /^- \*\*Default Obsidian corpus:\*\* `([^`\n]+)`$/gm,
+      /^- \*\*Default Obsidian corpus:\*\* `(?<corpus>[^`\n]+)`$/gmu,
     ),
   ];
-  if (matches.length !== 1)
+  if (matches.length !== 1) {
     return ["USER.md must declare exactly one default Obsidian corpus"];
-  const defaultCorpus = matches[0]?.[1];
+  }
+  const defaultCorpus = matches[0]?.groups?.corpus;
   return defaultCorpus !== undefined && isAbsolute(defaultCorpus)
     ? []
     : ["the default Obsidian corpus must be an absolute path"];

--- a/tooling/obsidian-retrieval/evaluation-contract.ts
+++ b/tooling/obsidian-retrieval/evaluation-contract.ts
@@ -2,8 +2,6 @@ import { z } from "zod";
 
 const evaluationDocumentSchema = z
   .object({
-    skill: z.literal("obsidian-retrieval"),
-    version: z.string().min(1),
     queries: z
       .array(
         z
@@ -15,25 +13,29 @@ const evaluationDocumentSchema = z
           .strict(),
       )
       .min(1),
+    skill: z.literal("obsidian-retrieval"),
+    version: z.string().min(1),
   })
   .strict();
 
 export const validateEvaluations = (value: unknown): string[] => {
   const result = evaluationDocumentSchema.safeParse(value);
-  if (!result.success) return [z.prettifyError(result.error)];
-  const queries = result.data.queries;
-  const texts = queries.map((query) => String(query.query));
-  const reasons = queries.map((query) => String(query.reason));
-  const activations = queries.map((query) => Boolean(query.should_activate));
+  if (!result.success) {
+    return [z.prettifyError(result.error)];
+  }
+  const { queries } = result.data;
+  const texts = queries.map((query) => query.query);
+  const reasons = queries.map((query) => query.reason);
+  const activations = new Set(queries.map((query) => query.should_activate));
   const coverage = [
-    activations.includes(true) && activations.includes(false),
-    texts.some((text) => /exact|title|identifier|tag/i.test(text)),
-    texts.some((text) => /concept|idea|theme/i.test(text)),
-    texts.some((text) => /backlink|property|properties|task|base/i.test(text)),
-    texts.some((text) => /web|weather/i.test(text)),
-    texts.some((text) => /write|create|edit/i.test(text)),
-    reasons.some((reason) => /missing|unavailable/i.test(reason)),
-    reasons.some((reason) => /empty|no match/i.test(reason)),
+    activations.has(true) && activations.has(false),
+    texts.some((text) => /exact|title|identifier|tag/iu.test(text)),
+    texts.some((text) => /concept|idea|theme/iu.test(text)),
+    texts.some((text) => /backlink|property|properties|task|base/iu.test(text)),
+    texts.some((text) => /web|weather/iu.test(text)),
+    texts.some((text) => /write|create|edit/iu.test(text)),
+    reasons.some((reason) => /missing|unavailable/iu.test(reason)),
+    reasons.some((reason) => /empty|no match/iu.test(reason)),
   ];
   return coverage.every(Boolean)
     ? []

--- a/tooling/scrapling-container.ts
+++ b/tooling/scrapling-container.ts
@@ -1,21 +1,21 @@
 import { z } from "zod";
 
 const containerSchema = z.object({
-  Name: z.string(),
   Config: z.object({
-    Image: z.string(),
-    Entrypoint: z.array(z.string()).nullable(),
     Cmd: z.array(z.string()).nullable(),
+    Entrypoint: z.array(z.string()).nullable(),
+    Image: z.string(),
   }),
   HostConfig: z.object({ ExtraHosts: z.array(z.string()).nullable() }),
   Mounts: z.array(
     z.object({
-      Type: z.string(),
-      Name: z.string().optional(),
       Destination: z.string(),
+      Name: z.string().optional(),
       RW: z.boolean(),
+      Type: z.string(),
     }),
   ),
+  Name: z.string(),
   State: z.object({ Running: z.boolean() }),
 });
 
@@ -26,7 +26,24 @@ type CommandResult = Readonly<{
   timedOut: boolean;
 }>;
 
-export type Configuration = Readonly<{
+type Container = Readonly<{
+  Config: Readonly<{
+    Cmd: readonly string[] | null;
+    Entrypoint: readonly string[] | null;
+    Image: string;
+  }>;
+  HostConfig: Readonly<{ ExtraHosts: readonly string[] | null }>;
+  Mounts: readonly Readonly<{
+    Destination: string;
+    Name?: string | undefined;
+    RW: boolean;
+    Type: string;
+  }>[];
+  Name: string;
+  State: Readonly<{ Running: boolean }>;
+}>;
+
+type Configuration = Readonly<{
   container: string;
   image: string;
   timeoutMilliseconds: number;
@@ -34,52 +51,89 @@ export type Configuration = Readonly<{
 
 const profileVolume = "scrapling-profiles";
 const decoder = new TextDecoder("utf-8", { fatal: true });
+const usageFailureExitCode = 64;
+const unavailableFailureExitCode = 69;
+const configurationFailureExitCode = 78;
+const dataFailureExitCode = 65;
+const timeoutFailureExitCode = 75;
+const maximumTimeoutMilliseconds = 300_000;
 
-export async function prepareScraplingContainer(
-  environment: NodeJS.ProcessEnv,
+class LifecycleError extends Error {
+  public readonly exitCode: number;
+
+  public constructor(exitCode: number, message: string) {
+    super(message);
+    this.exitCode = exitCode;
+    this.name = "LifecycleError";
+  }
+}
+
+async function prepareScraplingContainer(
+  environment: Readonly<NodeJS.ProcessEnv>,
 ): Promise<Configuration> {
   const configuration = readConfiguration(environment);
   await requireDocker(configuration.timeoutMilliseconds);
   const existing = await findContainer(configuration);
-  if (existing) await reuseContainer(existing, configuration);
-  else await createContainer(configuration);
+  await (existing === undefined
+    ? createContainer(configuration)
+    : reuseContainer(existing, configuration));
   return configuration;
 }
 
-function readConfiguration(environment: NodeJS.ProcessEnv): Configuration {
+function readConfiguration(
+  environment: Readonly<NodeJS.ProcessEnv>,
+): Configuration {
   const container = environment.SCRAPLING_CONTAINER ?? "scrapling-mcp";
   const image = environment.SCRAPLING_IMAGE ?? "pyd4vinci/scrapling";
   const timeout = environment.SCRAPLING_DOCKER_TIMEOUT_MS ?? "10000";
-  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(container)) {
-    throw new LifecycleError(64, `invalid container name: ${container}`);
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*$/u.test(container)) {
+    throw new LifecycleError(
+      usageFailureExitCode,
+      `invalid container name: ${container}`,
+    );
   }
-  if (!image || image.startsWith("-") || /[\x00-\x20\x7f]/.test(image)) {
-    throw new LifecycleError(64, `invalid image reference: ${image}`);
+  if (!image || image.startsWith("-") || /[\u0000-\u0020\u007F]/u.test(image)) {
+    throw new LifecycleError(
+      usageFailureExitCode,
+      `invalid image reference: ${image}`,
+    );
   }
   if (
-    !/^[1-9]\d*$/.test(timeout) ||
+    !/^[1-9]\d*$/u.test(timeout) ||
     !Number.isSafeInteger(Number(timeout)) ||
-    Number(timeout) > 300_000
+    Number(timeout) > maximumTimeoutMilliseconds
   ) {
-    throw new LifecycleError(64, `invalid Docker timeout: ${timeout}`);
+    throw new LifecycleError(
+      usageFailureExitCode,
+      `invalid Docker timeout: ${timeout}`,
+    );
   }
   return { container, image, timeoutMilliseconds: Number(timeout) };
 }
 
 async function requireDocker(timeoutMilliseconds: number): Promise<void> {
   const result = await runDocker(["info"], timeoutMilliseconds);
-  if (result.exitCode !== 0)
-    throw commandError(69, "Docker daemon unavailable", result);
+  if (result.exitCode !== 0) {
+    throw commandError(
+      unavailableFailureExitCode,
+      "Docker daemon unavailable",
+      result,
+    );
+  }
 }
 
-async function findContainer(configuration: Configuration) {
+async function findContainer(
+  configuration: Configuration,
+): Promise<Container | undefined> {
   const listed = await runDocker(
     ["container", "ls", "--all", "--format", "{{.Names}}"],
     configuration.timeoutMilliseconds,
   );
   requireSuccess(listed, "cannot list Docker containers");
   const names = listed.stdout.split("\n").filter(Boolean);
-  if (!names.includes(configuration.container)) return undefined;
+  if (!names.includes(configuration.container)) {
+    return undefined;
+  }
   const inspected = await runDocker(
     ["container", "inspect", "--format", "{{json .}}", configuration.container],
     configuration.timeoutMilliseconds,
@@ -92,23 +146,25 @@ async function findContainer(configuration: Configuration) {
     return containerSchema.parse(JSON.parse(inspected.stdout));
   } catch {
     throw new LifecycleError(
-      78,
+      configurationFailureExitCode,
       `container ${configuration.container} returned invalid inspection data`,
     );
   }
 }
 
 async function reuseContainer(
-  container: z.infer<typeof containerSchema>,
+  container: Container,
   configuration: Configuration,
 ): Promise<void> {
   if (!isCompatible(container, configuration)) {
     throw new LifecycleError(
-      78,
+      configurationFailureExitCode,
       `container ${configuration.container} is incompatible with the required Scrapling configuration`,
     );
   }
-  if (container.State.Running) return;
+  if (container.State.Running) {
+    return;
+  }
   const started = await runDocker(
     ["start", configuration.container],
     configuration.timeoutMilliseconds,
@@ -117,7 +173,7 @@ async function reuseContainer(
 }
 
 function isCompatible(
-  container: z.infer<typeof containerSchema>,
+  container: Container,
   configuration: Configuration,
 ): boolean {
   const profile = container.Mounts.find(
@@ -154,14 +210,17 @@ async function createContainer(configuration: Configuration): Promise<void> {
     ],
     configuration.timeoutMilliseconds,
   );
-  if (created.exitCode === 0) return;
+  if (created.exitCode === 0) {
+    return;
+  }
   const racedContainer = await findContainer(configuration);
-  if (!racedContainer)
+  if (!racedContainer) {
     throw commandError(
       1,
       `cannot create container ${configuration.container}`,
       created,
     );
+  }
   await reuseContainer(racedContainer, configuration);
 }
 
@@ -170,8 +229,8 @@ async function runDocker(
   timeoutMilliseconds: number,
 ): Promise<CommandResult> {
   const child = Bun.spawn(["docker", ...arguments_], {
-    stdout: "pipe",
     stderr: "pipe",
+    stdout: "pipe",
   });
   let timedOut = false;
   const timeout = setTimeout(() => {
@@ -187,20 +246,22 @@ async function runDocker(
   try {
     return {
       exitCode,
-      stdout: decoder.decode(stdoutBytes),
       stderr: decoder.decode(stderrBytes),
+      stdout: decoder.decode(stdoutBytes),
       timedOut,
     };
   } catch {
     throw new LifecycleError(
-      65,
+      dataFailureExitCode,
       `Docker ${arguments_[0] ?? "command"} returned invalid UTF-8`,
     );
   }
 }
 
 function requireSuccess(result: CommandResult, action: string): void {
-  if (result.exitCode !== 0) throw commandError(1, action, result);
+  if (result.exitCode !== 0) {
+    throw commandError(1, action, result);
+  }
 }
 
 function commandError(
@@ -208,7 +269,9 @@ function commandError(
   action: string,
   result: CommandResult,
 ): LifecycleError {
-  if (result.timedOut) return new LifecycleError(75, `${action} timed out`);
+  if (result.timedOut) {
+    return new LifecycleError(timeoutFailureExitCode, `${action} timed out`);
+  }
   const detail = result.stderr.trim();
   return new LifecycleError(
     exitCode,
@@ -226,11 +289,5 @@ function arraysEqual(
   );
 }
 
-export class LifecycleError extends Error {
-  constructor(
-    readonly exitCode: number,
-    message: string,
-  ) {
-    super(message);
-  }
-}
+export { LifecycleError, prepareScraplingContainer };
+export type { Configuration };

--- a/tooling/scrapling-mcp-test-provider.ts
+++ b/tooling/scrapling-mcp-test-provider.ts
@@ -9,12 +9,42 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, join } from "node:path";
+import { z } from "zod";
 
-const arguments_ = process.argv.slice(2);
+const scenarioSchema = z
+  .object({
+    compatible: z.boolean().optional(),
+    concurrent: z.boolean().optional(),
+    execExit: z.number().optional(),
+    execStderr: z.string().optional(),
+    execStdout: z.string().optional(),
+    hang: z.string().optional(),
+    infoFailure: z.boolean().optional(),
+    inspectFailure: z.boolean().optional(),
+    invalidInspect: z.boolean().optional(),
+    invalidUtf8: z.string().optional(),
+    listFailure: z.boolean().optional(),
+    present: z.boolean().optional(),
+    runFailure: z.boolean().optional(),
+    running: z.boolean().optional(),
+    startFailure: z.boolean().optional(),
+  })
+  .strict();
+
+const argumentOffset = 2;
+const concurrentListCount = 2;
+const concurrentPollMilliseconds = 2;
+const invalidByte = 0xff;
+const simulatedHangMilliseconds = 60_000;
+const dockerCreationFailureExitCode = 125;
+const usageFailureExitCode = 64;
+const commandArguments = process.argv.slice(argumentOffset);
 const realDocker = process.env.SCRAPLING_REAL_DOCKER_BIN;
-if (realDocker) {
-  if (arguments_[0] === "exec") finish(0, "mcp smoke\n");
-  const realArguments = arguments_.map((argument) =>
+if (realDocker !== undefined) {
+  if (commandArguments[0] === "exec") {
+    finish(0, "mcp smoke\n");
+  }
+  const realArguments = commandArguments.map((argument) =>
     argument === "scrapling-profiles:/profiles"
       ? `${process.env.SCRAPLING_REAL_PROFILE_VOLUME}:/profiles`
       : argument,
@@ -35,8 +65,8 @@ if (realDocker) {
     const inspection = result.stdout
       .toString()
       .replaceAll(
-        `\"Name\":\"${process.env.SCRAPLING_REAL_PROFILE_VOLUME}\"`,
-        '\"Name\":\"scrapling-profiles\"',
+        `"Name":"${process.env.SCRAPLING_REAL_PROFILE_VOLUME}"`,
+        '"Name":"scrapling-profiles"',
       );
     finish(result.exitCode, inspection, result.stderr.toString());
   }
@@ -44,81 +74,100 @@ if (realDocker) {
 }
 
 const state = process.env.SCRAPLING_TEST_STATE;
-if (!state) throw new Error("SCRAPLING_TEST_STATE is required");
-const scenario = JSON.parse(readFileSync(join(state, "scenario.json"), "utf8"));
-appendFileSync(join(state, "calls"), `${JSON.stringify(arguments_)}\n`);
-const command = arguments_.join(" ");
+if (state === undefined || state === "") {
+  throw new Error("SCRAPLING_TEST_STATE is required");
+}
+const scenario = scenarioSchema.parse(
+  JSON.parse(readFileSync(join(state, "scenario.json"), "utf8")),
+);
+appendFileSync(join(state, "calls"), `${JSON.stringify(commandArguments)}\n`);
+const command = commandArguments.join(" ");
 
-if (scenario.hang && command.includes(scenario.hang)) {
-  await Bun.sleep(60_000);
+if (scenario.hang !== undefined && command.includes(scenario.hang)) {
+  await Bun.sleep(simulatedHangMilliseconds);
 }
 
-if (scenario.invalidUtf8 && command.includes(scenario.invalidUtf8)) {
-  process.stdout.write(new Uint8Array([0xff]));
+if (
+  scenario.invalidUtf8 !== undefined &&
+  command.includes(scenario.invalidUtf8)
+) {
+  process.stdout.write(new Uint8Array([invalidByte]));
   process.exit(0);
 }
 
-if (arguments_[0] === "info")
-  finish(scenario.infoFailure ? 1 : 0, "", "daemon failed\n");
+if (commandArguments[0] === "info") {
+  finish(scenario.infoFailure === true ? 1 : 0, "", "daemon failed\n");
+}
 
 if (command.includes("container ls")) {
-  if (scenario.listFailure) finish(1, "", "list failed\n");
-  if (scenario.concurrent) {
+  if (scenario.listFailure === true) {
+    finish(1, "", "list failed\n");
+  }
+  if (scenario.concurrent === true) {
     writeFileSync(join(state, `list-${process.pid}`), "");
     while (
-      readdirSync(state).filter((name) => name.startsWith("list-")).length < 2
+      readdirSync(state).filter((name) => name.startsWith("list-")).length <
+      concurrentListCount
     ) {
-      Bun.sleepSync(2);
+      Bun.sleepSync(concurrentPollMilliseconds);
     }
   }
   finish(0, existsSync(join(state, "container")) ? "scrapling-mcp\n" : "");
 }
 
 if (command.includes("container inspect")) {
-  if (scenario.inspectFailure) finish(1, "", "inspect failed\n");
-  if (scenario.invalidInspect) finish(0, "not-json\n");
+  if (scenario.inspectFailure === true) {
+    finish(1, "", "inspect failed\n");
+  }
+  if (scenario.invalidInspect === true) {
+    finish(0, "not-json\n");
+  }
   const compatible = scenario.compatible !== false;
   finish(
     0,
     `${JSON.stringify({
-      Name: "/scrapling-mcp",
       Config: {
-        Image: compatible ? "pyd4vinci/scrapling" : "other/image",
-        Entrypoint: ["sleep"],
         Cmd: ["infinity"],
+        Entrypoint: ["sleep"],
+        Image: compatible ? "pyd4vinci/scrapling" : "other/image",
       },
       HostConfig: { ExtraHosts: ["host.docker.internal:host-gateway"] },
       Mounts: [
         {
-          Type: "volume",
-          Name: "scrapling-profiles",
           Destination: "/profiles",
+          Name: "scrapling-profiles",
           RW: true,
+          Type: "volume",
         },
       ],
+      Name: "/scrapling-mcp",
       State: { Running: existsSync(join(state, "running")) },
     })}\n`,
   );
 }
 
-if (arguments_[0] === "start") {
-  if (scenario.startFailure) finish(1, "", "start failed\n");
+if (commandArguments[0] === "start") {
+  if (scenario.startFailure === true) {
+    finish(1, "", "start failed\n");
+  }
   writeFileSync(join(state, "running"), "");
   finish(0);
 }
 
-if (arguments_[0] === "run") {
-  if (scenario.runFailure) finish(125, "", "create failed\n");
+if (commandArguments[0] === "run") {
+  if (scenario.runFailure === true) {
+    finish(dockerCreationFailureExitCode, "", "create failed\n");
+  }
   try {
     mkdirSync(join(state, "container"));
     writeFileSync(join(state, "running"), "");
     finish(0);
   } catch {
-    finish(125, "", "name conflict\n");
+    finish(dockerCreationFailureExitCode, "", "name conflict\n");
   }
 }
 
-if (arguments_[0] === "exec") {
+if (commandArguments[0] === "exec") {
   finish(
     scenario.execExit ?? 0,
     scenario.execStdout ?? "",
@@ -127,13 +176,17 @@ if (arguments_[0] === "exec") {
 }
 
 finish(
-  64,
+  usageFailureExitCode,
   "",
   `unexpected docker call from ${basename(process.argv[1] ?? "")}: ${command}\n`,
 );
 
 function finish(exitCode: number, stdout = "", stderr = ""): never {
-  if (stdout) process.stdout.write(stdout);
-  if (stderr && exitCode !== 0) process.stderr.write(stderr);
+  if (stdout) {
+    process.stdout.write(stdout);
+  }
+  if (stderr && exitCode !== 0) {
+    process.stderr.write(stderr);
+  }
   process.exit(exitCode);
 }

--- a/tooling/scrapling-mcp-test-support.ts
+++ b/tooling/scrapling-mcp-test-support.ts
@@ -7,10 +7,12 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { z } from "zod";
 
 const entryPoint = join(import.meta.dir, "scrapling-mcp");
+const executableFileMode = 0o755;
 const provider = join(import.meta.dir, "scrapling-mcp-test-provider.ts");
 const fixtures: Fixture[] = [];
 
@@ -32,16 +34,24 @@ type Scenario = Readonly<{
   hang?: string;
 }>;
 
-export type Fixture = Readonly<{
+type RunResult = Readonly<{
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}>;
+
+const callsSchema = z.array(z.array(z.string()));
+
+type Fixture = Readonly<{
   root: string;
   entryPoint: string;
-  environment: NodeJS.ProcessEnv;
+  environment: Readonly<NodeJS.ProcessEnv>;
   state: string;
 }>;
 
-export function createFixture(
+function createFixture(
   scenario: Scenario = {},
-  environment: Record<string, string> = {},
+  environment: Readonly<Record<string, string>> = {},
 ): Fixture {
   const root = mkdtempSync(join(tmpdir(), "scrapling-mcp-"));
   const binaries = join(root, "bin");
@@ -52,72 +62,81 @@ export function createFixture(
   symlinkSync(provider, join(binaries, "docker"));
   const installedEntryPoint = join(binaries, "scrapling_mcp");
   symlinkSync(entryPoint, installedEntryPoint);
-  chmodSync(provider, 0o755);
+  chmodSync(provider, executableFileMode);
   writeFileSync(join(state, "scenario.json"), JSON.stringify(scenario));
-  if (scenario.present) mkdirSync(join(state, "container"));
-  if (scenario.running) writeFileSync(join(state, "running"), "");
+  if (scenario.present === true) {
+    mkdirSync(join(state, "container"));
+  }
+  if (scenario.running === true) {
+    writeFileSync(join(state, "running"), "");
+  }
   const fixture = {
-    root,
     entryPoint: installedEntryPoint,
-    state,
     environment: {
       ...process.env,
       PATH: `${binaries}:${process.env.PATH ?? ""}`,
-      SCRAPLING_TEST_STATE: state,
       SCRAPLING_DOCKER_TIMEOUT_MS: "5000",
+      SCRAPLING_TEST_STATE: state,
       ...environment,
     },
+    root,
+    state,
   };
   fixtures.push(fixture);
   return fixture;
 }
 
-export function run(fixture: Fixture) {
-  const result = Bun.spawnSync([fixture.entryPoint], {
+function run(fixture: Fixture): RunResult {
+  const commandResult = Bun.spawnSync([fixture.entryPoint], {
     env: fixture.environment,
+    stderr: "pipe",
     stdin: "ignore",
     stdout: "pipe",
-    stderr: "pipe",
   });
   return {
-    exitCode: result.exitCode,
-    stdout: result.stdout.toString(),
-    stderr: result.stderr.toString(),
+    exitCode: commandResult.exitCode,
+    stderr: commandResult.stderr.toString(),
+    stdout: commandResult.stdout.toString(),
   };
 }
 
-export function start(fixture: Fixture) {
+function start(fixture: Fixture): Bun.Subprocess<"ignore", "pipe", "pipe"> {
   return Bun.spawn([fixture.entryPoint], {
     env: fixture.environment,
+    stderr: "pipe",
     stdin: "ignore",
     stdout: "pipe",
-    stderr: "pipe",
   });
 }
 
-export async function result(process: ReturnType<typeof start>) {
+async function result(fixture: Fixture): Promise<RunResult> {
+  const process = start(fixture);
   const [exitCode, stdout, stderr] = await Promise.all([
     process.exited,
     new Response(process.stdout).text(),
     new Response(process.stderr).text(),
   ]);
-  return { exitCode, stdout, stderr };
+  return { exitCode, stderr, stdout };
 }
 
-export function calls(fixture: Fixture): string[][] {
+function calls(fixture: Fixture): readonly (readonly string[])[] {
   try {
-    return readFileSync(join(fixture.state, "calls"), "utf8")
+    const parsedCalls = readFileSync(join(fixture.state, "calls"), "utf8")
       .trim()
       .split("\n")
       .filter(Boolean)
-      .map((line) => JSON.parse(line) as string[]);
+      .map((line): unknown => JSON.parse(line));
+    return callsSchema.parse(parsedCalls);
   } catch {
     return [];
   }
 }
 
-export function cleanupFixtures(): void {
+function cleanupFixtures(): void {
   for (const fixture of fixtures.splice(0)) {
-    rmSync(fixture.root, { recursive: true, force: true });
+    rmSync(fixture.root, { force: true, recursive: true });
   }
 }
+
+export { calls, cleanupFixtures, createFixture, result, run };
+export type { Fixture, Scenario };

--- a/tooling/scrapling-mcp.test.ts
+++ b/tooling/scrapling-mcp.test.ts
@@ -1,238 +1,272 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
 import {
   calls,
   cleanupFixtures,
   createFixture,
   result,
   run,
-  start,
 } from "./scrapling-mcp-test-support.ts";
+
+type Fixture = ReturnType<typeof createFixture>;
+type Scenario = Parameters<typeof createFixture>[0];
 
 afterEach(cleanupFixtures);
 
-describe("scrapling-mcp entry point", () => {
-  test("reuses a compatible running container and preserves MCP output", () => {
-    const fixture = createFixture({
-      present: true,
-      running: true,
-      execStdout: "mcp response\n",
-    });
+const concurrentProcessCount = 2;
+const configurationFailureExitCode = 78;
+const usageFailureExitCode = 64;
+const timeoutFailureExitCode = 75;
+const integrationTimeoutMilliseconds = 90_000;
 
-    expect(run(fixture)).toEqual({
-      exitCode: 0,
-      stdout: "mcp response\n",
-      stderr: "",
-    });
-    expect(calls(fixture).map((call) => call[0])).toEqual([
-      "info",
-      "container",
-      "container",
-      "exec",
-    ]);
-  });
+type DockerSmokeFixture = Readonly<{
+  container: string;
+  docker: string;
+  fixture: Fixture;
+  volume: string;
+  volumeLabel: string;
+  volumeOwner: string;
+}>;
 
-  test("starts a compatible stopped container", () => {
-    const fixture = createFixture({ present: true });
-
-    expect(run(fixture).exitCode).toBe(0);
-    expect(calls(fixture).map((call) => call[0])).toEqual([
-      "info",
-      "container",
-      "container",
-      "start",
-      "exec",
-    ]);
-  });
-
-  test("creates the established container when absent", () => {
-    const fixture = createFixture();
-
-    expect(run(fixture).exitCode).toBe(0);
-    expect(calls(fixture)).toContainEqual([
-      "run",
-      "--detach",
-      "--name",
-      "scrapling-mcp",
-      "--add-host=host.docker.internal:host-gateway",
-      "--volume",
-      "scrapling-profiles:/profiles",
-      "--entrypoint",
-      "sleep",
-      "pyd4vinci/scrapling",
-      "infinity",
-    ]);
-  });
-
-  test("concurrent entry points converge on one named container", async () => {
-    const fixture = createFixture({ concurrent: true });
-
-    const outcomes = await Promise.all([
-      result(start(fixture)),
-      result(start(fixture)),
-    ]);
-
-    expect(outcomes.map(({ exitCode }) => exitCode)).toEqual([0, 0]);
-    expect(calls(fixture).filter((call) => call[0] === "exec")).toHaveLength(2);
-  });
-
-  test("refuses an incompatible existing container", () => {
-    const fixture = createFixture({ present: true, compatible: false });
-
-    const outcome = run(fixture);
-
-    expect(outcome.exitCode).toBe(78);
-    expect(outcome.stderr).toContain("incompatible");
-    expect(calls(fixture).some((call) => call[0] === "exec")).toBeFalse();
-  });
-
-  test.each([
-    ["Docker daemon unavailable", { infoFailure: true }],
-    ["cannot list", { listFailure: true }],
-    ["cannot inspect", { present: true, inspectFailure: true }],
-    ["cannot start", { present: true, startFailure: true }],
-    ["cannot create", { runFailure: true }],
-  ])("reports %s", (_label, scenario) => {
-    const outcome = run(createFixture(scenario));
-
-    expect(outcome.exitCode).not.toBe(0);
-    expect(outcome.stderr).not.toBe("");
-  });
-
-  test("propagates the MCP process status and stderr", () => {
-    const fixture = createFixture({
-      present: true,
-      running: true,
-      execExit: 42,
-      execStderr: "mcp failed\n",
-    });
-
-    expect(run(fixture)).toEqual({
-      exitCode: 42,
-      stdout: "",
-      stderr: "mcp failed\n",
-    });
-  });
-
-  test("rejects malformed and non-UTF-8 Docker evidence", () => {
-    for (const scenario of [
-      { present: true, invalidInspect: true },
-      { invalidUtf8: "container ls" },
-    ]) {
-      const outcome = run(createFixture(scenario));
-      expect(outcome.exitCode).not.toBe(0);
-      expect(outcome.stdout).toBe("");
-      expect(outcome.stderr).toMatch(/invalid (inspection data|UTF-8)/);
-    }
-  });
-
-  test("rejects unsafe environment overrides before Docker runs", () => {
-    for (const environment of [
-      { SCRAPLING_CONTAINER: "--privileged" },
-      { SCRAPLING_IMAGE: "-v /:/host" },
-      { SCRAPLING_DOCKER_TIMEOUT_MS: "0" },
-    ]) {
-      const fixture = createFixture({}, environment);
-      expect(run(fixture).exitCode).toBe(64);
-      expect(calls(fixture)).toEqual([]);
-    }
-  });
-
-  test("times out a blocked lifecycle command", () => {
-    const fixture = createFixture(
-      { hang: "container ls" },
-      { SCRAPLING_DOCKER_TIMEOUT_MS: "100" },
-    );
-
-    const outcome = run(fixture);
-
-    expect(outcome.exitCode).toBe(75);
-    expect(outcome.stderr).toContain("timed out");
-  });
-
-  test.skipIf(process.env.SCRAPLING_DOCKER_SMOKE !== "1")(
-    "uses an isolated real Docker lifecycle when explicitly enabled",
-    () => {
-      const docker = Bun.which("docker");
-      expect(docker).not.toBeNull();
-      const container = `scrapling-mcp-smoke-${crypto.randomUUID()}`;
-      const volume = `scrapling-profiles-smoke-${crypto.randomUUID()}`;
-      const volumeOwner = crypto.randomUUID();
-      const volumeLabel = "dotfiles.scrapling-smoke";
-      const fixture = createFixture(
-        {},
-        {
-          SCRAPLING_CONTAINER: container,
-          SCRAPLING_IMAGE: "alpine:3.22",
-          SCRAPLING_REAL_DOCKER_BIN: docker!,
-          SCRAPLING_REAL_PROFILE_VOLUME: volume,
-          SCRAPLING_REAL_OWNER: volumeOwner,
-          SCRAPLING_REAL_OWNER_LABEL: volumeLabel,
-          SCRAPLING_DOCKER_TIMEOUT_MS: "60000",
-        },
-      );
-      try {
-        const existingContainer = Bun.spawnSync([
-          docker!,
-          "container",
-          "inspect",
-          container,
-        ]);
-        expect(existingContainer.exitCode).not.toBe(0);
-        const existingVolume = Bun.spawnSync([
-          docker!,
-          "volume",
-          "inspect",
-          volume,
-        ]);
-        expect(existingVolume.exitCode).not.toBe(0);
-        const createdVolume = Bun.spawnSync([
-          docker!,
-          "volume",
-          "create",
-          "--label",
-          `${volumeLabel}=${volumeOwner}`,
-          volume,
-        ]);
-        expect(createdVolume.exitCode).toBe(0);
-        const owner = Bun.spawnSync([
-          docker!,
-          "volume",
-          "inspect",
-          "--format",
-          `{{ index .Labels "${volumeLabel}" }}`,
-          volume,
-        ]);
-        expect(owner.stdout.toString().trim()).toBe(volumeOwner);
-        expect(run(fixture)).toEqual({
-          exitCode: 0,
-          stdout: "mcp smoke\n",
-          stderr: "",
-        });
-        expect(run(fixture)).toEqual({
-          exitCode: 0,
-          stdout: "mcp smoke\n",
-          stderr: "",
-        });
-        const inspection = Bun.spawnSync([docker!, "inspect", container]);
-        expect(inspection.exitCode).toBe(0);
-      } finally {
-        const ownedContainer = Bun.spawnSync([
-          docker!,
-          "container",
-          "inspect",
-          "--format",
-          `{{.Id}} {{ index .Config.Labels "${volumeLabel}" }}`,
-          container,
-        ]);
-        const [containerId, containerOwner] = ownedContainer.stdout
-          .toString()
-          .trim()
-          .split(" ");
-        if (ownedContainer.exitCode === 0 && containerOwner === volumeOwner) {
-          Bun.spawnSync([docker!, "rm", "--force", containerId!]);
-        }
-      }
+function createDockerSmokeFixture(docker: string): DockerSmokeFixture {
+  const container = `scrapling-mcp-smoke-${crypto.randomUUID()}`;
+  const volume = `scrapling-profiles-smoke-${crypto.randomUUID()}`;
+  const volumeOwner = crypto.randomUUID();
+  const volumeLabel = "dotfiles.scrapling-smoke";
+  const fixture = createFixture(
+    {},
+    {
+      SCRAPLING_CONTAINER: container,
+      SCRAPLING_DOCKER_TIMEOUT_MS: "60000",
+      SCRAPLING_IMAGE: "alpine:3.22",
+      SCRAPLING_REAL_DOCKER_BIN: docker,
+      SCRAPLING_REAL_OWNER: volumeOwner,
+      SCRAPLING_REAL_OWNER_LABEL: volumeLabel,
+      SCRAPLING_REAL_PROFILE_VOLUME: volume,
     },
-    90_000,
+  );
+  return { container, docker, fixture, volume, volumeLabel, volumeOwner };
+}
+
+function assertDockerSmokeAbsent(smoke: DockerSmokeFixture): void {
+  const existingContainer = Bun.spawnSync([
+    smoke.docker,
+    "container",
+    "inspect",
+    smoke.container,
+  ]);
+  expect(existingContainer.exitCode).not.toBe(0);
+  const existingVolume = Bun.spawnSync([
+    smoke.docker,
+    "volume",
+    "inspect",
+    smoke.volume,
+  ]);
+  expect(existingVolume.exitCode).not.toBe(0);
+}
+
+function createOwnedVolume(smoke: DockerSmokeFixture): void {
+  const createdVolume = Bun.spawnSync([
+    smoke.docker,
+    "volume",
+    "create",
+    "--label",
+    `${smoke.volumeLabel}=${smoke.volumeOwner}`,
+    smoke.volume,
+  ]);
+  expect(createdVolume.exitCode).toBe(0);
+  const owner = Bun.spawnSync([
+    smoke.docker,
+    "volume",
+    "inspect",
+    "--format",
+    `{{ index .Labels "${smoke.volumeLabel}" }}`,
+    smoke.volume,
+  ]);
+  expect(owner.stdout.toString().trim()).toBe(smoke.volumeOwner);
+}
+
+function exerciseDockerSmoke(smoke: DockerSmokeFixture): void {
+  const expected = { exitCode: 0, stderr: "", stdout: "mcp smoke\n" };
+  expect(run(smoke.fixture)).toEqual(expected);
+  expect(run(smoke.fixture)).toEqual(expected);
+  const inspection = Bun.spawnSync([smoke.docker, "inspect", smoke.container]);
+  expect(inspection.exitCode).toBe(0);
+}
+
+function cleanupDockerSmoke(smoke: DockerSmokeFixture): void {
+  const ownedContainer = Bun.spawnSync([
+    smoke.docker,
+    "container",
+    "inspect",
+    "--format",
+    `{{.Id}} {{ index .Config.Labels "${smoke.volumeLabel}" }}`,
+    smoke.container,
+  ]);
+  const [containerId, containerOwner] = ownedContainer.stdout
+    .toString()
+    .trim()
+    .split(" ");
+  if (
+    ownedContainer.exitCode === 0 &&
+    containerOwner === smoke.volumeOwner &&
+    containerId !== undefined
+  ) {
+    Bun.spawnSync([smoke.docker, "rm", "--force", containerId]);
+  }
+}
+
+function runDockerSmoke(): void {
+  const docker = Bun.which("docker");
+  expect(docker).not.toBeNull();
+  if (docker === null) {
+    throw new Error("Docker is unavailable");
+  }
+  const smoke = createDockerSmokeFixture(docker);
+  try {
+    assertDockerSmokeAbsent(smoke);
+    createOwnedVolume(smoke);
+    exerciseDockerSmoke(smoke);
+  } finally {
+    cleanupDockerSmoke(smoke);
+  }
+}
+
+test("reuses a compatible running container and preserves MCP output", () => {
+  const fixture = createFixture({
+    execStdout: "mcp response\n",
+    present: true,
+    running: true,
+  });
+
+  expect(run(fixture)).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout: "mcp response\n",
+  });
+  expect(calls(fixture).map((call) => call[0])).toEqual([
+    "info",
+    "container",
+    "container",
+    "exec",
+  ]);
+});
+
+test("starts a compatible stopped container", () => {
+  const fixture = createFixture({ present: true });
+
+  expect(run(fixture).exitCode).toBe(0);
+  expect(calls(fixture).map((call) => call[0])).toEqual([
+    "info",
+    "container",
+    "container",
+    "start",
+    "exec",
+  ]);
+});
+
+test("creates the established container when absent", () => {
+  const fixture = createFixture();
+
+  expect(run(fixture).exitCode).toBe(0);
+  expect(calls(fixture)).toContainEqual([
+    "run",
+    "--detach",
+    "--name",
+    "scrapling-mcp",
+    "--add-host=host.docker.internal:host-gateway",
+    "--volume",
+    "scrapling-profiles:/profiles",
+    "--entrypoint",
+    "sleep",
+    "pyd4vinci/scrapling",
+    "infinity",
+  ]);
+});
+
+test("concurrent entry points converge on one named container", async () => {
+  const fixture = createFixture({ concurrent: true });
+  const outcomes = await Promise.all([result(fixture), result(fixture)]);
+
+  expect(outcomes.map(({ exitCode }) => exitCode)).toEqual([0, 0]);
+  expect(calls(fixture).filter((call) => call[0] === "exec")).toHaveLength(
+    concurrentProcessCount,
   );
 });
+
+test("refuses an incompatible existing container", () => {
+  const fixture = createFixture({ compatible: false, present: true });
+  const outcome = run(fixture);
+
+  expect(outcome.exitCode).toBe(configurationFailureExitCode);
+  expect(outcome.stderr).toContain("incompatible");
+  expect(calls(fixture).some((call) => call[0] === "exec")).toBeFalse();
+});
+
+test.each([
+  ["Docker daemon unavailable", { infoFailure: true }],
+  ["cannot list", { listFailure: true }],
+  ["cannot inspect", { inspectFailure: true, present: true }],
+  ["cannot start", { present: true, startFailure: true }],
+  ["cannot create", { runFailure: true }],
+])("reports %s", (...[_label, scenario]: readonly [string, Scenario]) => {
+  const outcome = run(createFixture(scenario));
+
+  expect(outcome.exitCode).not.toBe(0);
+  expect(outcome.stderr).not.toBe("");
+});
+
+test("propagates the MCP process status and stderr", () => {
+  const fixture = createFixture({
+    execExit: 42,
+    execStderr: "mcp failed\n",
+    present: true,
+    running: true,
+  });
+
+  expect(run(fixture)).toEqual({
+    exitCode: 42,
+    stderr: "mcp failed\n",
+    stdout: "",
+  });
+});
+
+test("rejects malformed and non-UTF-8 Docker evidence", () => {
+  for (const scenario of [
+    { invalidInspect: true, present: true },
+    { invalidUtf8: "container ls" },
+  ]) {
+    const outcome = run(createFixture(scenario));
+    expect(outcome.exitCode).not.toBe(0);
+    expect(outcome.stdout).toBe("");
+    expect(outcome.stderr).toMatch(/invalid (?<reason>inspection data|UTF-8)/u);
+  }
+});
+
+test("rejects unsafe environment overrides before Docker runs", () => {
+  for (const environment of [
+    { SCRAPLING_CONTAINER: "--privileged" },
+    { SCRAPLING_IMAGE: "-v /:/host" },
+    { SCRAPLING_DOCKER_TIMEOUT_MS: "0" },
+  ]) {
+    const fixture = createFixture({}, environment);
+    expect(run(fixture).exitCode).toBe(usageFailureExitCode);
+    expect(calls(fixture)).toEqual([]);
+  }
+});
+
+test("times out a blocked lifecycle command", () => {
+  const fixture = createFixture(
+    { hang: "container ls" },
+    { SCRAPLING_DOCKER_TIMEOUT_MS: "100" },
+  );
+  const outcome = run(fixture);
+
+  expect(outcome.exitCode).toBe(timeoutFailureExitCode);
+  expect(outcome.stderr).toContain("timed out");
+});
+
+test.skipIf(process.env.SCRAPLING_DOCKER_SMOKE !== "1")(
+  "uses an isolated real Docker lifecycle when explicitly enabled",
+  runDockerSmoke,
+  integrationTimeoutMilliseconds,
+);

--- a/tooling/scrapling-mcp.ts
+++ b/tooling/scrapling-mcp.ts
@@ -1,11 +1,11 @@
 import {
+  type Configuration,
   LifecycleError,
   prepareScraplingContainer,
-  type Configuration,
 } from "./scrapling-container.ts";
 
-export async function runScraplingMcp(
-  environment: NodeJS.ProcessEnv,
+async function runScraplingMcp(
+  environment: Readonly<NodeJS.ProcessEnv>,
 ): Promise<number> {
   try {
     return await runMcp(await prepareScraplingContainer(environment));
@@ -29,10 +29,14 @@ async function runMcp(configuration: Configuration): Promise<number> {
       "scrapling",
       "mcp",
     ],
-    { stdin: "inherit", stdout: "inherit", stderr: "inherit" },
+    { stderr: "inherit", stdin: "inherit", stdout: "inherit" },
   );
-  const forwardInterrupt = () => child.kill("SIGINT");
-  const forwardTermination = () => child.kill("SIGTERM");
+  const forwardInterrupt = (): void => {
+    child.kill("SIGINT");
+  };
+  const forwardTermination = (): void => {
+    child.kill("SIGTERM");
+  };
   process.on("SIGINT", forwardInterrupt);
   process.on("SIGTERM", forwardTermination);
   try {
@@ -42,3 +46,5 @@ async function runMcp(configuration: Configuration): Promise<number> {
     process.off("SIGTERM", forwardTermination);
   }
 }
+
+export { runScraplingMcp };


### PR DESCRIPTION
Closes #218.

## Summary

- pin Oxlint and `oxlint-tsgolint`, with one root type-aware configuration enabling every applicable stable category at error severity and a zero-warning budget
- add a fail-closed tracked-file lint entry point covering `.ts`, `.tsx`, `.mts`, `.cts`, and `.d.ts`, including future tracked files, nested-config/ignore bypasses, inline suppressions, symlinks, and hard links
- keep `tsc --noEmit` independent and make Ubuntu CI run install, lint, tests, and typecheck without lifecycle hooks, Bun config preloads, or dotenv input
- enable `max-lines-per-function`, `no-continue`, complexity and the remaining sustainable quality rules, then refactor the full TypeScript corpus until the barrier passes

The remaining disabled rules are individually inventoried and tested. They represent direct rule conflicts, Bun/Node or existing API contracts, Oxfmt ownership, or intentionally scoped test/CLI roles; no category or plugin is disabled.

## Validation

On the exact head `fe54259430edf0583a92f01588d97b0321d076a1`, in a clean worktree on macOS 26.6.2 arm64 with Bun 1.4.0 and the pinned Oxlint 1.80.0:

- `bun --config=/dev/null --no-env-file install --frozen-lockfile --ignore-scripts`
- `bun --config=/dev/null --no-env-file tooling/lint-typescript.ts` — 93 tracked TypeScript files
- `bun --config=/dev/null --no-env-file run typecheck`
- `bun --config=/dev/null --no-env-file run format:typescript:check` — 93 tracked TypeScript files
- `bun --config=/dev/null --no-env-file test` — 253 passed, 4 conditional skips, 0 failed

Ubuntu evidence is provided by the GitHub Actions checks on this PR. No Cursor authentication file or behavior is changed.

## Concurrency boundary

The gate assumes its checkout and pinned Oxlint binary are not controlled by a concurrent same-UID process. CI runs no repository code before lint because dependency lifecycle scripts, Bun config preloads, and dotenv input are disabled; persistent tracked-input changes during lint are detected and rejected.

## Structural note

Files remaining above the 250-line review trigger are cohesive test suites or boundary adapters directly exercised by this migration; splitting them further would separate one contract without reducing production-function complexity. Every changed production function is at or below the 50-line trigger.

## Comments added

None.
