### PR TITLE
fix(install): verify Docker-backed targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Execute install twice
+        env:
+          DOCKER_UNAVAILABLE_POLICY: allow-skip
         run: |
           make trust-taps "${{ matrix.target }}" SKIP_PAID_APPS=1
           make trust-taps "${{ matrix.target }}" SKIP_PAID_APPS=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           DOCKER_UNAVAILABLE_POLICY: allow-skip
         run: |
+          export PATH="/Applications/OrbStack.app/Contents/MacOS/xbin:$PATH"
           make trust-taps "${{ matrix.target }}" SKIP_PAID_APPS=1
           make trust-taps "${{ matrix.target }}" SKIP_PAID_APPS=1
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ LOCAL_BIN:=$(HOME)/.local/bin
 APP_BIN:=/Applications
 SCRAPLING_IMAGE?=pyd4vinci/scrapling
 CLOAKBROWSER_IMAGE?=cloakhq/cloakbrowser:0.5.3
+DOCKER_UNAVAILABLE_POLICY?=allow-skip
 DOTFILES_PATH:=$(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 CREATE_SYMLINK=test ! -e "$@" && test ! -L "$@" && ln -s "$<" "$@"
 # SKIP_PAID_APPS: set to 1 to skip paid Mac App Store apps (useful for CI)
@@ -16,8 +17,6 @@ SKIP_PAID_APPS?=0
 export HOMEBREW_NO_ASK:=1
 # HAS_BREW_TRUST: check if brew trust command is available (Homebrew >= 5.1.15)
 HAS_BREW_TRUST:=$(shell brew trust --help >/dev/null 2>&1 && echo yes || echo no)
-# Recipe guard: no Docker daemon in CI, and none right after a fresh Orbstack install.
-DOCKER_OR_SKIP=docker info >/dev/null 2>&1 || { echo "Docker unavailable, skipping $@"; exit 0; }
 
 .PHONY: usage
 usage:
@@ -597,12 +596,20 @@ qovery-cli: /usr/local/bin/qovery
 	curl -s https://get.qovery.com | bash
 
 .PHONY: firecrawl
-firecrawl: docker
-	@$(DOCKER_OR_SKIP); docker compose -f ${DOTFILES_PATH}/harness/firecrawl/compose.yml up -d
+firecrawl: docker bun
+	@"${DOTFILES_PATH}/tooling/install-docker-artifact" install firecrawl "${DOCKER_UNAVAILABLE_POLICY}" "${DOTFILES_PATH}/harness/firecrawl/compose.yml"
+
+.PHONY: verify-firecrawl-docker
+verify-firecrawl-docker: bun
+	@"${DOTFILES_PATH}/tooling/install-docker-artifact" verify firecrawl "${DOCKER_UNAVAILABLE_POLICY}" "${DOTFILES_PATH}/harness/firecrawl/compose.yml"
 
 .PHONY: scrapling
-scrapling: docker ${LOCAL_BIN}/scrapling_mcp
-	@$(DOCKER_OR_SKIP); docker image inspect ${SCRAPLING_IMAGE} >/dev/null 2>&1 || docker pull ${SCRAPLING_IMAGE}
+scrapling: docker bun ${LOCAL_BIN}/scrapling_mcp
+	@"${DOTFILES_PATH}/tooling/install-docker-artifact" install scrapling "${DOCKER_UNAVAILABLE_POLICY}" "${SCRAPLING_IMAGE}"
+
+.PHONY: verify-scrapling-docker
+verify-scrapling-docker: bun
+	@"${DOTFILES_PATH}/tooling/install-docker-artifact" verify scrapling "${DOCKER_UNAVAILABLE_POLICY}" "${SCRAPLING_IMAGE}"
 
 # MCP command for agents: starts the shared container on demand instead of one per session.
 ${LOCAL_BIN}/scrapling_mcp: ${DOTFILES_PATH}/tooling/scrapling-mcp | ${LOCAL_BIN}
@@ -611,8 +618,12 @@ ${LOCAL_BIN}:
 	mkdir -p $@
 
 .PHONY: cloakbrowser
-cloakbrowser: docker
-	@$(DOCKER_OR_SKIP); docker image inspect ${CLOAKBROWSER_IMAGE} >/dev/null 2>&1 || docker pull ${CLOAKBROWSER_IMAGE}
+cloakbrowser: docker bun
+	@"${DOTFILES_PATH}/tooling/install-docker-artifact" install cloakbrowser "${DOCKER_UNAVAILABLE_POLICY}" "${CLOAKBROWSER_IMAGE}"
+
+.PHONY: verify-cloakbrowser-docker
+verify-cloakbrowser-docker: bun
+	@"${DOTFILES_PATH}/tooling/install-docker-artifact" verify cloakbrowser "${DOCKER_UNAVAILABLE_POLICY}" "${CLOAKBROWSER_IMAGE}"
 
 .PHONY: skills
 skills: ${VOLTA_BIN}/skills

--- a/docs/adr/018-orbstack-runtime-conteneurs.md
+++ b/docs/adr/018-orbstack-runtime-conteneurs.md
@@ -20,7 +20,8 @@ Fish reste utilisable sans lui.
 
 - Démarrage rapide et empreinte réduite au repos ; CLI `docker` inchangée.
 - Les cibles Docker doivent tolérer l'absence de daemon — en CI, ou juste
-  après une installation neuve — d'où le garde `DOCKER_OR_SKIP`
+  après une installation neuve — en rapportant un résultat `skipped` distinct
+  d'une installation vérifiée selon la politique explicite de l'appelant
   ([ADR-023](023-ci-lint-et-installation.md)).
 - Dépendance à un produit tiers propriétaire.
 

--- a/docs/adr/023-ci-lint-et-installation.md
+++ b/docs/adr/023-ci-lint-et-installation.md
@@ -24,8 +24,9 @@ l'installation par défaut sur un runner macOS. Sur une pull request,
 `ci-smoke-targets` repère les blocs `.PHONY` modifiés et les exécute sur des
 runners macOS isolés et parallèles. Une sélection ambiguë ou un changement de
 l'infrastructure d'installation retombe sur `all`. Les apps payantes sont
-exclues (`SKIP_PAID_APPS`) et les cibles Docker ignorées en l'absence de daemon
-(`DOCKER_OR_SKIP`).
+exclues (`SKIP_PAID_APPS`). Le job d'installation autorise explicitement un
+résultat Docker `skipped` en l'absence de daemon ; lorsque Docker est disponible,
+chaque cible vérifie l'artefact qu'elle promet avant de réussir.
 
 ## Conséquences
 

--- a/docs/adr/031-mcp-en-conteneurs-nommes.md
+++ b/docs/adr/031-mcp-en-conteneurs-nommes.md
@@ -27,7 +27,9 @@ automatique.
 
 - Un conteneur oublié coûte au plus un conteneur, non un par session.
 - Les dépendances lourdes restent isolées du poste.
-- Les cibles Docker doivent tolérer l'absence de daemon
+- Les cibles Docker doivent tolérer l'absence de daemon avec un résultat
+  `skipped` explicite, décidé par la politique de l'appelant, et ne rapporter
+  `verified` qu'après leur oracle Docker
   ([ADR-018](018-orbstack-runtime-conteneurs.md),
   [ADR-023](023-ci-lint-et-installation.md)).
 

--- a/tooling/docker-install-source-inventory.test.ts
+++ b/tooling/docker-install-source-inventory.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import {
+  inventoryComposeSources,
+  inventorySources,
+} from "./software-source-inventory.ts";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { checkSoftwareSources } from "./check-software-sources.ts";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+test("inventories an image installed through the Docker artifact entry point", () => {
+  const command =
+    '"/repo/tooling/install-docker-artifact" install scrapling "allow-skip" "registry.example.test/scrapling:1"';
+
+  expect(inventorySources(command)).toEqual([
+    "channel:docker",
+    "docker:registry.example.test/scrapling:1",
+  ]);
+});
+
+test("inventories Compose images reached through the Docker artifact entry point", () => {
+  const root = mkdtempSync(join(tmpdir(), "docker-install-inventory-"));
+  const compose = join(root, "compose.yml");
+  const makefile = join(root, "Makefile");
+  writeFileSync(
+    compose,
+    "services:\n  api:\n    image: registry.example.test/api:1\n",
+  );
+  writeFileSync(makefile, "all:\n");
+
+  try {
+    const command = `"${root}/tooling/install-docker-artifact" install firecrawl "allow-skip" "${compose}"`;
+    expect(inventoryComposeSources(command, makefile)).toEqual([
+      "docker:registry.example.test/api:1",
+    ]);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test.each([
+  '"/repo/tooling/install-docker-artifact" install scrapling "allow-skip"',
+  '"/repo/tooling/install-docker-artifact" install unknown "allow-skip" "image"',
+  '"/repo/tooling/install-docker-artifact" install scrapling "allow-skip" "image" extra',
+])("refuses unsupported Docker artifact entry point syntax", (command) => {
+  expect(inventorySources(command)).toContain(
+    "docker-installer:unsupported-syntax",
+  );
+});
+
+test("the complete gate rejects an undeclared image through a relative entry point", () => {
+  const root = mkdtempSync(join(tmpdir(), "docker-install-gate-"));
+  const makefile = join(root, "Makefile");
+  writeFileSync(
+    makefile,
+    [
+      "all:",
+      "\t@brew install example",
+      '\t@tooling/install-docker-artifact install scrapling "allow-skip" "evil.example/payload:latest"',
+      "",
+    ].join("\n"),
+  );
+
+  try {
+    expect(checkSoftwareSources(makefile)).toContain(
+      "docker:evil.example/payload:latest",
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});

--- a/tooling/docker-install-test-provider.ts
+++ b/tooling/docker-install-test-provider.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env bun
+
+import { appendFileSync, readFileSync } from "node:fs";
+import { z } from "zod";
+
+const environmentSchema = z.object({
+  DOCKER_INSTALL_TEST_SCENARIO: z.enum([
+    "artifact-absent",
+    "artifact-present",
+    "command-failure",
+    "daemon-unavailable",
+    "invalid-evidence",
+  ]),
+  DOCKER_INSTALL_TEST_STATE: z.string().min(1),
+  DOCKER_INSTALL_TEST_TARGET: z.enum([
+    "cloakbrowser",
+    "firecrawl",
+    "scrapling",
+  ]),
+});
+const environment = environmentSchema.parse(process.env);
+const cliArgumentStart = 2;
+const usageExitCode = 64;
+const command = process.argv.slice(cliArgumentStart);
+const renderedCommand = command.join(" ");
+appendFileSync(environment.DOCKER_INSTALL_TEST_STATE, `${renderedCommand}\n`);
+
+function finish(exitCode: number, stdout = "", stderr = ""): never {
+  process.stdout.write(stdout);
+  process.stderr.write(stderr);
+  process.exit(exitCode);
+}
+
+function imageInspectionCount(): number {
+  const trace = readFileSync(environment.DOCKER_INSTALL_TEST_STATE, "utf8");
+  return trace.split("\n").filter((line) => line.startsWith("image inspect "))
+    .length;
+}
+
+if (renderedCommand === "info") {
+  if (environment.DOCKER_INSTALL_TEST_SCENARIO === "daemon-unavailable") {
+    finish(1, "", "daemon unavailable\n");
+  }
+  finish(0, "test daemon\n");
+}
+
+if (command.includes("--help")) {
+  finish(0, "Docker help\n");
+}
+
+if (command[0] === "compose") {
+  if (command.includes("up")) {
+    if (environment.DOCKER_INSTALL_TEST_SCENARIO === "command-failure") {
+      finish(1, "", "compose up failed\n");
+    }
+    finish(0);
+  }
+  if (command.includes("config")) {
+    if (environment.DOCKER_INSTALL_TEST_SCENARIO === "invalid-evidence") {
+      finish(0, "api\ninvalid service\n");
+    }
+    finish(0, "api\nplaywright-service\nredis\nrabbitmq\nnuq-postgres\n");
+  }
+  if (command.includes("ps")) {
+    const services =
+      environment.DOCKER_INSTALL_TEST_SCENARIO === "artifact-present"
+        ? "api\nplaywright-service\nredis\nrabbitmq\nnuq-postgres\n"
+        : "api\n";
+    finish(0, services);
+  }
+}
+
+if (command[0] === "image" && command[1] === "inspect") {
+  const presentInitially =
+    environment.DOCKER_INSTALL_TEST_SCENARIO === "artifact-present";
+  const presentAfterInstall =
+    environment.DOCKER_INSTALL_TEST_SCENARIO !== "artifact-absent" &&
+    imageInspectionCount() > 1;
+  finish(presentInitially || presentAfterInstall ? 0 : 1);
+}
+
+if (command[0] === "pull") {
+  if (environment.DOCKER_INSTALL_TEST_SCENARIO === "command-failure") {
+    finish(1, "", "pull failed\n");
+  }
+  finish(0, `pulled ${command[1] ?? ""}\n`);
+}
+
+finish(usageExitCode, "", `unexpected Docker command: ${renderedCommand}\n`);

--- a/tooling/docker-install-test-provider.ts
+++ b/tooling/docker-install-test-provider.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { appendFileSync, readFileSync } from "node:fs";
+import { appendFileSync } from "node:fs";
 import { z } from "zod";
 
 const environmentSchema = z.object({
@@ -20,6 +20,7 @@ const environmentSchema = z.object({
 });
 const environment = environmentSchema.parse(process.env);
 const cliArgumentStart = 2;
+const sha256HexadecimalLength = 64;
 const usageExitCode = 64;
 const command = process.argv.slice(cliArgumentStart);
 const renderedCommand = command.join(" ");
@@ -31,17 +32,23 @@ function finish(exitCode: number, stdout = "", stderr = ""): never {
   process.exit(exitCode);
 }
 
-function imageInspectionCount(): number {
-  const trace = readFileSync(environment.DOCKER_INSTALL_TEST_STATE, "utf8");
-  return trace.split("\n").filter((line) => line.startsWith("image inspect "))
-    .length;
-}
-
 if (renderedCommand === "info") {
   if (environment.DOCKER_INSTALL_TEST_SCENARIO === "daemon-unavailable") {
     finish(1, "", "daemon unavailable\n");
   }
   finish(0, "test daemon\n");
+}
+
+if (command[0] === "image" && command[1] === "ls") {
+  const identifier = `sha256:${"a".repeat(sha256HexadecimalLength)}`;
+  if (environment.DOCKER_INSTALL_TEST_SCENARIO === "invalid-evidence") {
+    finish(0, "invalid image identifier\n");
+  }
+  const output =
+    environment.DOCKER_INSTALL_TEST_SCENARIO === "artifact-present"
+      ? `${identifier}\n`
+      : "";
+  finish(0, output);
 }
 
 if (command.includes("--help")) {
@@ -71,12 +78,9 @@ if (command[0] === "compose") {
 }
 
 if (command[0] === "image" && command[1] === "inspect") {
-  const presentInitially =
-    environment.DOCKER_INSTALL_TEST_SCENARIO === "artifact-present";
-  const presentAfterInstall =
-    environment.DOCKER_INSTALL_TEST_SCENARIO !== "artifact-absent" &&
-    imageInspectionCount() > 1;
-  finish(presentInitially || presentAfterInstall ? 0 : 1);
+  finish(
+    environment.DOCKER_INSTALL_TEST_SCENARIO === "artifact-present" ? 0 : 1,
+  );
 }
 
 if (command[0] === "pull") {

--- a/tooling/docker-install-test-support.ts
+++ b/tooling/docker-install-test-support.ts
@@ -67,7 +67,7 @@ function runDockerInstallTarget(
       DOCKER_INSTALL_TEST_SCENARIO: scenario,
       DOCKER_INSTALL_TEST_STATE: fixture.trace,
       DOCKER_INSTALL_TEST_TARGET: target,
-      PATH: `${fixture.binaryDirectory}:${dirname(process.execPath)}:/usr/bin:/bin`,
+      PATH: `${fixture.binaryDirectory}:${dirname(process.execPath)}`,
     },
     stderr: "pipe",
     stdout: "pipe",

--- a/tooling/docker-install-test-support.ts
+++ b/tooling/docker-install-test-support.ts
@@ -1,0 +1,138 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const repositoryRoot = resolve(import.meta.dir, "..");
+const make = Bun.which("make");
+const provider = resolve(import.meta.dir, "docker-install-test-provider.ts");
+const executableMode = 0o755;
+const fixtures: string[] = [];
+
+type DockerInstallScenario =
+  | "artifact-absent"
+  | "artifact-present"
+  | "command-failure"
+  | "daemon-unavailable"
+  | "invalid-evidence";
+type DockerInstallTarget = "cloakbrowser" | "firecrawl" | "scrapling";
+type DockerInstallOptions = Readonly<{
+  dockerProviderAvailable?: boolean;
+  imageOverride?: string;
+  policy?: string;
+}>;
+type DockerInstallFixture = Readonly<{
+  binaryDirectory: string;
+  localBinaryDirectory: string;
+  makeCommand: string;
+  trace: string;
+}>;
+type MakeArgumentOptions = Readonly<{
+  imageOverride: string | undefined;
+  policy: string;
+}>;
+type MakeResult = Readonly<{
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+  trace: string;
+}>;
+
+function runDockerInstallTarget(
+  target: DockerInstallTarget,
+  scenario: DockerInstallScenario,
+  options: DockerInstallOptions = {},
+): MakeResult {
+  if (make === null) {
+    throw new Error("make is unavailable");
+  }
+  const {
+    dockerProviderAvailable = true,
+    imageOverride,
+    policy = "allow-skip",
+  } = options;
+  const fixture = createDockerInstallFixture(dockerProviderAvailable, make);
+  const result = Bun.spawnSync({
+    cmd: makeArguments(target, fixture, { imageOverride, policy }),
+    cwd: repositoryRoot,
+    env: {
+      ...process.env,
+      DOCKER_INSTALL_TEST_SCENARIO: scenario,
+      DOCKER_INSTALL_TEST_STATE: fixture.trace,
+      DOCKER_INSTALL_TEST_TARGET: target,
+      PATH: `${fixture.binaryDirectory}:${dirname(process.execPath)}:/usr/bin:/bin`,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
+    trace: readFileSync(fixture.trace, "utf8"),
+  };
+}
+
+function createDockerInstallFixture(
+  dockerProviderAvailable: boolean,
+  makeCommand: string,
+): DockerInstallFixture {
+  const root = mkdtempSync(join(tmpdir(), "docker-install-"));
+  const binaryDirectory = join(root, "bin");
+  const localBinaryDirectory = join(root, "local-bin");
+  const trace = join(root, "docker-trace");
+  fixtures.push(root);
+  mkdirSync(binaryDirectory);
+  mkdirSync(localBinaryDirectory);
+  writeFileSync(trace, "");
+  chmodSync(provider, executableMode);
+  if (dockerProviderAvailable) {
+    symlinkSync(provider, join(binaryDirectory, "docker"));
+  }
+  writeFileSync(join(localBinaryDirectory, "scrapling_mcp"), "installed\n");
+  return { binaryDirectory, localBinaryDirectory, makeCommand, trace };
+}
+
+function makeArguments(
+  target: DockerInstallTarget,
+  fixture: DockerInstallFixture,
+  options: MakeArgumentOptions,
+): string[] {
+  const imageAssignment =
+    options.imageOverride === undefined
+      ? []
+      : [
+          `${target === "scrapling" ? "SCRAPLING_IMAGE" : "CLOAKBROWSER_IMAGE"}=${options.imageOverride}`,
+        ];
+  return [
+    fixture.makeCommand,
+    "--no-print-directory",
+    "--old-file=docker",
+    "--old-file=bun",
+    target,
+    `LOCAL_BIN=${fixture.localBinaryDirectory}`,
+    `DOCKER_UNAVAILABLE_POLICY=${options.policy}`,
+    ...imageAssignment,
+  ];
+}
+
+function cleanupDockerInstallFixtures(): void {
+  for (const fixture of fixtures.splice(0)) {
+    rmSync(fixture, { force: true, recursive: true });
+  }
+}
+
+export {
+  cleanupDockerInstallFixtures,
+  runDockerInstallTarget,
+  type DockerInstallScenario,
+  type DockerInstallTarget,
+  type MakeResult,
+};

--- a/tooling/docker-install.test.ts
+++ b/tooling/docker-install.test.ts
@@ -44,6 +44,9 @@ describe.each(targets)("%s Docker installation target", (target) => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain(resultMarker(target, "verified"));
     expect(result.trace).toContain(oracleCommand(target));
+    if (target !== "firecrawl") {
+      expect(result.trace).not.toContain("pull ");
+    }
   });
 });
 
@@ -53,6 +56,16 @@ test("Firecrawl rejects malformed Docker service evidence", () => {
   expect(result.exitCode).not.toBe(0);
   expect(result.stdout).not.toContain(resultMarker("firecrawl", "verified"));
 });
+
+test.each(["scrapling", "cloakbrowser"] as DockerInstallTarget[])(
+  "%s rejects malformed local image evidence",
+  (target) => {
+    const result = runDockerInstallTarget(target, "invalid-evidence");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).not.toContain(resultMarker(target, "verified"));
+  },
+);
 
 test.each(["scrapling", "cloakbrowser"] as DockerInstallTarget[])(
   "%s rejects an image value that Docker would interpret as an option",

--- a/tooling/docker-install.test.ts
+++ b/tooling/docker-install.test.ts
@@ -1,0 +1,114 @@
+import {
+  type DockerInstallTarget,
+  cleanupDockerInstallFixtures,
+  runDockerInstallTarget,
+} from "./docker-install-test-support.ts";
+import { afterAll, describe, expect, test } from "bun:test";
+
+const targets: DockerInstallTarget[] = [
+  "firecrawl",
+  "scrapling",
+  "cloakbrowser",
+];
+
+afterAll(cleanupDockerInstallFixtures);
+
+describe.each(targets)("%s Docker installation target", (target) => {
+  test("reports an allowed unavailable daemon as skipped", () => {
+    const result = runDockerInstallTarget(target, "daemon-unavailable");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(resultMarker(target, "skipped"));
+    expect(result.stderr).toContain("daemon unavailable");
+    expect(result.trace).toBe("info\n");
+  });
+
+  test("fails when the installation command fails", () => {
+    const result = runDockerInstallTarget(target, "command-failure");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).not.toContain(resultMarker(target, "verified"));
+  });
+
+  test("fails when the promised Docker artifact is absent", () => {
+    const result = runDockerInstallTarget(target, "artifact-absent");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).not.toContain(resultMarker(target, "verified"));
+    expect(result.trace).toContain(oracleCommand(target));
+  });
+
+  test("reports verified only when the promised artifact is present", () => {
+    const result = runDockerInstallTarget(target, "artifact-present");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(resultMarker(target, "verified"));
+    expect(result.trace).toContain(oracleCommand(target));
+  });
+});
+
+test("Firecrawl rejects malformed Docker service evidence", () => {
+  const result = runDockerInstallTarget("firecrawl", "invalid-evidence");
+
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stdout).not.toContain(resultMarker("firecrawl", "verified"));
+});
+
+test.each(["scrapling", "cloakbrowser"] as DockerInstallTarget[])(
+  "%s rejects an image value that Docker would interpret as an option",
+  (target) => {
+    const result = runDockerInstallTarget(target, "artifact-present", {
+      imageOverride: "--help",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).not.toContain(resultMarker(target, "verified"));
+  },
+);
+
+test.each(targets)(
+  "%s fails closed when the Docker CLI is absent",
+  (target) => {
+    const result = runDockerInstallTarget(target, "artifact-present", {
+      dockerProviderAvailable: false,
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Docker CLI unavailable");
+    expect(result.stdout).not.toContain(resultMarker(target, "skipped"));
+  },
+);
+
+test.each(targets)("%s refuses an unknown skip policy", (target) => {
+  const result = runDockerInstallTarget(target, "daemon-unavailable", {
+    policy: "unknown-policy",
+  });
+
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stdout).not.toContain(resultMarker(target, "skipped"));
+});
+
+test.each(targets)(
+  "%s fails closed when daemon skips are forbidden",
+  (target) => {
+    const result = runDockerInstallTarget(target, "daemon-unavailable", {
+      policy: "require-docker",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).not.toContain(resultMarker(target, "skipped"));
+  },
+);
+
+function resultMarker(
+  target: DockerInstallTarget,
+  result: "skipped" | "verified",
+): string {
+  return `docker-install target=${target} result=${result}`;
+}
+
+function oracleCommand(target: DockerInstallTarget): string {
+  return target === "firecrawl"
+    ? "ps --services --status running"
+    : "image inspect";
+}

--- a/tooling/docker-install.test.ts
+++ b/tooling/docker-install.test.ts
@@ -10,6 +10,7 @@ const targets: DockerInstallTarget[] = [
   "scrapling",
   "cloakbrowser",
 ];
+const sha256HexadecimalLength = 64;
 
 afterAll(cleanupDockerInstallFixtures);
 
@@ -76,6 +77,20 @@ test.each(["scrapling", "cloakbrowser"] as DockerInstallTarget[])(
 
     expect(result.exitCode).not.toBe(0);
     expect(result.stdout).not.toContain(resultMarker(target, "verified"));
+  },
+);
+
+test.each(["scrapling", "cloakbrowser"] as DockerInstallTarget[])(
+  "%s rejects an unsupported image digest before Docker runs",
+  (target) => {
+    const digest = `registry.example/image@sha256:${"a".repeat(sha256HexadecimalLength)}`;
+    const result = runDockerInstallTarget(target, "artifact-present", {
+      imageOverride: digest,
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).not.toContain(resultMarker(target, "verified"));
+    expect(result.trace).toBe("");
   },
 );
 

--- a/tooling/install-docker-artifact
+++ b/tooling/install-docker-artifact
@@ -1,0 +1,5 @@
+#!/usr/bin/env bun
+
+import { runDockerArtifactInstallation } from "./install-docker-artifact.ts";
+
+process.exitCode = runDockerArtifactInstallation(process.argv.slice(2));

--- a/tooling/install-docker-artifact.ts
+++ b/tooling/install-docker-artifact.ts
@@ -10,7 +10,7 @@ const actionSchema = z.enum(["install", "verify"]);
 const imageReferenceSchema = z
   .string()
   .min(1)
-  .regex(/^(?!-)\S+$/u, "invalid Docker image reference");
+  .regex(/^(?!-)(?!.*@)\S+$/u, "unsupported Docker image reference");
 const invocationSchema = z.union([
   z.tuple([
     actionSchema,

--- a/tooling/install-docker-artifact.ts
+++ b/tooling/install-docker-artifact.ts
@@ -1,0 +1,179 @@
+import { z } from "zod";
+
+const successExitCode = 0;
+const failureExitCode = 1;
+const dockerCommandTimeoutMilliseconds = 600_000;
+const policySchema = z.enum(["allow-skip", "require-docker"]);
+const targetSchema = z.enum(["cloakbrowser", "firecrawl", "scrapling"]);
+const actionSchema = z.enum(["install", "verify"]);
+const imageReferenceSchema = z
+  .string()
+  .min(1)
+  .regex(/^(?!-)\S+$/u, "invalid Docker image reference");
+const invocationSchema = z.union([
+  z.tuple([
+    actionSchema,
+    z.literal("firecrawl"),
+    policySchema,
+    z.string().min(1),
+  ]),
+  z.tuple([
+    actionSchema,
+    z.enum(["cloakbrowser", "scrapling"]),
+    policySchema,
+    imageReferenceSchema,
+  ]),
+]);
+const serviceNameSchema = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u);
+const serviceListSchema = z.array(serviceNameSchema).min(1);
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+type DockerCommandResult = Readonly<{
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+  timedOut: boolean;
+}>;
+type DockerInstallResult =
+  | Readonly<{ result: "skipped"; target: z.infer<typeof targetSchema> }>
+  | Readonly<{ result: "verified"; target: z.infer<typeof targetSchema> }>;
+type Invocation = z.infer<typeof invocationSchema>;
+
+function runDockerArtifactInstallation(arguments_: readonly string[]): number {
+  try {
+    const invocation = invocationSchema.parse(arguments_);
+    const result = installOrVerifyDockerArtifact(invocation);
+    process.stdout.write(
+      `docker-install target=${result.target} result=${result.result}${result.result === "skipped" ? " policy=allow-skip" : ""}\n`,
+    );
+    return successExitCode;
+  } catch (error) {
+    process.stderr.write(`docker-install: ${renderError(error)}\n`);
+    return failureExitCode;
+  }
+}
+
+function installOrVerifyDockerArtifact(
+  invocation: Readonly<Invocation>,
+): DockerInstallResult {
+  const [, target, policy] = invocation;
+  if (Bun.which("docker") === null) {
+    throw new Error("Docker CLI unavailable");
+  }
+  const daemon = runDocker(["info"]);
+  if (daemon.timedOut || daemon.exitCode !== successExitCode) {
+    forwardOutput(daemon);
+    if (policy === "allow-skip") {
+      return { result: "skipped", target };
+    }
+    throw new Error("Docker daemon unavailable and policy requires Docker");
+  }
+  if (invocation[0] === "install") {
+    installDockerArtifact(invocation);
+  }
+  verifyDockerArtifact(invocation);
+  return { result: "verified", target };
+}
+
+function installDockerArtifact(invocation: Readonly<Invocation>): void {
+  const [, target, , artifact] = invocation;
+  const command =
+    target === "firecrawl"
+      ? ["compose", "-f", artifact, "up", "--wait", "--wait-timeout", "120"]
+      : ["pull", "--", artifact];
+  const result = runDocker(command);
+  if (result.exitCode === successExitCode && !result.timedOut) {
+    forwardOutput(result);
+  }
+  requireSuccessfulCommand(result, command);
+}
+
+function verifyDockerArtifact(invocation: Readonly<Invocation>): void {
+  const [, target, , artifact] = invocation;
+  if (target !== "firecrawl") {
+    requireSuccessfulCommand(runDocker(["image", "inspect", "--", artifact]), [
+      "image",
+      "inspect",
+      "--",
+      artifact,
+    ]);
+    return;
+  }
+  verifyComposeServices(artifact);
+}
+
+function verifyComposeServices(composePath: string): void {
+  const prefix = ["compose", "-f", composePath];
+  const configured = runDocker([...prefix, "config", "--services"]);
+  requireSuccessfulCommand(configured, [...prefix, "config", "--services"]);
+  const running = runDocker([
+    ...prefix,
+    "ps",
+    "--services",
+    "--status",
+    "running",
+  ]);
+  requireSuccessfulCommand(running, [
+    ...prefix,
+    "ps",
+    "--services",
+    "--status",
+    "running",
+  ]);
+  const configuredServices = parseServiceList(configured.stdout);
+  const runningServices = new Set(parseServiceList(running.stdout));
+  const missingServices = configuredServices.filter(
+    (service) => !runningServices.has(service),
+  );
+  if (missingServices.length > 0) {
+    throw new Error(`Docker services absent: ${missingServices.join(", ")}`);
+  }
+}
+
+function parseServiceList(output: string): readonly string[] {
+  return serviceListSchema.parse(
+    output
+      .split("\n")
+      .map((service) => service.trim())
+      .filter((service) => service.length > 0),
+  );
+}
+
+function runDocker(arguments_: readonly string[]): DockerCommandResult {
+  const result = Bun.spawnSync(["docker", ...arguments_], {
+    stderr: "pipe",
+    stdout: "pipe",
+    timeout: dockerCommandTimeoutMilliseconds,
+  });
+  return {
+    exitCode: result.exitCode,
+    stderr: decoder.decode(result.stderr),
+    stdout: decoder.decode(result.stdout),
+    timedOut: result.exitedDueToTimeout === true,
+  };
+}
+
+function requireSuccessfulCommand(
+  result: DockerCommandResult,
+  command: readonly string[],
+): void {
+  if (result.timedOut) {
+    forwardOutput(result);
+    throw new Error(`docker ${command.join(" ")} timed out`);
+  }
+  if (result.exitCode !== successExitCode) {
+    forwardOutput(result);
+    throw new Error(`docker ${command.join(" ")} failed`);
+  }
+}
+
+function forwardOutput(result: DockerCommandResult): void {
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+}
+
+function renderError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export { runDockerArtifactInstallation };

--- a/tooling/install-docker-artifact.ts
+++ b/tooling/install-docker-artifact.ts
@@ -26,6 +26,7 @@ const invocationSchema = z.union([
 ]);
 const serviceNameSchema = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u);
 const serviceListSchema = z.array(serviceNameSchema).min(1);
+const imageIdentifierSchema = z.string().regex(/^sha256:[0-9a-f]{64}$/u);
 const decoder = new TextDecoder("utf-8", { fatal: true });
 
 type DockerCommandResult = Readonly<{
@@ -77,6 +78,9 @@ function installOrVerifyDockerArtifact(
 
 function installDockerArtifact(invocation: Readonly<Invocation>): void {
   const [, target, , artifact] = invocation;
+  if (target !== "firecrawl" && localImageExists(artifact)) {
+    return;
+  }
   const command =
     target === "firecrawl"
       ? ["compose", "-f", artifact, "up", "--wait", "--wait-timeout", "120"]
@@ -86,6 +90,24 @@ function installDockerArtifact(invocation: Readonly<Invocation>): void {
     forwardOutput(result);
   }
   requireSuccessfulCommand(result, command);
+}
+
+function localImageExists(image: string): boolean {
+  const command = [
+    "image",
+    "ls",
+    "--quiet",
+    "--no-trunc",
+    "--filter",
+    `reference=${image}`,
+  ];
+  const result = runDocker(command);
+  requireSuccessfulCommand(result, command);
+  const identifiers = result.stdout
+    .split("\n")
+    .map((identifier) => identifier.trim())
+    .filter((identifier) => identifier.length > 0);
+  return z.array(imageIdentifierSchema).parse(identifiers).length > 0;
 }
 
 function verifyDockerArtifact(invocation: Readonly<Invocation>): void {

--- a/tooling/install-docker-artifact.ts
+++ b/tooling/install-docker-artifact.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 const successExitCode = 0;
 const failureExitCode = 1;
+const dockerDaemonProbeTimeoutMilliseconds = 10_000;
 const dockerCommandTimeoutMilliseconds = 600_000;
 const policySchema = z.enum(["allow-skip", "require-docker"]);
 const targetSchema = z.enum(["cloakbrowser", "firecrawl", "scrapling"]);
@@ -61,7 +62,7 @@ function installOrVerifyDockerArtifact(
   if (Bun.which("docker") === null) {
     throw new Error("Docker CLI unavailable");
   }
-  const daemon = runDocker(["info"]);
+  const daemon = runDocker(["info"], dockerDaemonProbeTimeoutMilliseconds);
   if (daemon.timedOut || daemon.exitCode !== successExitCode) {
     forwardOutput(daemon);
     if (policy === "allow-skip") {
@@ -161,11 +162,14 @@ function parseServiceList(output: string): readonly string[] {
   );
 }
 
-function runDocker(arguments_: readonly string[]): DockerCommandResult {
+function runDocker(
+  arguments_: readonly string[],
+  timeout = dockerCommandTimeoutMilliseconds,
+): DockerCommandResult {
   const result = Bun.spawnSync(["docker", ...arguments_], {
     stderr: "pipe",
     stdout: "pipe",
-    timeout: dockerCommandTimeoutMilliseconds,
+    timeout,
   });
   return {
     exitCode: result.exitCode,

--- a/tooling/software-source-inventory.ts
+++ b/tooling/software-source-inventory.ts
@@ -7,6 +7,18 @@ const composeSchema = z
     services: z.record(z.string(), z.looseObject({ image: z.string().min(1) })),
   })
   .loose();
+const dockerInstallerInvocationSchema = z
+  .object({
+    action: z.enum(["install", "verify"]),
+    artifact: z.string().min(1),
+    policy: z.enum(["allow-skip", "require-docker"]),
+    target: z.enum(["cloakbrowser", "firecrawl", "scrapling"]),
+  })
+  .strict();
+const dockerInstallerPattern =
+  /^"?(?:[^"\s]*\/)?tooling\/install-docker-artifact"? (?<action>install|verify) (?<target>cloakbrowser|firecrawl|scrapling) "(?<policy>allow-skip|require-docker)" "(?<artifact>[^"\n]+)"$/u;
+
+// Make -n exposes shell text, not expanded argv; this source inventory is advisory.
 const channelPatterns = [
   ["channel:homebrew", /\bbrew install\b/u],
   ["channel:mas", /\bmas install\b/u],
@@ -58,12 +70,44 @@ function extractDockerReferences(output: string): readonly string[] {
   return references;
 }
 
+function parseDockerInstallerInvocations(output: string): Readonly<{
+  invocations: readonly z.infer<typeof dockerInstallerInvocationSchema>[];
+  unsupported: boolean;
+}> {
+  const installerLines = output
+    .split("\n")
+    .filter((line) => line.includes("install-docker-artifact"));
+  const invocations: z.infer<typeof dockerInstallerInvocationSchema>[] = [];
+  let unsupported = false;
+  for (const line of installerLines) {
+    const match = dockerInstallerPattern.exec(line);
+    if (match?.groups === undefined) {
+      unsupported = true;
+    } else {
+      invocations.push(dockerInstallerInvocationSchema.parse(match.groups));
+    }
+  }
+  return { invocations, unsupported };
+}
+
 function inventorySources(output: string): readonly string[] {
+  const dockerInstaller = parseDockerInstallerInvocations(output);
+  const installedDockerArtifacts = dockerInstaller.invocations
+    .filter(({ action }) => action === "install")
+    .flatMap(({ artifact, target }) =>
+      target === "firecrawl"
+        ? ["channel:docker"]
+        : ["channel:docker", `docker:${artifact}`],
+    );
   return [
     ...new Set([
       ...extractChannels(output),
       ...extractDockerReferences(output),
+      ...installedDockerArtifacts,
       ...extractRemoteReferences(output),
+      ...(dockerInstaller.unsupported
+        ? ["docker-installer:unsupported-syntax"]
+        : []),
     ]),
   ].toSorted();
 }
@@ -78,6 +122,13 @@ function extractComposePaths(output: string): readonly string[] {
       paths.push(path);
     }
   }
+  for (const { action, artifact, target } of parseDockerInstallerInvocations(
+    output,
+  ).invocations) {
+    if (action === "install" && target === "firecrawl") {
+      paths.push(artifact);
+    }
+  }
   return paths;
 }
 
@@ -85,6 +136,7 @@ function usesUnsupportedComposeSyntax(output: string): boolean {
   return output
     .split("\n")
     .flatMap((line) => line.split(/&&|\|\||[;&|]/u))
+    .filter((command) => !command.includes("install-docker-artifact"))
     .filter((command) =>
       /\bdocker(?:-compose|\b[^\n]*\bcompose)\b/u.test(command),
     )


### PR DESCRIPTION
## Description

- replace implicit Docker success with explicit `verified` and policy-authorized `skipped` outcomes
- verify Firecrawl running services and the Scrapling/CloakBrowser images after installation
- reuse already-present tagged images without pulling and reject unsupported digest references before Docker runs
- expose one named Docker oracle per target and make the macOS CI skip policy explicit
- cover daemon unavailable, command failure, artifact absent, artifact present, malformed evidence, missing CLI, and option-like image values through the real Make targets
- keep the software-source inventory aligned with the typed installer entry point

## Useful Links

- Fixes #232

## How to Test

- `bun run format:typescript:check`
- `bun run lint`
- `bun run typecheck`
- `SCRAPLING_DOCKER_SMOKE=1 bun test` — 338 passed, 3 skipped
- `make -n firecrawl scrapling cloakbrowser`
- `make -n verify-firecrawl-docker verify-scrapling-docker verify-cloakbrowser-docker`
- real named oracles verified on macOS arm64 with OrbStack and Docker client/server 29.4.0

The software-source inventory remains advisory because `make -n` exposes shell text rather than expanded argv.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated
- [x] No breaking changes
