### PR TITLE
fix(deployment): retire stale command links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,9 +466,12 @@ hunspell-dictionaries: bun
 	"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.dic" "f0b1a234bd178bdd01875b2a392a9647f888b8fe879f79c52aae62c2759b3647" "$(HOME)/Library/Spelling/en_US.dic"
 
 .PHONY: codex
-codex: bun ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.agents/skills/agent-instructions ~/.agents/skills/claude-developer ~/.agents/skills/codegraph ~/.agents/skills/handoff ~/.agents/skills/enforcement-code ~/.agents/skills/harness-reflection ~/.agents/skills/issue-creation ~/.agents/skills/linear-issue-spec ~/.agents/skills/linear-start ~/.agents/skills/linear-sync ~/.agents/skills/linear-workflow ~/.agents/skills/obsidian-retrieval ~/.agents/skills/pr-fix ~/.agents/skills/pr-verdict ~/.agents/skills/requirements-clarification ~/.agents/skills/skill-manager ~/.agents/skills/workflow-automation codex-hooks
+codex: bun ${VOLTA_BIN}/codex claude-developer-link-cleanup ~/.codex/AGENTS.md ~/.agents/skills/agent-instructions ~/.agents/skills/claude-developer ~/.agents/skills/codegraph ~/.agents/skills/handoff ~/.agents/skills/enforcement-code ~/.agents/skills/harness-reflection ~/.agents/skills/issue-creation ~/.agents/skills/linear-issue-spec ~/.agents/skills/linear-start ~/.agents/skills/linear-sync ~/.agents/skills/linear-workflow ~/.agents/skills/obsidian-retrieval ~/.agents/skills/pr-fix ~/.agents/skills/pr-verdict ~/.agents/skills/requirements-clarification ~/.agents/skills/skill-manager ~/.agents/skills/workflow-automation codex-hooks
 ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 	${BREW_BIN}/volta install @openai/codex
+.PHONY: claude-developer-link-cleanup
+claude-developer-link-cleanup: bun
+	"${BREW_BIN}/bun" "${DOTFILES_PATH}/tooling/retire-command-link" "${DOTFILES_PATH}/tooling/claude-developer" "${LOCAL_BIN}/claude-developer"
 ~/.codex:
 	mkdir -p $@
 # Codex ignores AGENTS.md @import directives, so the sources are assembled
@@ -559,8 +562,8 @@ codegraph-ignore:
 	mkdir -p "$$(dirname "$$target")"; \
 	ln -s "$$expected" "$$target"
 
-${LOCAL_BIN}/codegraph-repository-size: ${DOTFILES_PATH}/tooling/codegraph-repository-size | ${LOCAL_BIN}
-	${CREATE_SYMLINK}
+${LOCAL_BIN}/codegraph-repository-size: FORCE ${DOTFILES_PATH}/tooling/codegraph-repository-size | ${BREW_BIN}/bun ${LOCAL_BIN}
+	"${BREW_BIN}/bun" "${DOTFILES_PATH}/tooling/retire-command-link" "${DOTFILES_PATH}/harness/skills/codegraph/scripts/measure_repository.sh" "${DOTFILES_PATH}/tooling/codegraph-repository-size" "$@"
 
 .PHONY: googleworkspace-cli
 googleworkspace-cli: ${VOLTA_BIN}/gws

--- a/tooling/deployment-command-links.test.ts
+++ b/tooling/deployment-command-links.test.ts
@@ -15,7 +15,8 @@ import { mkdirSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 afterEach(cleanupDeploymentFixtures);
 
 const FUTURE_MTIME_OFFSET_MILLISECONDS = 60_000;
-const bunDirectory = dirname(requireCommand("bun"));
+type CommandLinkFixture = Parameters<typeof runMake>[0];
+type CommandLinkResult = ReturnType<typeof runMake>;
 
 test("migrates the former CodeGraph measurement command link", () => {
   const fixture = createDeploymentFixture("codegraph-command-migration");
@@ -47,17 +48,15 @@ test("migrates the former CodeGraph measurement command link", () => {
   symlinkSync(retiredTarget, destination);
 
   expectSuccess(
-    runMake(fixture, [destination], {
+    runCommandLinkMake(fixture, [destination], {
       repository,
-      variables: { BREW_BIN: bunDirectory },
     }),
   );
 
   expect(linkTarget(destination)).toBe(currentTarget);
   expectSuccess(
-    runMake(fixture, [destination], {
+    runCommandLinkMake(fixture, [destination], {
       repository,
-      variables: { BREW_BIN: bunDirectory },
     }),
   );
 });
@@ -77,9 +76,8 @@ test("refuses a newline-suffixed CodeGraph command link", () => {
   mkdirSync(localBin, { recursive: true });
   symlinkSync(unexpected, destination);
 
-  const result = runMake(fixture, [destination], {
+  const result = runCommandLinkMake(fixture, [destination], {
     repository: project,
-    variables: { BREW_BIN: bunDirectory },
   });
 
   expect(result.exitCode).not.toBe(0);
@@ -94,17 +92,15 @@ test("removes only the retired Claude developer command link", () => {
   symlinkSync(join(project, "tooling", "claude-developer"), destination);
 
   expectSuccess(
-    runMake(fixture, ["claude-developer-link-cleanup"], {
+    runCommandLinkMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
-      variables: { BREW_BIN: bunDirectory },
     }),
   );
 
   expect(pathExists(destination)).toBeFalse();
   expectSuccess(
-    runMake(fixture, ["claude-developer-link-cleanup"], {
+    runCommandLinkMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
-      variables: { BREW_BIN: bunDirectory },
     }),
   );
 });
@@ -117,9 +113,9 @@ test("removes the retired link from a destination containing an apostrophe", () 
   symlinkSync(join(project, "tooling", "claude-developer"), destination);
 
   expectSuccess(
-    runMake(fixture, ["claude-developer-link-cleanup"], {
+    runCommandLinkMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
-      variables: { BREW_BIN: bunDirectory, LOCAL_BIN: localBin },
+      variables: { LOCAL_BIN: localBin },
     }),
   );
 
@@ -135,9 +131,8 @@ test("preserves a newline-suffixed link during retired command cleanup", () => {
   symlinkSync(unexpected, destination);
 
   expectSuccess(
-    runMake(fixture, ["claude-developer-link-cleanup"], {
+    runCommandLinkMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
-      variables: { BREW_BIN: bunDirectory },
     }),
   );
   expect(linkTarget(destination)).toBe(unexpected);
@@ -151,9 +146,8 @@ test("preserves a regular file during retired command cleanup", () => {
   writeFileSync(destination, "keep\n");
 
   expectSuccess(
-    runMake(fixture, ["claude-developer-link-cleanup"], {
+    runCommandLinkMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
-      variables: { BREW_BIN: bunDirectory },
     }),
   );
 
@@ -166,9 +160,8 @@ test("preserves a directory during retired command cleanup", () => {
   mkdirSync(destination, { recursive: true });
 
   expectSuccess(
-    runMake(fixture, ["claude-developer-link-cleanup"], {
+    runCommandLinkMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
-      variables: { BREW_BIN: bunDirectory },
     }),
   );
 
@@ -177,10 +170,9 @@ test("preserves a directory during retired command cleanup", () => {
 
 test("runs retired command cleanup from the Codex aggregate", () => {
   const fixture = createDeploymentFixture("claude-developer-wiring");
-  const result = runMake(fixture, ["codex"], {
+  const result = runCommandLinkMake(fixture, ["codex"], {
     dryRun: true,
     repository: project,
-    variables: { BREW_BIN: bunDirectory },
   });
 
   expectSuccess(result);
@@ -188,3 +180,26 @@ test("runs retired command cleanup from the Codex aggregate", () => {
     join(fixture.home, ".local", "bin", "claude-developer"),
   );
 });
+
+function runCommandLinkMake(
+  fixture: CommandLinkFixture,
+  targets: readonly string[],
+  options: Readonly<{
+    dryRun?: boolean;
+    repository?: string;
+    variables?: Readonly<Record<string, string>>;
+  }> = {},
+): CommandLinkResult {
+  const bun = join(fixture.bin, "bun");
+  const brew = join(fixture.bin, "brew");
+  if (!pathExists(bun)) {
+    symlinkSync(requireCommand("bun"), bun);
+  }
+  if (!pathExists(brew)) {
+    symlinkSync(requireCommand("true"), brew);
+  }
+  return runMake(fixture, targets, {
+    ...options,
+    variables: { BREW_BIN: fixture.bin, ...options.variables },
+  });
+}

--- a/tooling/deployment-command-links.test.ts
+++ b/tooling/deployment-command-links.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, expect, test } from "bun:test";
+import {
+  cleanupDeploymentFixtures,
+  createDeploymentFixture,
+  expectSuccess,
+  linkTarget,
+  pathExists,
+  project,
+  runMake,
+} from "./deployment-test-support.ts";
+import { dirname, join } from "node:path";
+import { mkdirSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+
+afterEach(cleanupDeploymentFixtures);
+
+const FUTURE_MTIME_OFFSET_MILLISECONDS = 60_000;
+
+test("migrates the former CodeGraph measurement command link", () => {
+  const fixture = createDeploymentFixture("codegraph-command-migration");
+  const { repository } = fixture;
+  const localBin = join(fixture.home, ".local", "bin");
+  const destination = join(localBin, "codegraph-repository-size");
+  const retiredTarget = join(
+    repository,
+    "harness",
+    "skills",
+    "codegraph",
+    "scripts",
+    "measure_repository.sh",
+  );
+  const currentTarget = join(
+    repository,
+    "tooling",
+    "codegraph-repository-size",
+  );
+  const cleanupCommand = join(repository, "tooling", "retire-command-link");
+  mkdirSync(join(repository, "tooling"), { recursive: true });
+  mkdirSync(dirname(retiredTarget), { recursive: true });
+  mkdirSync(localBin, { recursive: true });
+  writeFileSync(currentTarget, "current\n");
+  writeFileSync(retiredTarget, "retired\n");
+  symlinkSync(join(project, "tooling", "retire-command-link"), cleanupCommand);
+  const future = new Date(Date.now() + FUTURE_MTIME_OFFSET_MILLISECONDS);
+  utimesSync(retiredTarget, future, future);
+  symlinkSync(retiredTarget, destination);
+
+  expectSuccess(runMake(fixture, [destination], { repository }));
+
+  expect(linkTarget(destination)).toBe(currentTarget);
+  expectSuccess(runMake(fixture, [destination], { repository }));
+});
+
+test("refuses a newline-suffixed CodeGraph command link", () => {
+  const fixture = createDeploymentFixture("codegraph-command-unknown");
+  const localBin = join(fixture.home, ".local", "bin");
+  const destination = join(localBin, "codegraph-repository-size");
+  const unexpected = `${join(
+    project,
+    "harness",
+    "skills",
+    "codegraph",
+    "scripts",
+    "measure_repository.sh",
+  )}\n`;
+  mkdirSync(localBin, { recursive: true });
+  symlinkSync(unexpected, destination);
+
+  const result = runMake(fixture, [destination], { repository: project });
+
+  expect(result.exitCode).not.toBe(0);
+  expect(linkTarget(destination)).toBe(unexpected);
+});
+
+test("removes only the retired Claude developer command link", () => {
+  const fixture = createDeploymentFixture("claude-developer-retired");
+  const localBin = join(fixture.home, ".local", "bin");
+  const destination = join(localBin, "claude-developer");
+  mkdirSync(localBin, { recursive: true });
+  symlinkSync(join(project, "tooling", "claude-developer"), destination);
+
+  expectSuccess(
+    runMake(fixture, ["claude-developer-link-cleanup"], {
+      repository: project,
+    }),
+  );
+
+  expect(pathExists(destination)).toBeFalse();
+  expectSuccess(
+    runMake(fixture, ["claude-developer-link-cleanup"], {
+      repository: project,
+    }),
+  );
+});
+
+test("removes the retired link from a destination containing an apostrophe", () => {
+  const fixture = createDeploymentFixture("claude-developer-apostrophe");
+  const localBin = join(fixture.home, "local'bin");
+  const destination = join(localBin, "claude-developer");
+  mkdirSync(localBin, { recursive: true });
+  symlinkSync(join(project, "tooling", "claude-developer"), destination);
+
+  expectSuccess(
+    runMake(fixture, ["claude-developer-link-cleanup"], {
+      repository: project,
+      variables: { LOCAL_BIN: localBin },
+    }),
+  );
+
+  expect(pathExists(destination)).toBeFalse();
+});
+
+test("preserves a newline-suffixed link during retired command cleanup", () => {
+  const fixture = createDeploymentFixture("claude-developer-preserved");
+  const localBin = join(fixture.home, ".local", "bin");
+  const destination = join(localBin, "claude-developer");
+  const unexpected = `${join(project, "tooling", "claude-developer")}\n`;
+  mkdirSync(localBin, { recursive: true });
+  symlinkSync(unexpected, destination);
+
+  expectSuccess(
+    runMake(fixture, ["claude-developer-link-cleanup"], {
+      repository: project,
+    }),
+  );
+  expect(linkTarget(destination)).toBe(unexpected);
+});
+
+test("preserves a regular file during retired command cleanup", () => {
+  const fixture = createDeploymentFixture("claude-developer-file");
+  const localBin = join(fixture.home, ".local", "bin");
+  const destination = join(localBin, "claude-developer");
+  mkdirSync(localBin, { recursive: true });
+  writeFileSync(destination, "keep\n");
+
+  expectSuccess(
+    runMake(fixture, ["claude-developer-link-cleanup"], {
+      repository: project,
+    }),
+  );
+
+  expect(pathExists(destination)).toBeTrue();
+});
+
+test("preserves a directory during retired command cleanup", () => {
+  const fixture = createDeploymentFixture("claude-developer-directory");
+  const destination = join(fixture.home, ".local", "bin", "claude-developer");
+  mkdirSync(destination, { recursive: true });
+
+  expectSuccess(
+    runMake(fixture, ["claude-developer-link-cleanup"], {
+      repository: project,
+    }),
+  );
+
+  expect(pathExists(destination)).toBeTrue();
+});
+
+test("runs retired command cleanup from the Codex aggregate", () => {
+  const fixture = createDeploymentFixture("claude-developer-wiring");
+  const result = runMake(fixture, ["codex"], {
+    dryRun: true,
+    repository: project,
+  });
+
+  expectSuccess(result);
+  expect(result.stdout).toContain(
+    join(fixture.home, ".local", "bin", "claude-developer"),
+  );
+});

--- a/tooling/deployment-command-links.test.ts
+++ b/tooling/deployment-command-links.test.ts
@@ -6,6 +6,7 @@ import {
   linkTarget,
   pathExists,
   project,
+  requireCommand,
   runMake,
 } from "./deployment-test-support.ts";
 import { dirname, join } from "node:path";
@@ -14,6 +15,7 @@ import { mkdirSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 afterEach(cleanupDeploymentFixtures);
 
 const FUTURE_MTIME_OFFSET_MILLISECONDS = 60_000;
+const bunDirectory = dirname(requireCommand("bun"));
 
 test("migrates the former CodeGraph measurement command link", () => {
   const fixture = createDeploymentFixture("codegraph-command-migration");
@@ -44,10 +46,20 @@ test("migrates the former CodeGraph measurement command link", () => {
   utimesSync(retiredTarget, future, future);
   symlinkSync(retiredTarget, destination);
 
-  expectSuccess(runMake(fixture, [destination], { repository }));
+  expectSuccess(
+    runMake(fixture, [destination], {
+      repository,
+      variables: { BREW_BIN: bunDirectory },
+    }),
+  );
 
   expect(linkTarget(destination)).toBe(currentTarget);
-  expectSuccess(runMake(fixture, [destination], { repository }));
+  expectSuccess(
+    runMake(fixture, [destination], {
+      repository,
+      variables: { BREW_BIN: bunDirectory },
+    }),
+  );
 });
 
 test("refuses a newline-suffixed CodeGraph command link", () => {
@@ -65,7 +77,10 @@ test("refuses a newline-suffixed CodeGraph command link", () => {
   mkdirSync(localBin, { recursive: true });
   symlinkSync(unexpected, destination);
 
-  const result = runMake(fixture, [destination], { repository: project });
+  const result = runMake(fixture, [destination], {
+    repository: project,
+    variables: { BREW_BIN: bunDirectory },
+  });
 
   expect(result.exitCode).not.toBe(0);
   expect(linkTarget(destination)).toBe(unexpected);
@@ -81,6 +96,7 @@ test("removes only the retired Claude developer command link", () => {
   expectSuccess(
     runMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
+      variables: { BREW_BIN: bunDirectory },
     }),
   );
 
@@ -88,6 +104,7 @@ test("removes only the retired Claude developer command link", () => {
   expectSuccess(
     runMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
+      variables: { BREW_BIN: bunDirectory },
     }),
   );
 });
@@ -102,7 +119,7 @@ test("removes the retired link from a destination containing an apostrophe", () 
   expectSuccess(
     runMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
-      variables: { LOCAL_BIN: localBin },
+      variables: { BREW_BIN: bunDirectory, LOCAL_BIN: localBin },
     }),
   );
 
@@ -120,6 +137,7 @@ test("preserves a newline-suffixed link during retired command cleanup", () => {
   expectSuccess(
     runMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
+      variables: { BREW_BIN: bunDirectory },
     }),
   );
   expect(linkTarget(destination)).toBe(unexpected);
@@ -135,6 +153,7 @@ test("preserves a regular file during retired command cleanup", () => {
   expectSuccess(
     runMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
+      variables: { BREW_BIN: bunDirectory },
     }),
   );
 
@@ -149,6 +168,7 @@ test("preserves a directory during retired command cleanup", () => {
   expectSuccess(
     runMake(fixture, ["claude-developer-link-cleanup"], {
       repository: project,
+      variables: { BREW_BIN: bunDirectory },
     }),
   );
 
@@ -160,6 +180,7 @@ test("runs retired command cleanup from the Codex aggregate", () => {
   const result = runMake(fixture, ["codex"], {
     dryRun: true,
     repository: project,
+    variables: { BREW_BIN: bunDirectory },
   });
 
   expectSuccess(result);

--- a/tooling/retire-command-link
+++ b/tooling/retire-command-link
@@ -1,0 +1,5 @@
+#!/usr/bin/env bun
+
+import { main } from "./retire-command-link.ts";
+
+main(process.argv.slice(2));

--- a/tooling/retire-command-link.test.ts
+++ b/tooling/retire-command-link.test.ts
@@ -1,0 +1,132 @@
+import {
+  type CommandLinkFileSystem,
+  retireCommandLink,
+} from "./retire-command-link.ts";
+import { afterEach, expect, test } from "bun:test";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  rmdirSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const roots: string[] = [];
+const QUARANTINED_READ = 2;
+const fileSystem: CommandLinkFileSystem = {
+  lstat: lstatSync,
+  makeTemporaryDirectory: mkdtempSync,
+  readlink: readlinkSync,
+  removeDirectory: rmdirSync,
+  rename: renameSync,
+  symlink: symlinkSync,
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("rejects a relative command-line path", () => {
+  const entryPoint = join(import.meta.dir, "retire-command-link");
+  const result = Bun.spawnSync([entryPoint, "relative", "/destination"], {
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr.toString()).toContain("paths must be absolute");
+});
+
+test("restores an unexpected link substituted during quarantine", () => {
+  const root = createRoot();
+  const destination = join(root, "command");
+  const expected = join(root, "expected");
+  const unexpected = join(root, "unexpected");
+  symlinkSync(expected, destination);
+  let raced = false;
+  const racingFileSystem: CommandLinkFileSystem = {
+    ...fileSystem,
+    rename(source, target) {
+      if (!raced) {
+        raced = true;
+        unlinkSync(source);
+        symlinkSync(unexpected, source);
+      }
+      renameSync(source, target);
+    },
+  };
+
+  expect(() =>
+    retireCommandLink(expected, destination, racingFileSystem),
+  ).toThrow("changed during retirement and was restored");
+  expect(readlinkSync(destination)).toBe(unexpected);
+  const quarantine = readdirSync(root).find((entry) =>
+    entry.startsWith(".retire-command-link-"),
+  );
+  expect(quarantine).toBeDefined();
+  expect(readlinkSync(join(root, quarantine ?? "", "entry"))).toBe(unexpected);
+});
+
+test("does not delete an entry substituted after quarantine validation", () => {
+  const root = createRoot();
+  const destination = join(root, "command");
+  const expected = join(root, "expected");
+  symlinkSync(expected, destination);
+  let readCount = 0;
+  const racingFileSystem: CommandLinkFileSystem = {
+    ...fileSystem,
+    readlink(path) {
+      const target = readlinkSync(path);
+      readCount += 1;
+      if (readCount === QUARANTINED_READ) {
+        unlinkSync(path);
+        writeFileSync(path, "valuable-data");
+      }
+      return target;
+    },
+  };
+
+  expect(retireCommandLink(expected, destination, racingFileSystem)).toBe(
+    "removed",
+  );
+  const quarantine = readdirSync(root).find((entry) =>
+    entry.startsWith(".retire-command-link-"),
+  );
+  expect(quarantine).toBeDefined();
+  expect(readFileSync(join(root, quarantine ?? "", "entry"), "utf8")).toBe(
+    "valuable-data",
+  );
+});
+
+test("surfaces destination probe failures", () => {
+  const root = createRoot();
+  const destination = join(root, "command");
+  const failingFileSystem: CommandLinkFileSystem = {
+    ...fileSystem,
+    lstat() {
+      throw new Error("probe failed");
+    },
+  };
+
+  expect(() =>
+    retireCommandLink(join(root, "expected"), destination, failingFileSystem),
+  ).toThrow(`could not inspect ${destination}`);
+});
+
+function createRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "retire-command-link-"));
+  roots.push(root);
+  mkdirSync(root, { recursive: true });
+  return root;
+}

--- a/tooling/retire-command-link.ts
+++ b/tooling/retire-command-link.ts
@@ -1,0 +1,186 @@
+import {
+  type Stats,
+  lstatSync,
+  mkdtempSync,
+  readlinkSync,
+  renameSync,
+  rmdirSync,
+  symlinkSync,
+} from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
+import { z } from "zod";
+
+type CommandLinkFileSystem = Readonly<{
+  lstat: (path: string) => Stats;
+  makeTemporaryDirectory: (prefix: string) => string;
+  readlink: (path: string) => string;
+  rename: (source: string, destination: string) => void;
+  removeDirectory: (path: string) => void;
+  symlink: (target: string, path: string) => void;
+}>;
+
+const absolutePathSchema = z
+  .string()
+  .min(1)
+  .refine(isAbsolute, "paths must be absolute");
+const argumentsSchema = z.union([
+  z.tuple([absolutePathSchema, absolutePathSchema]),
+  z.tuple([absolutePathSchema, absolutePathSchema, absolutePathSchema]),
+]);
+const RETIRE_ARGUMENT_COUNT = 2;
+const systemFileSystem: CommandLinkFileSystem = {
+  lstat: lstatSync,
+  makeTemporaryDirectory: mkdtempSync,
+  readlink: readlinkSync,
+  removeDirectory: rmdirSync,
+  rename: renameSync,
+  symlink: symlinkSync,
+};
+
+function retireCommandLink(
+  expectedTarget: string,
+  destination: string,
+  fileSystem: CommandLinkFileSystem = systemFileSystem,
+): "absent" | "preserved" | "removed" {
+  const metadata = inspectDestination(destination, fileSystem);
+  if (metadata === undefined) {
+    return "absent";
+  }
+  if (!metadata.isSymbolicLink()) {
+    return "preserved";
+  }
+  const currentTarget = fileSystem.readlink(destination);
+  if (currentTarget !== expectedTarget) {
+    return "preserved";
+  }
+
+  const quarantine = fileSystem.makeTemporaryDirectory(
+    join(dirname(destination), ".retire-command-link-"),
+  );
+  const quarantined = join(quarantine, "entry");
+  try {
+    fileSystem.rename(destination, quarantined);
+  } catch (error) {
+    fileSystem.removeDirectory(quarantine);
+    throw new Error(`could not quarantine ${destination}`, { cause: error });
+  }
+
+  const quarantinedMetadata = fileSystem.lstat(quarantined);
+  if (
+    quarantinedMetadata.isSymbolicLink() &&
+    fileSystem.readlink(quarantined) === expectedTarget
+  ) {
+    return "removed";
+  }
+
+  restoreUnexpectedEntry({ destination, quarantined }, fileSystem);
+  throw new Error(`${destination} changed during retirement and was restored`);
+}
+
+function ensureCommandLink(
+  expectedTarget: string,
+  destination: string,
+  fileSystem: CommandLinkFileSystem = systemFileSystem,
+): "created" | "current" {
+  const metadata = inspectDestination(destination, fileSystem);
+  if (metadata === undefined) {
+    try {
+      fileSystem.symlink(expectedTarget, destination);
+      return "created";
+    } catch (error) {
+      if (hasExpectedCommandLink(expectedTarget, destination, fileSystem)) {
+        return "current";
+      }
+      throw new Error(`could not create ${destination}`, { cause: error });
+    }
+  }
+  if (hasExpectedCommandLink(expectedTarget, destination, fileSystem)) {
+    return "current";
+  }
+  throw new Error(`${destination} is not the expected symbolic link`);
+}
+
+function main(arguments_: readonly string[]): void {
+  try {
+    const parsedArguments = argumentsSchema.parse(arguments_);
+    if (parsedArguments.length === RETIRE_ARGUMENT_COUNT) {
+      retireCommandLink(...parsedArguments);
+      return;
+    }
+    const [retiredTarget, expectedTarget, destination] = parsedArguments;
+    retireCommandLink(retiredTarget, destination);
+    ensureCommandLink(expectedTarget, destination);
+  } catch (error) {
+    process.stderr.write(`retire-command-link: ${errorMessage(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+function hasExpectedCommandLink(
+  expectedTarget: string,
+  destination: string,
+  fileSystem: CommandLinkFileSystem,
+): boolean {
+  const metadata = inspectDestination(destination, fileSystem);
+  return (
+    metadata?.isSymbolicLink() === true &&
+    fileSystem.readlink(destination) === expectedTarget
+  );
+}
+
+function inspectDestination(
+  destination: string,
+  fileSystem: CommandLinkFileSystem,
+): Stats | undefined {
+  try {
+    return fileSystem.lstat(destination);
+  } catch (error) {
+    if (isMissing(error)) {
+      return undefined;
+    }
+    throw new Error(`could not inspect ${destination}`, { cause: error });
+  }
+}
+
+function restoreUnexpectedEntry(
+  paths: Readonly<{
+    destination: string;
+    quarantined: string;
+  }>,
+  fileSystem: CommandLinkFileSystem,
+): void {
+  const { destination, quarantined } = paths;
+  const metadata = fileSystem.lstat(quarantined);
+  if (!metadata.isSymbolicLink()) {
+    throw new Error(
+      `${destination} changed during retirement; recover it from ${quarantined}`,
+    );
+  }
+  const target = fileSystem.readlink(quarantined);
+  try {
+    fileSystem.symlink(target, destination);
+  } catch (error) {
+    throw new Error(
+      `${destination} changed during retirement; recover it from ${quarantined}`,
+      { cause: error },
+    );
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    return z.prettifyError(error);
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export {
+  type CommandLinkFileSystem,
+  ensureCommandLink,
+  main,
+  retireCommandLink,
+};


### PR DESCRIPTION
## Outcome

Retire only the known obsolete Claude developer and CodeGraph command links, then install the current CodeGraph command without overwriting unrelated entries.

## Evidence

- Bun test suite: 265 passed, 4 skipped, 0 failed on macOS arm64
- Deployment suite: 29 passed, 0 failed on macOS arm64
- TypeScript format: 96 files checked
- Oxlint: 0 errors
- TypeScript typecheck: 0 errors
- Adversarial pass: newer legacy targets and apostrophes in paths covered

## Limits

Linux behavior is covered by CI but was not reproduced locally. Real Docker, CodeGraph network, and real Claude/Codex CLI integration tests remain explicitly skipped.