### PR TITLE
fix(install): reconcile software sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -678,6 +678,7 @@ specsmd:
 .PHONY: vibe-island
 vibe-island: brew ${BREW_CASKROOM}/vibe-island
 ${BREW_CASKROOM}/vibe-island:
+	brew update
 	brew install --cask --adopt vibe-island
 
 ################################################################################

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BREW_BIN:=$(shell if [ "$(shell uname -p)" = "arm" ]; then echo "/opt/homebrew/bin"; else echo "/usr/local/bin"; fi)
 BREW_GNU_BIN:=$(shell if [ "$(shell uname -p)" = "arm" ]; then echo "/opt/homebrew/opt"; else echo "/usr/local/opt"; fi)
+BREW_CASKROOM:=$(shell if [ "$(shell uname -p)" = "arm" ]; then echo "/opt/homebrew/Caskroom"; else echo "/usr/local/Caskroom"; fi)
 VOLTA_BIN:=$(HOME)/.volta/bin
 CODEGRAPH_GLOBAL_IGNORE?=$(HOME)/.config/git/ignore
 PNPM_BIN:=$(HOME)/Library/pnpm
@@ -357,9 +358,9 @@ ${APP_BIN}/1Password.app:
 	brew install --cask 1password
 
 .PHONY: cursor
-cursor: ~/.local/bin/cursor-agent ~/.cursor/skills/claude-developer ~/.cursor/skills/codegraph ~/.cursor/skills/enforcement-code ~/.cursor/skills/harness-reflection ~/.cursor/skills/issue-creation ~/.cursor/skills/linear-issue-spec ~/.cursor/skills/linear-start ~/.cursor/skills/linear-sync ~/.cursor/skills/linear-workflow ~/.cursor/skills/obsidian-retrieval ~/.cursor/skills/pr-fix ~/.cursor/skills/pr-verdict ~/.cursor/skills/requirements-clarification ~/.cursor/skills/skill-manager ~/.cursor/skills/workflow-automation cursor-hooks
-~/.local/bin/cursor-agent:
-	curl https://cursor.com/install -fsS | bash
+cursor: brew ${BREW_BIN}/cursor-agent ~/.cursor/skills/claude-developer ~/.cursor/skills/codegraph ~/.cursor/skills/enforcement-code ~/.cursor/skills/harness-reflection ~/.cursor/skills/issue-creation ~/.cursor/skills/linear-issue-spec ~/.cursor/skills/linear-start ~/.cursor/skills/linear-sync ~/.cursor/skills/linear-workflow ~/.cursor/skills/obsidian-retrieval ~/.cursor/skills/pr-fix ~/.cursor/skills/pr-verdict ~/.cursor/skills/requirements-clarification ~/.cursor/skills/skill-manager ~/.cursor/skills/workflow-automation cursor-hooks
+${BREW_BIN}/cursor-agent:
+	brew install --cask cursor-cli
 ~/.cursor/skills:
 	mkdir -p $@
 ~/.cursor/skills/claude-developer: ${DOTFILES_PATH}/harness/skills/claude-developer | ~/.cursor/skills
@@ -675,13 +676,9 @@ specsmd:
 	npx specsmd@latest install
 
 .PHONY: vibe-island
-vibe-island: /Applications/Vibe\ Island.app
-/Applications/Vibe\ Island.app:
-	curl -L https://dl.vibeisland.app/VibeIsland.dmg -o /tmp/VibeIsland.dmg
-	hdiutil attach /tmp/VibeIsland.dmg -nobrowse -quiet -mountpoint /tmp/VibeIsland-mount
-	cp -R /tmp/VibeIsland-mount/Vibe\ Island.app /Applications/
-	hdiutil detach /tmp/VibeIsland-mount -quiet
-	rm -f /tmp/VibeIsland.dmg
+vibe-island: brew ${BREW_CASKROOM}/vibe-island
+${BREW_CASKROOM}/vibe-island:
+	brew install --cask --adopt vibe-island
 
 ################################################################################
 # End of work section
@@ -825,10 +822,9 @@ font-iosevka-nerd-font: ~/Library/Fonts/IosevkaNerdFont-Regular.ttf
 	brew install font-iosevka-nerd-font
 
 .PHONY: fzf
-fzf: ~/.fzf
-~/.fzf:
-	git clone https://github.com/junegunn/fzf.git ~/.fzf
-	~/.fzf/install --no-update-rc --no-fish
+fzf: brew ${BREW_BIN}/fzf
+${BREW_BIN}/fzf:
+	brew install fzf
 
 .PHONY: ripgrep
 ripgrep: brew ${BREW_BIN}/rg

--- a/docs/adr/002-homebrew-source-unique.md
+++ b/docs/adr/002-homebrew-source-unique.md
@@ -12,12 +12,42 @@ impossible à automatiser et l'installation impossible à rejouer en CI.
 
 ## Décision
 
-Tout paquet passe par Homebrew (formule ou cask), et par `mas` pour ce que
-seul l'App Store distribue. Les services sont pilotés par `brew services`. Les
-applications payantes de l'App Store sont exclues par défaut via
-`SKIP_PAID_APPS`, ce qui permet à la CI d'exécuter l'installation complète.
-`HOMEBREW_NO_ASK` supprime les invites interactives, et les taps sont
+Par défaut, tout paquet passe par Homebrew (formule ou cask), et par `mas` pour
+ce que seul l'App Store distribue. Les sources non-Homebrew du graphe pris en
+charge sont exhaustivement déclarées ci-dessous. Les services sont pilotés par
+`brew services`. Les applications payantes de l'App Store sont exclues par
+défaut via `SKIP_PAID_APPS`, ce qui permet à la CI d'exécuter l'installation
+complète. `HOMEBREW_NO_ASK` supprime les invites interactives, et les taps sont
 approuvés (`brew trust`) avant toute mise à jour.
+
+Les trois paquets réconciliés suivent la version stable publiée par Homebrew ;
+leurs définitions actuelles fixent un checksum qui protège l'intégrité du
+téléchargement. `tooling/upgrade` met à jour les formules et les casks, y
+compris ceux qui se déclarent auto-mis à jour, et les sentinelles Homebrew
+rendent l'installation rejouable. `--adopt` n'est admis que pour reprendre un
+artefact existant identique à celui du cask ; une divergence est refusée au
+lieu d'être écrasée.
+
+Les sources non-Homebrew admises ont le contrat suivant :
+
+| Source | Version | Intégrité | Mise à jour | Rejeu |
+| --- | --- | --- | --- | --- |
+| Amorçage Homebrew | Installateur `HEAD` officiel | Script servi par Homebrew en HTTPS | Mise à jour propre à Homebrew après installation | Exécuté seulement lorsque le binaire Homebrew est absent |
+| Paquets Node via Volta ou npm ([ADR-016](016-volta-gestionnaire-node.md), [ADR-017](017-npm-pour-paquets-globaux.md)) | Coordonnée déclarée par la cible, avec canal explicite lorsqu'il existe | Registre npm et vérification de la charge utile par le gestionnaire | `volta install node` et `npm update -g` par `tooling/upgrade` | Shims ou binaires sentinelles ; une cible déjà satisfaite n'installe pas une seconde copie |
+| Plugins Fish et tmux | Révision obtenue par Fisher ou Git lors de la première installation | Transport GitHub en HTTPS et objets Git | Mise à jour explicite par leur gestionnaire ; absente de `tooling/upgrade` | Le fichier Fisher ou le checkout TPM sert de sentinelle et conserve la révision locale |
+| Claude Code | Canal éditeur `latest` résolu à l'installation | Installateur et charge utile servis par l'éditeur en HTTPS | `claude update` par `tooling/upgrade` | La sentinelle du binaire évite une seconde installation ; la mise à jour converge séparément vers le dernier `latest` disponible |
+| Images Docker des MCP | Référence déclarée dans le `Makefile` ou le fichier Compose, tag compris | Manifeste et couches vérifiés par leur digest lors du transfert depuis le registre | `docker pull` ou `docker compose pull` explicite ; `make all` ne télécharge qu'une image absente | Une référence déjà présente est réutilisée ; un tag flottant conserve donc le digest local jusqu'à la mise à jour explicite |
+| Thèmes Bat | Branche par défaut Catppuccin lors de la première installation | Fichiers servis par GitHub en HTTPS | Changement explicite de la source ou suppression de la sentinelle | Les fichiers de thème servent de sentinelles et conservent leur contenu local |
+| Dictionnaires Hunspell | Commit LibreOffice et SHA-256 déclarés dans le `Makefile` | SHA-256 vérifié avant publication atomique | Changement explicite du commit et du checksum | Une destination identique est conservée ; une divergence est refusée |
+
+`tooling/check-software-sources.ts` matérialise les commandes émises par le
+graphe `all` en mode à sec et refuse toute référence distante ou tout
+gestionnaire visible absent de l'inventaire déclaré. Il contrôle aussi les
+images exactes des fichiers Compose atteints et les commandes `$(shell ...)`
+sans les exécuter. Une impossibilité de produire le graphe, une configuration
+Compose invalide ou l'absence du canal Homebrew fait échouer le contrôle. Les
+sources internes à un outil local appelé par le `Makefile` restent sous le
+contrat et les tests propres de cet outil, hors de cette barrière.
 
 ## Conséquences
 
@@ -25,8 +55,8 @@ approuvés (`brew trust`) avant toute mise à jour.
   ([ADR-004](004-script-upgrade-unique.md)).
 - Dépendance forte aux dépréciations Homebrew : plusieurs commits ne font que
   suivre des taps ou des formules retirés en amont.
-- Quelques outils échappent à la règle (installateur natif de Claude Code,
-  images Docker des MCP) et constituent des exceptions assumées.
+- Les exceptions ne bénéficient pas du contrat de version et de mise à jour
+  Homebrew ; leur contrat plus faible est explicite et contrôlé séparément.
 
 ## Alternatives écartées
 

--- a/docs/adr/002-homebrew-source-unique.md
+++ b/docs/adr/002-homebrew-source-unique.md
@@ -12,42 +12,15 @@ impossible à automatiser et l'installation impossible à rejouer en CI.
 
 ## Décision
 
-Par défaut, tout paquet passe par Homebrew (formule ou cask), et par `mas` pour
-ce que seul l'App Store distribue. Les sources non-Homebrew du graphe pris en
-charge sont exhaustivement déclarées ci-dessous. Les services sont pilotés par
-`brew services`. Les applications payantes de l'App Store sont exclues par
-défaut via `SKIP_PAID_APPS`, ce qui permet à la CI d'exécuter l'installation
-complète. `HOMEBREW_NO_ASK` supprime les invites interactives, et les taps sont
-approuvés (`brew trust`) avant toute mise à jour.
+Tout paquet passe par Homebrew (formule ou cask), et par `mas` pour ce que seul
+l'App Store distribue. Une autre source exige une exception explicite et un
+contrat de version, d'intégrité, de mise à jour et de rejeu. L'inventaire de ces
+exceptions est un document opérationnel distinct.
 
