### PR TITLE
fix(node): enforce project Volta pin

### DIFF
--- a/.github/workflows/test-typescript.yml
+++ b/.github/workflows/test-typescript.yml
@@ -19,10 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: volta-cli/action@v4
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: package.json
       - run: bun --config=/dev/null --no-env-file install --frozen-lockfile --ignore-scripts
+      - run: bun --config=/dev/null --no-env-file tooling/node-version-contract.ts verify-runtime
       - run: bun --config=/dev/null --no-env-file test --timeout 15000
         env:
           SCRAPLING_DOCKER_SMOKE: "1"

--- a/Makefile
+++ b/Makefile
@@ -918,12 +918,10 @@ ${BREW_BIN}/mas:
 
 .PHONY: node
 node: ${VOLTA_BIN}/node
-${VOLTA_BIN}/node: ${BREW_BIN}/volta ${DOTFILES_PATH}/package.json ${DOTFILES_PATH}/tooling/node-version-contract.ts | ${BREW_BIN}/bun ${DOTFILES_PATH}/node_modules/zod/package.json
+${VOLTA_BIN}/node: ${BREW_BIN}/volta ${DOTFILES_PATH}/package.json ${DOTFILES_PATH}/tooling/node-version-contract.ts | ${BREW_BIN}/bun
 	node_install_spec=$$(${BREW_BIN}/bun --no-install ${DOTFILES_PATH}/tooling/node-version-contract.ts install-spec) && \
 		${BREW_BIN}/volta install "$$node_install_spec"
 	touch $@
-${DOTFILES_PATH}/node_modules/zod/package.json: ${DOTFILES_PATH}/package.json ${DOTFILES_PATH}/bun.lock | ${BREW_BIN}/bun
-	cd "${DOTFILES_PATH}" && "${BREW_BIN}/bun" --config=/dev/null --no-env-file install --frozen-lockfile --ignore-scripts
 
 .PHONY: bun
 bun: ${BREW_BIN}/bun

--- a/Makefile
+++ b/Makefile
@@ -918,9 +918,12 @@ ${BREW_BIN}/mas:
 
 .PHONY: node
 node: ${VOLTA_BIN}/node
-${VOLTA_BIN}/node: ${BREW_BIN}/volta
-	${BREW_BIN}/volta install node@lts
+${VOLTA_BIN}/node: ${BREW_BIN}/volta ${DOTFILES_PATH}/package.json ${DOTFILES_PATH}/tooling/node-version-contract.ts | ${BREW_BIN}/bun ${DOTFILES_PATH}/node_modules/zod/package.json
+	node_install_spec=$$(${BREW_BIN}/bun --no-install ${DOTFILES_PATH}/tooling/node-version-contract.ts install-spec) && \
+		${BREW_BIN}/volta install "$$node_install_spec"
 	touch $@
+${DOTFILES_PATH}/node_modules/zod/package.json: ${DOTFILES_PATH}/package.json ${DOTFILES_PATH}/bun.lock | ${BREW_BIN}/bun
+	cd "${DOTFILES_PATH}" && "${BREW_BIN}/bun" --config=/dev/null --no-env-file install --frozen-lockfile --ignore-scripts
 
 .PHONY: bun
 bun: ${BREW_BIN}/bun

--- a/docs/adr/016-volta-gestionnaire-node.md
+++ b/docs/adr/016-volta-gestionnaire-node.md
@@ -14,7 +14,9 @@ signifie exécuter un projet sur la mauvaise version de Node.
 
 Adopter Volta : la version est déclarée dans le `package.json` du projet et
 appliquée automatiquement par des shims, sans hook de shell. Le `Makefile`
-installe Volta puis le Node LTS, et le script d'upgrade fait suivre le LTS.
+installe Volta puis la version Node exacte déclarée. Le script d'upgrade résout
+la LTS courante dans le pin projet avant d'installer cette même version comme
+défaut utilisateur.
 
 ## Conséquences
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "type": "module",
   "packageManager": "bun@1.4.0",