-Les trois paquets réconciliés suivent la version stable publiée par Homebrew ;
-leurs définitions actuelles fixent un checksum qui protège l'intégrité du
-téléchargement. `tooling/upgrade` met à jour les formules et les casks, y
-compris ceux qui se déclarent auto-mis à jour, et les sentinelles Homebrew
-rendent l'installation rejouable. `--adopt` n'est admis que pour reprendre un
-artefact existant identique à celui du cask ; une divergence est refusée au
-lieu d'être écrasée.
-
-Les sources non-Homebrew admises ont le contrat suivant :
-
-| Source | Version | Intégrité | Mise à jour | Rejeu |
-| --- | --- | --- | --- | --- |
-| Amorçage Homebrew | Installateur `HEAD` officiel | Script servi par Homebrew en HTTPS | Mise à jour propre à Homebrew après installation | Exécuté seulement lorsque le binaire Homebrew est absent |
-| Paquets Node via Volta ou npm ([ADR-016](016-volta-gestionnaire-node.md), [ADR-017](017-npm-pour-paquets-globaux.md)) | Coordonnée déclarée par la cible, avec canal explicite lorsqu'il existe | Registre npm et vérification de la charge utile par le gestionnaire | `volta install node` et `npm update -g` par `tooling/upgrade` | Shims ou binaires sentinelles ; une cible déjà satisfaite n'installe pas une seconde copie |
-| Plugins Fish et tmux | Révision obtenue par Fisher ou Git lors de la première installation | Transport GitHub en HTTPS et objets Git | Mise à jour explicite par leur gestionnaire ; absente de `tooling/upgrade` | Le fichier Fisher ou le checkout TPM sert de sentinelle et conserve la révision locale |
-| Claude Code | Canal éditeur `latest` résolu à l'installation | Installateur et charge utile servis par l'éditeur en HTTPS | `claude update` par `tooling/upgrade` | La sentinelle du binaire évite une seconde installation ; la mise à jour converge séparément vers le dernier `latest` disponible |
-| Images Docker des MCP | Référence déclarée dans le `Makefile` ou le fichier Compose, tag compris | Manifeste et couches vérifiés par leur digest lors du transfert depuis le registre | `docker pull` ou `docker compose pull` explicite ; `make all` ne télécharge qu'une image absente | Une référence déjà présente est réutilisée ; un tag flottant conserve donc le digest local jusqu'à la mise à jour explicite |
-| Thèmes Bat | Branche par défaut Catppuccin lors de la première installation | Fichiers servis par GitHub en HTTPS | Changement explicite de la source ou suppression de la sentinelle | Les fichiers de thème servent de sentinelles et conservent leur contenu local |
-| Dictionnaires Hunspell | Commit LibreOffice et SHA-256 déclarés dans le `Makefile` | SHA-256 vérifié avant publication atomique | Changement explicite du commit et du checksum | Une destination identique est conservée ; une divergence est refusée |
-
-`tooling/check-software-sources.ts` matérialise les commandes émises par le
-graphe `all` en mode à sec et refuse toute référence distante ou tout
-gestionnaire visible absent de l'inventaire déclaré. Il contrôle aussi les
-images exactes des fichiers Compose atteints et les commandes `$(shell ...)`
-sans les exécuter. Une impossibilité de produire le graphe, une configuration
-Compose invalide ou l'absence du canal Homebrew fait échouer le contrôle. Les
-sources internes à un outil local appelé par le `Makefile` restent sous le
-contrat et les tests propres de cet outil, hors de cette barrière.
+Le graphe `make all` est contrôlé automatiquement : toute source absente de
+l'inventaire est refusée. Les services sont pilotés par `brew services` et les
+applications payantes de l'App Store restent exclues par défaut via
+`SKIP_PAID_APPS` afin que la CI puisse rejouer l'installation complète.
 
 ## Conséquences
 

--- a/docs/software-source-exceptions.md
+++ b/docs/software-source-exceptions.md
@@ -1,0 +1,19 @@
+# Exceptions aux sources Homebrew
+
+Ce document est l'inventaire opérationnel requis par
+[ADR-002](adr/002-homebrew-source-unique.md). L'inventaire exécutable est dans
+`tooling/check-software-sources.ts` ; toute nouvelle source doit modifier les
+deux dans le même changement.
+
+| Source | Version | Intégrité | Mise à jour | Rejeu |
+| --- | --- | --- | --- | --- |
+| Amorçage Homebrew | Installateur officiel `HEAD` | HTTPS Homebrew | Gérée par Homebrew après installation | Seulement si `brew` est absent |
+| Paquets Node via Volta ou npm | Coordonnée de la cible | Vérification du registre par le gestionnaire | `tooling/upgrade` | Sentinelle du shim ou du binaire |
+| Plugins Fisher et TPM | Révision distante à l'installation | Objets GitHub en HTTPS | Commande explicite du gestionnaire | Configuration Fisher ou checkout TPM |
+| Claude Code | Canal éditeur `latest` | HTTPS éditeur | `claude update` | Sentinelle du binaire |
+| Images Docker des MCP | Image et tag déclarés | Manifeste et couches du registre | `docker pull` ou `docker compose pull` | Image locale réutilisée |
+| Thèmes Bat | Branche Catppuccin par défaut | HTTPS GitHub | Changement explicite de source | Fichier de thème existant |
+| Dictionnaires Hunspell | Commit LibreOffice déclaré | SHA-256 déclaré | Changement du commit et du checksum | Destination identique conservée, divergence refusée |
+
+Les sources internes à un outil local appelé par le `Makefile` relèvent des
+tests de cet outil et ne sont pas inspectées par cette barrière.

--- a/tooling/check-software-sources.test.ts
+++ b/tooling/check-software-sources.test.ts
@@ -42,7 +42,9 @@ test("the reconciled tools use their supported Homebrew artifacts", () => {
 
   expect(graph).toContain("brew install fzf");
   expect(graph).toContain("brew install --cask cursor-cli");
-  expect(graph).toContain("brew install --cask --adopt vibe-island");
+  expect(graph).toContain(
+    "brew update\nbrew install --cask --adopt vibe-island",
+  );
 });
 
 test.each([

--- a/tooling/check-software-sources.test.ts
+++ b/tooling/check-software-sources.test.ts
@@ -1,0 +1,215 @@
+import {
+  dryRunInstallationGraph,
+  findUndeclaredSources,
+} from "./check-software-sources.ts";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+import { inventorySources } from "./software-source-inventory.ts";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const repositoryRoot = resolve(import.meta.dir, "..");
+const gate = resolve(import.meta.dir, "check-software-sources.ts");
+type CommandResult = Readonly<{
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}>;
+
+function runGate(makefile: string): CommandResult {
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, gate, makefile],
+    cwd: repositoryRoot,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
+  };
+}
+
+test("the supported installation graph has no undeclared source", () => {
+  const result = runGate(resolve(repositoryRoot, "Makefile"));
+
+  expect(result.stderr).toBe("");
+  expect(result.exitCode).toBe(0);
+});
+
+test("the reconciled tools use their supported Homebrew artifacts", () => {
+  const graph = dryRunInstallationGraph(resolve(repositoryRoot, "Makefile"));
+
+  expect(graph).toContain("brew install fzf");
+  expect(graph).toContain("brew install --cask cursor-cli");
+  expect(graph).toContain("brew install --cask --adopt vibe-island");
+});
+
+test.each([
+  ["another HTTPS download", "wget https://downloads.example.test/tool.dmg"],
+  ["an SCP-style Git source", "git clone git@example.test:tools/tool.git"],
+  ["Cargo", "cargo install tool"],
+  ["Go", "go install example.test/tool@latest"],
+  ["RubyGems", "gem install tool"],
+  ["pip", "pipx install tool"],
+  ["uv", "uv tool install tool"],
+  ["npx", "npx tool install"],
+])("refuses %s as an undeclared source", (_name, command) => {
+  const sources = inventorySources(command);
+
+  expect(findUndeclaredSources(sources, [])).not.toEqual([]);
+});
+
+test("does not confuse an allowed manager with a new source channel", () => {
+  const sources = inventorySources("brew install --cask example");
+
+  expect(findUndeclaredSources(sources, ["channel:homebrew"])).toEqual([]);
+});
+
+test.each(["pull", "run"])(
+  "requires each Docker %s image to be declared separately",
+  (command) => {
+    const sources = inventorySources(
+      `docker ${command} evil.example/team/tool:latest`,
+    );
+
+    expect(findUndeclaredSources(sources, ["channel:docker"])).toEqual([
+      "docker:evil.example/team/tool:latest",
+    ]);
+  },
+);
+
+test("refuses an undeclared image from a reached Compose file", () => {
+  const directory = mkdtempSync(resolve(tmpdir(), "software-sources-compose-"));
+  const makefile = resolve(directory, "Makefile");
+  writeFileSync(
+    makefile,
+    "all:\n\t@brew install example\n\t@docker compose -f compose.yml up -d\n",
+  );
+  writeFileSync(
+    resolve(directory, "compose.yml"),
+    "services:\n  example:\n    image: evil.example/team/tool:latest\n",
+  );
+
+  try {
+    const result = runGate(makefile);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("docker:evil.example/team/tool:latest");
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test.each([";", "&", "|"])(
+  "refuses a noncanonical Compose call beside a canonical call with %s",
+  (separator) => {
+    const directory = mkdtempSync(
+      resolve(tmpdir(), "software-sources-compose-"),
+    );
+    const makefile = resolve(directory, "Makefile");
+    writeFileSync(
+      makefile,
+      `all:\n\t@brew install example\n\t@docker compose --file hidden.yml up -d ${separator} docker compose -f declared.yml up -d\n`,
+    );
+
+    try {
+      const result = runGate(makefile);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("compose:unsupported-syntax");
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  },
+);
+
+test.each([
+  "docker compose --file compose.yml up -d",
+  "docker compose --file=compose.yml up -d",
+  "docker compose up -d",
+  "docker --context desktop-linux compose -f compose.yml up -d",
+])("refuses unsupported Compose syntax: %s", (composeCommand) => {
+  const directory = mkdtempSync(resolve(tmpdir(), "software-sources-compose-"));
+  const makefile = resolve(directory, "Makefile");
+  writeFileSync(
+    makefile,
+    `all:\n\t@brew install example\n\t@${composeCommand}\n`,
+  );
+
+  try {
+    const result = runGate(makefile);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("compose:unsupported-syntax");
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("fails closed when the Makefile is unreadable", () => {
+  const result = runGate(resolve(repositoryRoot, "missing-Makefile"));
+
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain("ENOENT");
+});
+
+test("fails closed when make is unavailable", () => {
+  expect(() =>
+    dryRunInstallationGraph(
+      resolve(repositoryRoot, "Makefile"),
+      "/missing/make",
+    ),
+  ).toThrow();
+});
+
+test("fails closed when the graph canary is absent", () => {
+  const directory = mkdtempSync(resolve(tmpdir(), "software-sources-"));
+  const makefile = resolve(directory, "Makefile");
+  writeFileSync(makefile, "all:\n\t@echo local-only\n");
+
+  try {
+    const result = runGate(makefile);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "installation graph canary missing: channel:homebrew",
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("does not execute parse-time shell while inspecting the graph", () => {
+  const directory = mkdtempSync(resolve(tmpdir(), "software-sources-shell-"));
+  const makefile = resolve(directory, "Makefile");
+  const marker = resolve(directory, "executed");
+  writeFileSync(
+    makefile,
+    `PROBE:=$(shell curl https://downloads.example.test/tool -o ${marker})\nall:\n\t@brew install example\n`,
+  );
+
+  try {
+    const result = runGate(makefile);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("https://downloads.example.test/tool");
+    expect(existsSync(marker)).toBe(false);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("finds a source after a nested parse-time expansion", () => {
+  const directory = mkdtempSync(resolve(tmpdir(), "software-sources-shell-"));
+  const makefile = resolve(directory, "Makefile");
+  const marker = resolve(directory, "executed");
+  writeFileSync(
+    makefile,
+    `PROBE:=$(shell value=$(OTHER); curl https://nested.example.test/tool -o ${marker})\nall:\n\t@brew install example\n`,
+  );
+
+  try {
+    const result = runGate(makefile);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("https://nested.example.test/tool");
+    expect(existsSync(marker)).toBe(false);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});

--- a/tooling/check-software-sources.ts
+++ b/tooling/check-software-sources.ts
@@ -1,0 +1,122 @@
+import { dirname, resolve } from "node:path";
+import {
+  extractParseTimeCommands,
+  inventoryComposeSources,
+  inventorySources,
+} from "./software-source-inventory.ts";
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+
+const SUCCESS = 0;
+const FAILURE = 1;
+const CLI_ARGUMENT_START = 2;
+const cliArgumentsSchema = z.tuple([z.string().min(1)]);
+const allowedSources = [
+  "channel:docker",
+  "channel:fisher",
+  "channel:homebrew",
+  "channel:mas",
+  "channel:npm",
+  "docker:cloakhq/cloakbrowser:0.5.3",
+  "docker:ghcr.io/firecrawl/firecrawl:latest",
+  "docker:ghcr.io/firecrawl/nuq-postgres:latest",
+  "docker:ghcr.io/firecrawl/playwright-service:latest",
+  "docker:pyd4vinci/scrapling",
+  "docker:rabbitmq:3-management",
+  "docker:redis:alpine",
+  "https://claude.ai/install.sh",
+  "https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Latte.tmTheme",
+  "https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Mocha.tmTheme",
+  "https://github.com/tmux-plugins/tpm",
+  "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh",
+  "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.aff",
+  "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.dic",
+  "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/fr_FR/dictionaries/fr.aff",
+  "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/fr_FR/dictionaries/fr.dic",
+] as const;
+
+function findUndeclaredSources(
+  sources: readonly string[],
+  allowed: readonly string[] = allowedSources,
+): readonly string[] {
+  return sources.filter((source) => !allowed.includes(source));
+}
+
+function dryRunInstallationGraph(
+  makefile: string,
+  makeCommand = "make",
+): string {
+  readFileSync(makefile, "utf8");
+  const result = Bun.spawnSync({
+    cmd: [
+      makeCommand,
+      "-B",
+      "-n",
+      "-f",
+      makefile,
+      "all",
+      "SKIP_PAID_APPS=1",
+      "SHELL=/usr/bin/false",
+      "MAKE=/usr/bin/false",
+    ],
+    cwd: dirname(makefile),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const stderr = result.stderr.toString();
+  if (result.exitCode !== SUCCESS) {
+    throw new Error(`make dry-run failed:\n${stderr}`);
+  }
+  const output = result.stdout.toString();
+  if (output.trim() === "") {
+    throw new Error("make dry-run returned no installation graph");
+  }
+  return output;
+}
+
+function checkSoftwareSources(makefile: string): readonly string[] {
+  const contents = readFileSync(makefile, "utf8");
+  const evidence = [
+    dryRunInstallationGraph(makefile),
+    ...extractParseTimeCommands(contents),
+  ].join("\n");
+  const sources = [
+    ...inventorySources(evidence),
+    ...inventoryComposeSources(evidence, makefile),
+  ].toSorted();
+  if (!sources.includes("channel:homebrew")) {
+    throw new Error("installation graph canary missing: channel:homebrew");
+  }
+  return findUndeclaredSources(sources);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "unknown software source failure";
+}
+
+function main(): number {
+  try {
+    const [makefile] = cliArgumentsSchema.parse(
+      Bun.argv.slice(CLI_ARGUMENT_START),
+    );
+    const undeclared = checkSoftwareSources(resolve(makefile));
+    if (undeclared.length > 0) {
+      process.stderr.write(
+        `undeclared software sources:\n${undeclared.join("\n")}\n`,
+      );
+      return FAILURE;
+    }
+    return SUCCESS;
+  } catch (error) {
+    process.stderr.write(`${errorMessage(error)}\n`);
+    return FAILURE;
+  }
+}
+
+if (import.meta.main) {
+  process.exitCode = main();
+}
+
+export { checkSoftwareSources, dryRunInstallationGraph, findUndeclaredSources };

--- a/tooling/firecrawl-compose.test.ts
+++ b/tooling/firecrawl-compose.test.ts
@@ -59,7 +59,9 @@ test("the unauthenticated Firecrawl API is published only on host loopback", () 
   );
 
   expect(publishedApiPorts).toHaveLength(1);
-  expect(loopbackFirecrawlPortSchema.safeParse(publishedApiPorts[0]).success).toBeTrue();
+  expect(
+    loopbackFirecrawlPortSchema.safeParse(publishedApiPorts[0]).success,
+  ).toBeTrue();
 });
 
 test.each([
@@ -78,7 +80,9 @@ test.each([
       target: firecrawlPort,
     };
 
-    expect(loopbackFirecrawlPortSchema.safeParse(renderedPort).success).toBeFalse();
+    expect(
+      loopbackFirecrawlPortSchema.safeParse(renderedPort).success,
+    ).toBeFalse();
   },
 );
 
@@ -91,5 +95,7 @@ test("rejects host networking that bypasses published port confinement", () => {
     },
   };
 
-  expect(renderedComposeSchema.safeParse(hostNetworkConfiguration).success).toBeFalse();
+  expect(
+    renderedComposeSchema.safeParse(hostNetworkConfiguration).success,
+  ).toBeFalse();
 });

--- a/tooling/software-source-inventory.ts
+++ b/tooling/software-source-inventory.ts
@@ -1,0 +1,151 @@
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+
+const composeSchema = z
+  .object({
+    services: z.record(z.string(), z.looseObject({ image: z.string().min(1) })),
+  })
+  .loose();
+const channelPatterns = [
+  ["channel:homebrew", /\bbrew install\b/u],
+  ["channel:mas", /\bmas install\b/u],
+  ["channel:npm", /(?:\bnpm install\b|\bvolta install\b)/u],
+  ["channel:docker", /(?:\bdocker pull\b|\bdocker run\b|\bdocker compose\b)/u],
+  ["channel:fisher", /\bfisher install\b/u],
+  ["channel:cargo", /\bcargo install\b/u],
+  ["channel:gem", /\bgem install\b/u],
+  ["channel:go", /\bgo install\b/u],
+  ["channel:npx", /\bnpx\b/u],
+  ["channel:pip", /\b(?:pip|pip3|pipx) install\b/u],
+  ["channel:uv-tool", /\buv tool install\b/u],
+] as const;
+
+function extractRemoteReferences(output: string): readonly string[] {
+  const urls = output.match(/https?:\/\/[^\s"'\\)]+/gu) ?? [];
+  const gitReferences: string[] = [];
+  for (const match of output.matchAll(
+    /\bgit clone\s+(?<source>[^\s]+:[^\s]+)(?:\s|$)/gu,
+  )) {
+    const source = match.groups?.source;
+    if (source !== undefined) {
+      gitReferences.push(source);
+    }
+  }
+  return [...urls, ...gitReferences];
+}
+
+function extractChannels(output: string): readonly string[] {
+  const channels: string[] = [];
+  for (const [channel, pattern] of channelPatterns) {
+    if (pattern.test(output)) {
+      channels.push(channel);
+    }
+  }
+  return channels;
+}
+
+function extractDockerReferences(output: string): readonly string[] {
+  const references: string[] = [];
+  for (const match of output.matchAll(
+    /\bdocker (?:pull|run)\s+(?<image>[^\s;&|]+)/gu,
+  )) {
+    const image = match.groups?.image;
+    if (image !== undefined) {
+      references.push(`docker:${image}`);
+    }
+  }
+  return references;
+}
+
+function inventorySources(output: string): readonly string[] {
+  return [
+    ...new Set([
+      ...extractChannels(output),
+      ...extractDockerReferences(output),
+      ...extractRemoteReferences(output),
+    ]),
+  ].toSorted();
+}
+
+function extractComposePaths(output: string): readonly string[] {
+  const paths: string[] = [];
+  for (const match of output.matchAll(
+    /\bdocker compose\s+-f\s+(?<path>[^\s;&|]+)/gu,
+  )) {
+    const path = match.groups?.path;
+    if (path !== undefined) {
+      paths.push(path);
+    }
+  }
+  return paths;
+}
+
+function usesUnsupportedComposeSyntax(output: string): boolean {
+  return output
+    .split("\n")
+    .flatMap((line) => line.split(/&&|\|\||[;&|]/u))
+    .filter((command) =>
+      /\bdocker(?:-compose|\b[^\n]*\bcompose)\b/u.test(command),
+    )
+    .some((command) => !/\bdocker compose\s+-f\s+[^\s;&|]+/u.test(command));
+}
+
+function inventoryComposeSources(
+  output: string,
+  makefile: string,
+): readonly string[] {
+  if (usesUnsupportedComposeSyntax(output)) {
+    return ["compose:unsupported-syntax"];
+  }
+
+  const repositoryRoot = dirname(makefile);
+  const sources: string[] = [];
+  for (const path of extractComposePaths(output)) {
+    const absolutePath = resolve(repositoryRoot, path);
+    const repositoryPath = relative(repositoryRoot, absolutePath);
+    if (repositoryPath.startsWith("..") || isAbsolute(repositoryPath)) {
+      sources.push(`compose:${path}`);
+    } else {
+      const compose = composeSchema.parse(
+        Bun.YAML.parse(readFileSync(absolutePath, "utf8")),
+      );
+      for (const service of Object.values(compose.services)) {
+        sources.push(`docker:${service.image}`);
+      }
+    }
+  }
+  return sources;
+}
+
+function closingMakeExpression(input: string, contentsStart: number): number {
+  let depth = 1;
+  for (let index = contentsStart; index < input.length; index += 1) {
+    if (input[index] === "$" && input[index + 1] === "(") {
+      depth += 1;
+      index += 1;
+    } else if (input[index] === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  throw new Error("unterminated Make shell expression");
+}
+
+function extractParseTimeCommands(makefile: string): readonly string[] {
+  const commands: string[] = [];
+  const shellExpression = /\$\(\s*shell\s+/gu;
+  let match = shellExpression.exec(makefile);
+  while (match !== null) {
+    const commandStart = shellExpression.lastIndex;
+    const commandEnd = closingMakeExpression(makefile, commandStart);
+    commands.push(makefile.slice(commandStart, commandEnd));
+    shellExpression.lastIndex = commandEnd + 1;
+    match = shellExpression.exec(makefile);
+  }
+  return commands;
+}
+
+export { extractParseTimeCommands, inventoryComposeSources, inventorySources };


### PR DESCRIPTION
## Description

- migrate Cursor CLI, fzf, and Vibe Island to supported Homebrew distributions
- reconcile ADR-002 with every deliberate non-Homebrew source and document its version, integrity, update, and replay contract
- add a fail-closed source inventory gate for the supported `make all` graph, with adversarial tests
- apply the existing formatter to `tooling/firecrawl-compose.test.ts` so the repository-wide Lint workflow can pass

## Useful Links

- Closes #233

## How to Test

- `bun run format:typescript:check`
- `bun run lint`
- `bun run typecheck`
- `bun test`
- `bun tooling/check-software-sources.ts Makefile`
- `make -n fzf`
- `make -n cursor`
- `make -n vibe-island`

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