+  "volta": {
+    "node": "24.19.0"
+  },
   "scripts": {
     "format:typescript": "bun tooling/format-typescript.ts",
     "format:typescript:check": "bun tooling/format-typescript.ts --check",

--- a/tooling/lint-typescript-contract.test.ts
+++ b/tooling/lint-typescript-contract.test.ts
@@ -136,6 +136,9 @@ const configSchema = z
 const checkoutStepSchema = z
   .object({ uses: z.literal("actions/checkout@v5") })
   .strict();
+const setupVoltaStepSchema = z
+  .object({ uses: z.literal("volta-cli/action@v4") })
+  .strict();
 const setupBunStepSchema = z
   .object({
     uses: z.literal("oven-sh/setup-bun@v2"),
@@ -168,8 +171,16 @@ const testJobSchema = z
     "runs-on": z.literal("ubuntu-latest"),
     steps: z.tuple([
       checkoutStepSchema,
+      setupVoltaStepSchema,
       setupBunStepSchema,
       installStepSchema,
+      z
+        .object({
+          run: z.literal(
+            "bun --config=/dev/null --no-env-file tooling/node-version-contract.ts verify-runtime",
+          ),
+        })
+        .strict(),
       z
         .object({
           run: z.literal(

--- a/tooling/node-version-contract.test.ts
+++ b/tooling/node-version-contract.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm } from "node:fs/promises";
+import {
+  nodeInstallSpec,
+  readNodeVersion,
+  verifyNodeRuntime,
+} from "./node-version-contract";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const executableMode = 0o755;
+const temporaryDirectories: string[] = [];
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "node-version-contract-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function writePackageJson(value: unknown): Promise<string> {
+  const directory = await createTemporaryDirectory();
+  const packageJsonPath = join(directory, "package.json");
+  await Bun.write(packageJsonPath, JSON.stringify(value));
+  return packageJsonPath;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true })),
+  );
+});
+
+describe("Node project pin", () => {
+  test("reads an exact version and builds the Volta install argument", async () => {
+    const packageJsonPath = await writePackageJson({
+      volta: { node: "24.19.0" },
+    });
+    const nodeVersion = await readNodeVersion(packageJsonPath);
+
+    expect(nodeVersion).toBe("24.19.0");
+    expect(nodeInstallSpec(nodeVersion)).toBe("node@24.19.0");
+  });
+
+  test.each([
+    ["absent", {}],
+    ["moving LTS alias", { volta: { node: "lts" } }],
+    ["partial version", { volta: { node: "24" } }],
+    ["invalid exact version", { volta: { node: "024.19.0" } }],
+  ])("rejects a pin that is %s", async (_name, packageJson: unknown) => {
+    const packageJsonPath = await writePackageJson(packageJson);
+
+    expect(readNodeVersion(packageJsonPath)).rejects.toThrow(
+      "Cannot read an exact Node pin",
+    );
+  });
+
+  test("rejects malformed JSON", async () => {
+    const directory = await createTemporaryDirectory();
+    const packageJsonPath = join(directory, "package.json");
+    await Bun.write(packageJsonPath, "{");
+
+    expect(readNodeVersion(packageJsonPath)).rejects.toThrow(
+      "Cannot read an exact Node pin",
+    );
+  });
+
+  test("rejects an unreadable package path", async () => {
+    const directory = await createTemporaryDirectory();
+
+    expect(readNodeVersion(join(directory, "missing.json"))).rejects.toThrow(
+      "Cannot read an exact Node pin",
+    );
+  });
+});
+
+describe("Node runtime", () => {
+  test("matches the repository pin through the active Volta shim", async () => {
+    const nodeVersion = await readNodeVersion(
+      fileURLToPath(new URL("../package.json", import.meta.url)),
+    );
+
+    expect(verifyNodeRuntime(nodeVersion)).resolves.toBeUndefined();
+  });
+
+  test("rejects a runtime version that diverges from the pin", async () => {
+    const directory = await createTemporaryDirectory();
+    const fakeNode = join(directory, "node");
+    await Bun.write(fakeNode, "#!/bin/sh\nprintf '%s\\n' v24.18.1\n");
+    await chmod(fakeNode, executableMode);
+    expect(verifyNodeRuntime("24.19.0", fakeNode)).rejects.toThrow(
+      "Node runtime 24.18.1 does not match project pin 24.19.0",
+    );
+  });
+
+  test("rejects an empty runtime version", async () => {
+    const directory = await createTemporaryDirectory();
+    const fakeNode = join(directory, "node");
+    await Bun.write(fakeNode, "#!/bin/sh\nexit 0\n");
+    await chmod(fakeNode, executableMode);
+    expect(verifyNodeRuntime("24.19.0", fakeNode)).rejects.toThrow();
+  });
+
+  test("keeps a failed runtime probe visible", async () => {
+    const directory = await createTemporaryDirectory();
+    const fakeNode = join(directory, "node");
+    await Bun.write(
+      fakeNode,
+      "#!/bin/sh\nprintf '%s\\n' unavailable >&2\nexit 23\n",
+    );
+    await chmod(fakeNode, executableMode);
+    expect(verifyNodeRuntime("24.19.0", fakeNode)).rejects.toThrow(
+      "node --version failed with status 23: unavailable",
+    );
+  });
+});

--- a/tooling/node-version-contract.ts
+++ b/tooling/node-version-contract.ts
@@ -1,19 +1,10 @@
 import { fileURLToPath } from "node:url";
-import { z } from "zod";
 
-const exactNodeVersionSchema = z
-  .string()
-  .regex(/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u);
-const packageJsonSchema = z.object({
-  volta: z.object({
-    node: exactNodeVersionSchema,
-  }),
-});
+const exactNodeVersionPattern =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u;
 const maximumArgumentCount = 2;
 const runtimeArgumentStart = 2;
-const argumentsSchema = z.array(z.string()).min(1).max(maximumArgumentCount);
-const commandSchema = z.enum(["install-spec", "verify-runtime"]);
-const runtimeVersionSchema = z.string().regex(/^v\d+\.\d+\.\d+$/u);
+const runtimeVersionPattern = /^v\d+\.\d+\.\d+$/u;
 
 const defaultPackageJsonPath = fileURLToPath(
   new URL("../package.json", import.meta.url),
@@ -22,7 +13,18 @@ const defaultPackageJsonPath = fileURLToPath(
 async function readNodeVersion(packageJsonPath: string): Promise<string> {
   try {
     const packageJson: unknown = await Bun.file(packageJsonPath).json();
-    return packageJsonSchema.parse(packageJson).volta.node;
+    if (
+      typeof packageJson !== "object" ||
+      packageJson === null ||
+      !("volta" in packageJson) ||
+      typeof packageJson.volta !== "object" ||
+      packageJson.volta === null ||
+      !("node" in packageJson.volta)
+    ) {
+      throw new Error("missing volta.node");
+    }
+
+    return parseExactNodeVersion(packageJson.volta.node);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(
@@ -32,8 +34,16 @@ async function readNodeVersion(packageJsonPath: string): Promise<string> {
   }
 }
 
+function parseExactNodeVersion(value: unknown): string {
+  if (typeof value !== "string" || !exactNodeVersionPattern.test(value)) {
+    throw new Error("Node version must be an exact major.minor.patch value");
+  }
+
+  return value;
+}
+
 function nodeInstallSpec(nodeVersion: string): string {
-  return `node@${exactNodeVersionSchema.parse(nodeVersion)}`;
+  return `node@${parseExactNodeVersion(nodeVersion)}`;
 }
 
 async function verifyNodeRuntime(
@@ -56,7 +66,14 @@ async function verifyNodeRuntime(
     );
   }
 
-  const runtimeVersion = runtimeVersionSchema.parse(stdout.trim()).slice(1);
+  const rawRuntimeVersion = stdout.trim();
+  if (!runtimeVersionPattern.test(rawRuntimeVersion)) {
+    throw new Error(
+      `node --version returned an invalid value: ${rawRuntimeVersion}`,
+    );
+  }
+
+  const runtimeVersion = rawRuntimeVersion.slice(1);
   if (runtimeVersion !== nodeVersion) {
     throw new Error(
       `Node runtime ${runtimeVersion} does not match project pin ${nodeVersion}`,
@@ -67,9 +84,15 @@ async function verifyNodeRuntime(
 async function runNodeVersionContract(
   args: readonly string[],
 ): Promise<string> {
-  const [rawCommand, packageJsonPath = defaultPackageJsonPath] =
-    argumentsSchema.parse(args);
-  const command = commandSchema.parse(rawCommand);
+  if (args.length === 0 || args.length > maximumArgumentCount) {
+    throw new Error("Expected a command and an optional package.json path");
+  }
+
+  const [command, packageJsonPath = defaultPackageJsonPath] = args;
+  if (command !== "install-spec" && command !== "verify-runtime") {
+    throw new Error(`Unknown command: ${command}`);
+  }
+
   const nodeVersion = await readNodeVersion(packageJsonPath);
 
   if (command === "install-spec") {

--- a/tooling/node-version-contract.ts
+++ b/tooling/node-version-contract.ts
@@ -1,0 +1,101 @@
+import { fileURLToPath } from "node:url";
+import { z } from "zod";
+
+const exactNodeVersionSchema = z
+  .string()
+  .regex(/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u);
+const packageJsonSchema = z.object({
+  volta: z.object({
+    node: exactNodeVersionSchema,
+  }),
+});
+const maximumArgumentCount = 2;
+const runtimeArgumentStart = 2;
+const argumentsSchema = z.array(z.string()).min(1).max(maximumArgumentCount);
+const commandSchema = z.enum(["install-spec", "verify-runtime"]);
+const runtimeVersionSchema = z.string().regex(/^v\d+\.\d+\.\d+$/u);
+
+const defaultPackageJsonPath = fileURLToPath(
+  new URL("../package.json", import.meta.url),
+);
+
+async function readNodeVersion(packageJsonPath: string): Promise<string> {
+  try {
+    const packageJson: unknown = await Bun.file(packageJsonPath).json();
+    return packageJsonSchema.parse(packageJson).volta.node;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Cannot read an exact Node pin from ${packageJsonPath}: ${detail}`,
+      { cause: error },
+    );
+  }
+}
+
+function nodeInstallSpec(nodeVersion: string): string {
+  return `node@${exactNodeVersionSchema.parse(nodeVersion)}`;
+}
+
+async function verifyNodeRuntime(
+  nodeVersion: string,
+  nodeExecutable = "node",
+): Promise<void> {
+  const node = Bun.spawn([nodeExecutable, "--version"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [status, stdout, stderr] = await Promise.all([
+    node.exited,
+    new Response(node.stdout).text(),
+    new Response(node.stderr).text(),
+  ]);
+
+  if (status !== 0) {
+    throw new Error(
+      `node --version failed with status ${status}: ${stderr.trim()}`,
+    );
+  }
+
+  const runtimeVersion = runtimeVersionSchema.parse(stdout.trim()).slice(1);
+  if (runtimeVersion !== nodeVersion) {
+    throw new Error(
+      `Node runtime ${runtimeVersion} does not match project pin ${nodeVersion}`,
+    );
+  }
+}
+
+async function runNodeVersionContract(
+  args: readonly string[],
+): Promise<string> {
+  const [rawCommand, packageJsonPath = defaultPackageJsonPath] =
+    argumentsSchema.parse(args);
+  const command = commandSchema.parse(rawCommand);
+  const nodeVersion = await readNodeVersion(packageJsonPath);
+
+  if (command === "install-spec") {
+    return nodeInstallSpec(nodeVersion);
+  }
+
+  await verifyNodeRuntime(nodeVersion);
+  return `Node runtime matches project pin ${nodeVersion}`;
+}
+
+if (import.meta.main) {
+  try {
+    process.stdout.write(
+      `${await runNodeVersionContract(Bun.argv.slice(runtimeArgumentStart))}\n`,
+    );
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+export {
+  nodeInstallSpec,
+  readNodeVersion,
+  runNodeVersionContract,
+  verifyNodeRuntime,
+};

--- a/tooling/node-version-installation-test-support.ts
+++ b/tooling/node-version-installation-test-support.ts
@@ -1,0 +1,188 @@
+import { chmod, cp, mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const temporaryDirectories: string[] = [];
+
+interface CommandResult {
+  readonly calls: string;
+  readonly output: string;
+  readonly status: number;
+}
+
+interface UpgradeScenario {
+  readonly failVoltaCommand?: "install" | "pin";
+  readonly includeBun?: boolean;
+  readonly includeDependencies?: boolean;
+  readonly includeVolta?: boolean;
+  readonly pinnedPackage: unknown;
+}
+
+const executableMode = 0o755;
+
+async function createTemporaryDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function writeExecutable(path: string, body: string): Promise<void> {
+  await Bun.write(path, `#!/bin/sh\n${body}\n`);
+  await chmod(path, executableMode);
+}
+
+async function createContractFixture(
+  root: string,
+  packageJson: unknown,
+  directoryName = "dotfiles",
+): Promise<string> {
+  const fixture = join(root, directoryName);
+  await mkdir(join(fixture, "tooling"), { recursive: true });
+  await cp(
+    join(repositoryRoot, "tooling/node-version-contract.ts"),
+    join(fixture, "tooling/node-version-contract.ts"),
+  );
+  await cp(join(repositoryRoot, "bun.lock"), join(fixture, "bun.lock"));
+  await Bun.write(join(fixture, "package.json"), JSON.stringify(packageJson));
+  await symlink(
+    join(repositoryRoot, "node_modules"),
+    join(fixture, "node_modules"),
+  );
+  return fixture;
+}
+
+async function run(
+  command: readonly string[],
+  environment: Readonly<Record<string, string>>,
+): Promise<Omit<CommandResult, "calls">> {
+  const child = Bun.spawn([...command], {
+    cwd: repositoryRoot,
+    env: { ...process.env, ...environment },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [status, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return { status, output: `${stdout}${stderr}` };
+}
+
+async function runMakeNode(packageJson: unknown): Promise<CommandResult> {
+  const root = await createTemporaryDirectory("node-make-");
+  const fixture = await createContractFixture(root, packageJson);
+  const bin = join(root, "bin");
+  const home = join(root, "home");
+  const voltaBin = join(home, ".volta/bin");
+  const commandLog = join(root, "volta.log");
+  await mkdir(bin, { recursive: true });
+  await mkdir(voltaBin, { recursive: true });
+  await writeExecutable(join(bin, "brew"), "exit 0");
+  await writeExecutable(
+    join(bin, "volta"),
+    String.raw`printf "%s\n" "$*" >>"$COMMAND_LOG"`,
+  );
+  await writeExecutable(
+    join(bin, "bun"),
+    'if [ "$1" = --config=/dev/null ]; then exit 0; fi\nexec "$REAL_BUN" "$@"',
+  );
+  const result = await run(
+    [
+      "make",
+      "-f",
+      join(repositoryRoot, "Makefile"),
+      "node",
+      `HOME=${home}`,
+      `BREW_BIN=${bin}`,
+      `VOLTA_BIN=${voltaBin}`,
+      `DOTFILES_PATH=${fixture}`,
+    ],
+    {
+      COMMAND_LOG: commandLog,
+      PATH: `${bin}:/usr/bin:/bin`,
+      REAL_BUN: process.execPath,
+    },
+  );
+  return {
+    ...result,
+    calls: await Bun.file(commandLog)
+      .text()
+      .catch(() => ""),
+  };
+}
+
+async function createUpgradeFakes(
+  root: string,
+  scenario: UpgradeScenario,
+): Promise<string> {
+  const bin = join(root, "bin");
+  await mkdir(bin, { recursive: true });
+  for (const command of ["brew", "mas", "npm"]) {
+    await writeExecutable(join(bin, command), "exit 0");
+  }
+  await writeExecutable(
+    join(bin, "date"),
+    String.raw`printf '%s\n' 2026-08-23T00:00:00Z`,
+  );
+  if (scenario.includeVolta !== false) {
+    await writeExecutable(
+      join(bin, "volta"),
+      String.raw`printf "%s\n" "$*" >>"$VOLTA_LOG"
+if [ "$FAIL_VOLTA_COMMAND" = "$1" ]; then printf "%s\n" "simulated $1 failure" >&2; exit 23; fi
+if [ "$1" = pin ]; then cp "$PINNED_PACKAGE" "$HOME/.dotfiles/package.json"; fi`,
+    );
+  }
+  if (scenario.includeBun !== false) {
+    await symlink(process.execPath, join(bin, "bun"));
+  }
+  return bin;
+}
+
+async function runUpgrade(scenario: UpgradeScenario): Promise<CommandResult> {
+  const root = await createTemporaryDirectory("node-upgrade-");
+  const home = join(root, "home");
+  const fixture = await createContractFixture(
+    home,
+    { volta: { node: "24.18.1" } },
+    ".dotfiles",
+  );
+  if (scenario.includeDependencies === false) {
+    await rm(join(fixture, "node_modules"));
+  }
+  const pinnedPackagePath = join(root, "pinned-package.json");
+  const voltaLog = join(root, "volta.log");
+  await Bun.write(pinnedPackagePath, JSON.stringify(scenario.pinnedPackage));
+  const bin = await createUpgradeFakes(root, scenario);
+  const result = await run([join(repositoryRoot, "tooling/upgrade")], {
+    FAIL_VOLTA_COMMAND: scenario.failVoltaCommand ?? "",
+    HOME: home,
+    PATH: `${bin}:/usr/bin:/bin`,
+    PINNED_PACKAGE: pinnedPackagePath,
+    VOLTA_LOG: voltaLog,
+  });
+  return {
+    ...result,
+    calls: await Bun.file(voltaLog)
+      .text()
+      .catch(() => ""),
+  };
+}
+
+async function cleanupNodeVersionFixtures(): Promise<void> {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true })),
+  );
+}
+
+export {
+  cleanupNodeVersionFixtures,
+  runMakeNode,
+  runUpgrade,
+  type CommandResult,
+  type UpgradeScenario,
+};

--- a/tooling/node-version-installation-test-support.ts
+++ b/tooling/node-version-installation-test-support.ts
@@ -8,6 +8,7 @@ const temporaryDirectories: string[] = [];
 
 interface CommandResult {
   readonly calls: string;
+  readonly finalPackageJson?: unknown;
   readonly output: string;
   readonly status: number;
 }
@@ -71,13 +72,19 @@ async function run(
   return { status, output: `${stdout}${stderr}` };
 }
 
-async function runMakeNode(packageJson: unknown): Promise<CommandResult> {
+async function runMakeNode(
+  packageJson: unknown,
+  includeDependencies = true,
+): Promise<CommandResult> {
   const root = await createTemporaryDirectory("node-make-");
   const fixture = await createContractFixture(root, packageJson);
   const bin = join(root, "bin");
   const home = join(root, "home");
   const voltaBin = join(home, ".volta/bin");
   const commandLog = join(root, "volta.log");
+  if (!includeDependencies) {
+    await rm(join(fixture, "node_modules"));
+  }
   await mkdir(bin, { recursive: true });
   await mkdir(voltaBin, { recursive: true });
   await writeExecutable(join(bin, "brew"), "exit 0");
@@ -132,7 +139,7 @@ async function createUpgradeFakes(
       join(bin, "volta"),
       String.raw`printf "%s\n" "$*" >>"$VOLTA_LOG"
 if [ "$FAIL_VOLTA_COMMAND" = "$1" ]; then printf "%s\n" "simulated $1 failure" >&2; exit 23; fi
-if [ "$1" = pin ]; then cp "$PINNED_PACKAGE" "$HOME/.dotfiles/package.json"; fi`,
+if [ "$1" = pin ]; then cp "$PINNED_PACKAGE" package.json; fi`,
     );
   }
   if (scenario.includeBun !== false) {
@@ -168,6 +175,7 @@ async function runUpgrade(scenario: UpgradeScenario): Promise<CommandResult> {
     calls: await Bun.file(voltaLog)
       .text()
       .catch(() => ""),
+    finalPackageJson: await Bun.file(join(fixture, "package.json")).json(),
   };
 }
 

--- a/tooling/node-version-installation.test.ts
+++ b/tooling/node-version-installation.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  cleanupNodeVersionFixtures,
+  runMakeNode,
+  runUpgrade,
+} from "./node-version-installation-test-support";
+
+afterEach(cleanupNodeVersionFixtures);
+
+describe("Makefile Node installation", () => {
+  test("passes the exact project pin to Volta", async () => {
+    const result = await runMakeNode({ volta: { node: "24.18.1" } });
+
+    expect(result.status).toBe(0);
+    expect(result.calls).toBe("install node@24.18.1\n");
+  });
+
+  test("fails closed when the project pin is absent", async () => {
+    const result = await runMakeNode({});
+
+    expect(result.status).not.toBe(0);
+    expect(result.calls).toBe("");
+    expect(result.output).toContain("Cannot read an exact Node pin");
+  });
+});
+
+describe("Node upgrade", () => {
+  test("pins the current LTS before installing the resolved exact version", async () => {
+    const result = await runUpgrade({
+      pinnedPackage: { volta: { node: "24.19.0" } },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.calls).toBe("pin node@lts\ninstall node@24.19.0\n");
+  });
+
+  test("fails closed when Volta produces an invalid pin", async () => {
+    const result = await runUpgrade({
+      pinnedPackage: { volta: { node: "lts" } },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.calls).toBe("pin node@lts\n");
+    expect(result.output).toContain("invalid Node.js project pin");
+  });
+
+  test("fails closed when the pin validator cannot run", async () => {
+    const result = await runUpgrade({
+      includeBun: false,
+      pinnedPackage: { volta: { node: "24.19.0" } },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.calls).toBe("");
+    expect(result.output).toContain(
+      "bun not found, unable to validate the Node.js pin",
+    );
+  });
+
+  test("fails closed when the pin validator dependencies are missing", async () => {
+    const result = await runUpgrade({
+      includeDependencies: false,
+      pinnedPackage: { volta: { node: "24.19.0" } },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.calls).toBe("");
+    expect(result.output).toContain(
+      "Node.js pin validator dependencies missing",
+    );
+  });
+});
+
+describe("Node upgrade command failures", () => {
+  test("fails closed when Volta cannot update the project pin", async () => {
+    const result = await runUpgrade({
+      failVoltaCommand: "pin",
+      pinnedPackage: { volta: { node: "24.19.0" } },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.calls).toBe("pin node@lts\n");
+    expect(result.output).toContain("unable to update the Node.js project pin");
+  });
+
+  test("fails closed when Volta cannot install the exact project pin", async () => {
+    const result = await runUpgrade({
+      failVoltaCommand: "install",
+      pinnedPackage: { volta: { node: "24.19.0" } },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.calls).toBe("pin node@lts\ninstall node@24.19.0\n");
+    expect(result.output).toContain(
+      "unable to install the pinned Node.js version",
+    );
+  });
+
+  test("fails closed when Volta is missing", async () => {
+    const result = await runUpgrade({
+      includeVolta: false,
+      pinnedPackage: { volta: { node: "24.19.0" } },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.calls).toBe("");
+    expect(result.output).toContain(
+      "volta not found, unable to upgrade Node.js",
+    );
+  });
+});

--- a/tooling/node-version-installation.test.ts
+++ b/tooling/node-version-installation.test.ts
@@ -15,6 +15,13 @@ describe("Makefile Node installation", () => {
     expect(result.calls).toBe("install node@24.18.1\n");
   });
 
+  test("does not bootstrap repository dependencies to read the pin", async () => {
+    const result = await runMakeNode({ volta: { node: "24.18.1" } }, false);
+
+    expect(result.status).toBe(0);
+    expect(result.calls).toBe("install node@24.18.1\n");
+  });
+
   test("fails closed when the project pin is absent", async () => {
     const result = await runMakeNode({});
 
@@ -32,6 +39,7 @@ describe("Node upgrade", () => {
 
     expect(result.status).toBe(0);
     expect(result.calls).toBe("pin node@lts\ninstall node@24.19.0\n");
+    expect(result.finalPackageJson).toEqual({ volta: { node: "24.19.0" } });
   });
 
   test("fails closed when Volta produces an invalid pin", async () => {
@@ -42,6 +50,7 @@ describe("Node upgrade", () => {
     expect(result.status).toBe(1);
     expect(result.calls).toBe("pin node@lts\n");
     expect(result.output).toContain("invalid Node.js project pin");
+    expect(result.finalPackageJson).toEqual({ volta: { node: "24.18.1" } });
   });
 
   test("fails closed when the pin validator cannot run", async () => {
@@ -57,17 +66,14 @@ describe("Node upgrade", () => {
     );
   });
 
-  test("fails closed when the pin validator dependencies are missing", async () => {
+  test("does not require repository dependencies to validate the pin", async () => {
     const result = await runUpgrade({
       includeDependencies: false,
       pinnedPackage: { volta: { node: "24.19.0" } },
     });
 
-    expect(result.status).toBe(1);
-    expect(result.calls).toBe("");
-    expect(result.output).toContain(
-      "Node.js pin validator dependencies missing",
-    );
+    expect(result.status).toBe(0);
+    expect(result.calls).toBe("pin node@lts\ninstall node@24.19.0\n");
   });
 });
 
@@ -94,6 +100,7 @@ describe("Node upgrade command failures", () => {
     expect(result.output).toContain(
       "unable to install the pinned Node.js version",
     );
+    expect(result.finalPackageJson).toEqual({ volta: { node: "24.18.1" } });
   });
 
   test("fails closed when Volta is missing", async () => {

--- a/tooling/upgrade
+++ b/tooling/upgrade
@@ -47,10 +47,29 @@ mas outdated
 mas upgrade
 
 echo "ℹ️  Volta Node.js upgrade"
-if command -v volta &> /dev/null; then
-  volta install node
+if ! command -v volta &> /dev/null; then
+  echo "  Warning: volta not found, unable to upgrade Node.js"
+  upgrade_status=1
+elif ! command -v bun &> /dev/null; then
+  echo "  Warning: bun not found, unable to validate the Node.js pin"
+  upgrade_status=1
+elif [[ ! -f $dotfiles_repo/tooling/node-version-contract.ts ]]; then
+  echo "  Warning: Node.js pin validator not found, unable to upgrade Node.js"
+  upgrade_status=1
+elif [[ ! -f $dotfiles_repo/node_modules/zod/package.json ]]; then
+  echo "  Warning: Node.js pin validator dependencies missing, unable to upgrade Node.js"
+  upgrade_status=1
+elif ! (cd "$dotfiles_repo" && volta pin node@lts); then
+  echo "  Warning: unable to update the Node.js project pin"
+  upgrade_status=1
+elif node_install_spec=$(bun --no-install "$dotfiles_repo/tooling/node-version-contract.ts" install-spec); then
+  if ! volta install "$node_install_spec"; then
+    echo "  Warning: unable to install the pinned Node.js version"
+    upgrade_status=1
+  fi
 else
-  echo "  Warning: volta not found, skipping Node.js upgrade"
+  echo "  Warning: invalid Node.js project pin, unable to install Node.js"
+  upgrade_status=1
 fi
 
 echo "ℹ️  npm global packages upgrade"

--- a/tooling/upgrade
+++ b/tooling/upgrade
@@ -47,6 +47,7 @@ mas outdated
 mas upgrade
 
 echo "ℹ️  Volta Node.js upgrade"
+node_pin_stage=
 if ! command -v volta &> /dev/null; then
   echo "  Warning: volta not found, unable to upgrade Node.js"
   upgrade_status=1
@@ -56,20 +57,29 @@ elif ! command -v bun &> /dev/null; then
 elif [[ ! -f $dotfiles_repo/tooling/node-version-contract.ts ]]; then
   echo "  Warning: Node.js pin validator not found, unable to upgrade Node.js"
   upgrade_status=1
-elif [[ ! -f $dotfiles_repo/node_modules/zod/package.json ]]; then
-  echo "  Warning: Node.js pin validator dependencies missing, unable to upgrade Node.js"
+elif ! node_pin_stage=$(mktemp -d "$dotfiles_repo/.node-pin.XXXXXX"); then
+  echo "  Warning: unable to stage the Node.js project pin"
   upgrade_status=1
-elif ! (cd "$dotfiles_repo" && volta pin node@lts); then
+elif ! cp "$dotfiles_repo/package.json" "$node_pin_stage/package.json"; then
+  echo "  Warning: unable to stage the Node.js project metadata"
+  upgrade_status=1
+elif ! (cd "$node_pin_stage" && volta pin node@lts); then
   echo "  Warning: unable to update the Node.js project pin"
   upgrade_status=1
-elif node_install_spec=$(bun --no-install "$dotfiles_repo/tooling/node-version-contract.ts" install-spec); then
+elif node_install_spec=$(bun --no-install "$dotfiles_repo/tooling/node-version-contract.ts" install-spec "$node_pin_stage/package.json"); then
   if ! volta install "$node_install_spec"; then
     echo "  Warning: unable to install the pinned Node.js version"
+    upgrade_status=1
+  elif ! mv "$node_pin_stage/package.json" "$dotfiles_repo/package.json"; then
+    echo "  Warning: unable to save the Node.js project pin"
     upgrade_status=1
   fi
 else
   echo "  Warning: invalid Node.js project pin, unable to install Node.js"
   upgrade_status=1
+fi
+if [[ -n $node_pin_stage ]]; then
+  rm -rf "$node_pin_stage"
 fi
 
 echo "ℹ️  npm global packages upgrade"

--- a/tooling/upgrade-test
+++ b/tooling/upgrade-test
@@ -6,6 +6,8 @@ upgrade=$tooling_dir/upgrade
 main_branch_helper=$tooling_dir/git-main-branch
 main_branch_cli=$tooling_dir/git-main-branch-cli.ts
 main_branch_core=$tooling_dir/git-main-branch-core.ts
+node_version_contract=$tooling_dir/node-version-contract.ts
+package_json=$tooling_dir/../package.json
 test_root=$(mktemp -d "${TMPDIR:-/tmp}/upgrade-test.XXXXXX")
 trap 'rm -rf "$test_root"' EXIT
 
@@ -28,6 +30,9 @@ git_log=$test_root/git.log
 command_log=$test_root/command.log
 mkdir -p "$repository/tooling" "$repository/home/.config/nvim" "$mock_bin"
 cp "$upgrade" "$main_branch_helper" "$main_branch_cli" "$main_branch_core" "$repository/tooling/"
+cp "$node_version_contract" "$repository/tooling/"
+cp "$package_json" "$repository/"
+ln -s "$tooling_dir/../node_modules" "$repository/node_modules"
 printf 'base\n' >"$repository/home/.config/nvim/lazy-lock.json"
 
 "$real_git" init --bare -q "$remote"
@@ -100,6 +105,8 @@ assert_equal "$("$real_git" -C "$repository" show --format= --name-only HEAD)" "
 assert_equal "$(cat "$git_log")" $'pull\ncommit' "unexpected main Git mutations"
 grep -Fxq 'npm update -g --before=2026-08-13T00:00:00Z --min-release-age-exclude=@openai/codex' "$command_log" ||
   fail "npm quarantine does not exempt Codex"
+grep -Fxq 'volta pin node@lts' "$command_log" || fail "Volta does not refresh the project Node pin"
+grep -Fxq 'volta install node@24.19.0' "$command_log" || fail "Volta does not install the exact project Node pin"
 grep -Fxq 'claude update' "$command_log" || fail "Claude update is not independent from npm"
 
 "$real_git" -C "$repository" checkout -q -B feature-test origin/main


### PR DESCRIPTION
## Description

- declare Node 24.19.0 as the exact project-scoped Volta pin
- derive Makefile installation and upgrade defaults from the validated project pin
- fail closed when the pin, validator, runtime, or Volta commands are invalid or unavailable
- stage upgrades so canonical metadata changes only after validation and installation succeed
- verify the active Node runtime in CI through Volta
- clarify ADR-016 without changing its accepted decision

Closes #231.

## Useful Links

- Issue: #231
- Volta project pins: https://docs.volta.sh/guide/
- Volta pin command: https://docs.volta.sh/reference/pin
- Volta install command: https://docs.volta.sh/reference/install

## How to Test

```sh
bun run format:typescript:check
bun run lint
bun run typecheck
bun test --timeout 20000
tooling/upgrade-test
shellcheck --severity=error tooling/upgrade tooling/upgrade-test
bun --no-install tooling/node-version-contract.ts verify-runtime
make -n -B node
```

Local evidence: macOS 26.6.2 arm64, Bun 1.4.0, Node 24.19.0, Volta 2.0.2; 324 tests passed and 4 explicit integration tests skipped. Real global installation was not executed from the worktree; Make behavior is covered by dry-runs and fake-process integration tests, while CI verifies the real Volta-selected runtime.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes
