### PR TITLE
feat(linear): reconcile checkbox evidence

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -142,6 +142,7 @@ jobs:
       - name: Check text syntax and formatting
         run: >-
           prettier --check .github/ISSUE_TEMPLATE/change.yml .github/dependabot.yml
+          .github/workflows/lint.yml
           package.json tsconfig.json
           docs/AGENTS.md docs/ARCHITECTURE.md
           harness/skills/obsidian-retrieval/SKILL.md
@@ -160,6 +161,7 @@ jobs:
           harness/skills/linear-issue-spec/SKILL.md
           harness/skills/linear-start/SKILL.md
           harness/skills/linear-sync/SKILL.md
+          harness/skills/linear-sync/references/checkbox-evidence.md
           harness/skills/linear-workflow/SKILL.md
           harness/skills/linear-workflow/references/bitbucket.md
           harness/skills/linear-workflow/references/transports.md
@@ -184,6 +186,7 @@ jobs:
             harness/skills/linear-issue-spec/SKILL.md \
             harness/skills/linear-start/SKILL.md \
             harness/skills/linear-sync/SKILL.md \
+            harness/skills/linear-sync/references/checkbox-evidence.md \
             harness/skills/linear-workflow/SKILL.md \
             harness/skills/linear-workflow/references/bitbucket.md \
             harness/skills/linear-workflow/references/transports.md \

--- a/harness/skills/README.md
+++ b/harness/skills/README.md
@@ -20,7 +20,7 @@ This directory is the canonical source for user-scoped agent skills.
 | `harness-reflection`         | Turn repeated agent failures into evidence-backed harness improvements.                              |
 | `issue-creation`             | Draft, validate, review, and publish tracker issues across forges.                                   |
 | `linear-start`               | Start or resume implementation of an assigned Linear issue in a Bitbucket repository.                |
-| `linear-sync`                | Reconcile assigned Linear issues with Bitbucket pull-request reality without reviewing code.         |
+| `linear-sync`                | Reconcile assigned Linear issues with Bitbucket pull-request and checklist evidence.                 |
 | `linear-workflow`            | Apply the shared Linear and Bitbucket work invariants.                                               |
 | `pr-fix`                     | Repair an open pull request after an independent merge review.                                       |
 | `pr-verdict`                 | Deliver a PR verdict on an open pull request, yours or another author's.                             |

--- a/harness/skills/linear-sync/SKILL.md
+++ b/harness/skills/linear-sync/SKILL.md
@@ -5,7 +5,9 @@ description: >
   user asks to synchronize lifecycle state, check proven items, or repair missing pull-request
   links. Make sure to use this skill whenever merged work should close an issue or its checkboxes
   must reflect evidence.
-compatibility: Requires Git, bkt, and an authenticated Linear transport with read and write access.
+compatibility: >
+  Requires an authenticated Linear transport with read and write access; Git and bkt are required
+  for lifecycle or pull-request link reconciliation.
 metadata:
   category: dev
 ---
@@ -22,10 +24,12 @@ manual reconciliation workflow, not a code review, implementation audit, or issu
 
 `/linear-sync`
 
-Run from the Bitbucket repository whose assigned Linear issues should be reconciled. The current
-repository scopes branch-based discovery; an attached canonical pull-request URL may identify a
-different repository explicitly. Report only applied transitions, repaired pull-request
-attachments, unresolved inconsistencies, and relevant issues that were already synchronized.
+Run lifecycle or link reconciliation from the Bitbucket repository whose assigned Linear issues
+should be reconciled. A request limited to an explicitly identified issue's checklist does not
+require repository discovery. The current repository scopes branch-based discovery; an attached
+canonical pull-request URL may identify a different repository explicitly. Report only applied
+transitions, checklist edits, repaired pull-request attachments, unresolved inconsistencies, and
+relevant issues that were already synchronized.
 
 ## Workflow
 
@@ -34,12 +38,13 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
    another integration. Verify current command schemas and authentication before reads or writes,
    and stop before any operation that the available transports do not cover.
 
-2. **Establish identity and repository scope.** Retrieve the current Linear identity. Resolve the
-   current Bitbucket repository from Git remotes and verify its workspace and repository slug with
-   `bkt`; never trust the active `bkt` context alone. Consider only Linear issues assigned to that
-   identity as synchronization candidates. Treat the resolved repository as the only scope for
-   branch-based discovery; when a canonical attachment identifies another repository, verify that
-   repository independently before reading its pull request.
+2. **Establish identity and required scope.** Retrieve the current Linear identity and consider only
+   issues assigned to it. For a request limited to checkbox evidence on an explicitly identified
+   issue, skip Git and Bitbucket discovery. Otherwise resolve the current Bitbucket repository from
+   Git remotes and verify its workspace and repository slug with `bkt`; never trust the active `bkt`
+   context alone. Treat the resolved repository as the only scope for branch-based discovery; when
+   a canonical attachment identifies another repository, verify that repository independently
+   before reading its pull request.
 
 3. **Read structured Linear facts.** Exhaust result pages while retrieving assigned candidates with
    their identifiers, workflow states, parents, direct sub-issues, blocking relations, links or
@@ -48,11 +53,11 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
    sub-issue when needed to decide whether an assigned parent is complete; never mutate or report
    that sub-issue as a candidate.
 
-4. **Reconcile evidence conditionally.** When the user asks to update checkboxes, or an issue being
-   completed contains a task list or a section that claims to track completion evidence, read and
-   apply [checkbox evidence](references/checkbox-evidence.md). Each checkbox has its own evidence
-   oracle. Reconcile it independently from workflow state, and do not inspect implementation or
-   run a new functional review to manufacture missing proof.
+4. **Reconcile explicitly requested evidence.** Only when the user explicitly asks to update
+   checkboxes or an entire evidence section, read and apply
+   [checkbox evidence](references/checkbox-evidence.md). Each checkbox has its own evidence oracle.
+   Reconcile it independently from workflow state, and do not inspect implementation or run a new
+   functional review to manufacture missing proof.
 
 5. **Resolve exact issue-to-work associations.** Prefer a canonical Bitbucket pull-request URL in
    Linear's structured links or attachments. Otherwise accept an exact issue identifier at the
@@ -70,11 +75,12 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
 
 7. **Complete assigned leaf issues from merged work.** For each assigned leaf with a certain linked
    Bitbucket pull request, read its state from Bitbucket. A merged state proves only the lifecycle
-   transition: move the issue to `Done` and verify the state by an independent Linear read even when
-   evidence checkboxes legitimately remain open. Preserve and name every unchecked residue in the
-   reconciliation result. Do not inspect the diff, rerun tests, invoke `pr-verdict`, or perform a
-   functional review. Several assigned leaves may transition from the same merged pull request only
-   when each association is explicit and certain.
+   transition. Before the state write, when the description contains a task list or evidence
+   section, read [checkbox evidence](references/checkbox-evidence.md), inspect it without mutating
+   it, and record every unchecked or untracked residue. Move the issue to `Done` and verify the
+   state by an independent Linear read even when that residue remains. Do not inspect the diff,
+   rerun tests, invoke `pr-verdict`, or perform a functional review. Several assigned leaves may
+   transition from the same merged pull request only when each association is explicit and certain.
 
 8. **Evaluate assigned parents from child state.** After leaf transitions are verified, process
    assigned parents bottom-up and re-read each parent with every direct sub-issue. A parent whose
@@ -128,6 +134,8 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
 - Never inspect implementation, review a diff, rerun functional checks, or invoke a review skill.
 - Never check an item from issue status, pull-request state, a generic green pipeline, or a desire
   to make the issue look complete; require item-specific evidence.
+- Never mutate a checkbox or evidence section unless the user explicitly requested that description
+  reconciliation; lifecycle synchronization alone authorizes only inspection and reporting.
 - Never rewrite a complete Linear description to change checklist markers when a verified targeted
   patch transport is available.
 - Never transition an issue from title similarity, prose, an ambiguous link, or an unverified

--- a/harness/skills/linear-sync/SKILL.md
+++ b/harness/skills/linear-sync/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: linear-sync
 description: >
-  Reconcile assigned Linear issues with Bitbucket pull-request reality without reviewing code. Use
-  when the user manually asks to synchronize Linear lifecycle state or repair missing pull-request
-  links. Make sure to use this skill whenever merged Bitbucket work should close Linear issues.
+  Reconcile assigned Linear issues with Bitbucket pull-request and checklist evidence. Use when the
+  user asks to synchronize lifecycle state, check proven items, or repair missing pull-request
+  links. Make sure to use this skill whenever merged work should close an issue or its checkboxes
+  must reflect evidence.
 compatibility: Requires Git, bkt, and an authenticated Linear transport with read and write access.
 metadata:
   category: dev
@@ -13,9 +14,9 @@ metadata:
 
 ## Overview
 
-Synchronize lifecycle facts for the current user's Linear issues from authoritative Linear and
-Bitbucket state. This is a manual reconciliation workflow, not a code review, implementation audit,
-or issue-shaping pass.
+Synchronize lifecycle facts and explicitly requested checklist evidence for the current user's
+Linear issues from authoritative Linear, Bitbucket, and supplied verification state. This is a
+manual reconciliation workflow, not a code review, implementation audit, or issue-shaping pass.
 
 ## Usage
 
@@ -41,12 +42,19 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
    repository independently before reading its pull request.
 
 3. **Read structured Linear facts.** Exhaust result pages while retrieving assigned candidates with
-   their identifiers, workflow states, parents, direct sub-issues, blocking relations, and links or
-   attachments. Read only the assignee and workflow state of an unassigned direct sub-issue when
-   needed to decide whether an assigned parent is complete; never mutate or report that sub-issue
-   as a candidate.
+   their identifiers, workflow states, parents, direct sub-issues, blocking relations, links or
+   attachments. Read the description when checklist reconciliation was requested or before a
+   transition to `Done`. Read only the assignee and workflow state of an unassigned direct
+   sub-issue when needed to decide whether an assigned parent is complete; never mutate or report
+   that sub-issue as a candidate.
 
-4. **Resolve exact issue-to-work associations.** Prefer a canonical Bitbucket pull-request URL in
+4. **Reconcile evidence conditionally.** When the user asks to update checkboxes, or an issue being
+   completed contains a task list or a section that claims to track completion evidence, read and
+   apply [checkbox evidence](references/checkbox-evidence.md). Each checkbox has its own evidence
+   oracle. Reconcile it independently from workflow state, and do not inspect implementation or
+   run a new functional review to manufacture missing proof.
+
+5. **Resolve exact issue-to-work associations.** Prefer a canonical Bitbucket pull-request URL in
    Linear's structured links or attachments. Otherwise accept an exact issue identifier at the
    start of a source branch shaped `<ISSUE-ID>-<slug>`, after verifying the branch or pull request
    belongs to the resolved repository. Accept another signal only when structured metadata
@@ -54,20 +62,21 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
    for reporting, but never proves an association or authorizes a write. Record zero, one, and
    multiple exact matches as distinct outcomes.
 
-5. **Repair certain attachments.** When an exact branch or explicit metadata proves a single
+6. **Repair certain attachments.** When an exact branch or explicit metadata proves a single
    issue-to-pull-request association and Linear lacks its canonical URL, attach that URL once.
    Independently read the issue back and verify the stored link. A failed attachment is a partial
    synchronization failure; preserve the Bitbucket state and retry only the idempotent Linear link
    operation.
 
-6. **Complete assigned leaf issues from merged work.** For each assigned leaf with a certain linked
-   Bitbucket pull request, read its state from Bitbucket. A merged state is sufficient completion
-   proof: move the issue to `Done` and verify the state by an independent Linear read. Do not inspect
-   the diff, rerun tests, invoke `pr-verdict`, or perform a functional review. Several assigned
-   leaves may transition from the same merged pull request only when each association is explicit
-   and certain.
+7. **Complete assigned leaf issues from merged work.** For each assigned leaf with a certain linked
+   Bitbucket pull request, read its state from Bitbucket. A merged state proves only the lifecycle
+   transition: move the issue to `Done` and verify the state by an independent Linear read even when
+   evidence checkboxes legitimately remain open. Preserve and name every unchecked residue in the
+   reconciliation result. Do not inspect the diff, rerun tests, invoke `pr-verdict`, or perform a
+   functional review. Several assigned leaves may transition from the same merged pull request only
+   when each association is explicit and certain.
 
-7. **Evaluate assigned parents from child state.** After leaf transitions are verified, process
+8. **Evaluate assigned parents from child state.** After leaf transitions are verified, process
    assigned parents bottom-up and re-read each parent with every direct sub-issue. A parent whose
    direct sub-issues are all `Done` is eligible for completion. Transition it automatically only
    when the selected Linear transport documents one atomic conditional mutation that writes `Done`
@@ -77,7 +86,7 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
    not infer completion from the parent description, pull-request title, or partial child set, and
    do not review the work again.
 
-8. **Surface inconsistent active work.** For an assigned `In Progress` issue explicitly associated
+9. **Surface inconsistent active work.** For an assigned `In Progress` issue explicitly associated
    with the resolved repository, search exact attachments, exact issue-prefixed pull-request source
    branches, and exact issue-prefixed remote branches there. When none identifies Bitbucket work,
    report the observed repository, branch, pull-request, attachment, and blocking-relation facts and
@@ -86,11 +95,12 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
    omit it unless conflicting explicit signals make it a relevant ambiguity. When evidence is
    ambiguous, report every conflicting fact and make no lifecycle or attachment write.
 
-9. **Return a concise reconciliation.** Include only transitions applied, attachments repaired,
-   inconsistencies or ambiguities requiring a human decision, and relevant issues already in the
-   state proven by the same oracle. Name partial failures. End with an automation assessment based
-   on observed repeated usage; absent evidence of a stable reliable trigger, state that automation
-   is not yet justified.
+10. **Return a concise reconciliation.** Include only transitions applied, checklist edits with
+    their evidence, unchecked or untracked evidence residue, attachments repaired, inconsistencies
+    or ambiguities requiring a human decision, and relevant issues already in the state proven by
+    the same oracle. Name partial failures. End with an automation assessment based on observed
+    repeated usage; absent evidence of a stable reliable trigger, state that automation is not yet
+    justified.
 
 ## Gotchas
 
@@ -109,11 +119,17 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
   require explicit repository scope before reporting the inconsistency.
 - **Retrying the whole synchronization after a partial write** — verified transitions or links are
   repeated unnecessarily; re-read both systems and retry only the failed idempotent operation.
+- **Cleaning the checklist when closing the issue** — unchecked claims become false assertions;
+  keep workflow state and checkbox evidence independent and report the remaining items.
 
 ## Constraints
 
 - Never mutate or report as a candidate an issue not assigned to the current Linear identity.
 - Never inspect implementation, review a diff, rerun functional checks, or invoke a review skill.
+- Never check an item from issue status, pull-request state, a generic green pipeline, or a desire
+  to make the issue look complete; require item-specific evidence.
+- Never rewrite a complete Linear description to change checklist markers when a verified targeted
+  patch transport is available.
 - Never transition an issue from title similarity, prose, an ambiguous link, or an unverified
   repository context.
 - Never auto-transition a parent through a separate read followed by an unconditional state update.

--- a/harness/skills/linear-sync/references/checkbox-evidence.md
+++ b/harness/skills/linear-sync/references/checkbox-evidence.md
@@ -3,6 +3,10 @@
 Load this procedure only when an issue description contains a task list or a section intended to
 track completion evidence, or when the user explicitly asks to reconcile checkboxes.
 
+Without an explicit request to reconcile checkboxes or the whole evidence section, use only the
+evidence and status-independence rules to inspect and report residue. Do not enter the conversion or
+safe-edit procedures.
+
 ## Evidence oracle
 
 1. Treat each checked item as a claim that the exact statement on that line is established.

--- a/harness/skills/linear-sync/references/checkbox-evidence.md
+++ b/harness/skills/linear-sync/references/checkbox-evidence.md
@@ -1,0 +1,81 @@
+# Linear Checkbox Evidence
+
+Load this procedure only when an issue description contains a task list or a section intended to
+track completion evidence, or when the user explicitly asks to reconcile checkboxes.
+
+## Evidence oracle
+
+1. Treat each checked item as a claim that the exact statement on that line is established.
+2. Check it only from item-specific, observed evidence, such as:
+   - a named test that exercises the stated scenario and a green result from the relevant commit
+     and environment;
+   - the requested measurement and its recorded result;
+   - a directly observed manual result or durable artifact that establishes the whole claim.
+3. A merge, `Done` state, implemented code, test existence without an executed result, generic green
+   CI that does not exercise the claim, plan, expectation, or request for a tidy issue is not enough.
+4. Keep an item unchecked when proof is missing, partial, stale, from an irrelevant environment, or
+   unable to establish every part of the claim. Name the missing proof rather than inferring it.
+5. Preserve already checked items unless current evidence disproves them or the user explicitly asks
+   for a fresh audit and their proof cannot be recovered. Do not turn absence of evidence in the
+   current session into evidence of absence.
+
+## Status independence
+
+- Workflow state and checkbox state have separate oracles. Never check items because the issue is
+  closing, and never block a proven lifecycle transition solely to make the checklist reach 100%.
+- An issue may be `Done` with unchecked items. Leave those markers unchanged and list each residue,
+  with its missing proof, in the reconciliation result.
+- Do not hide residue by deleting an item, weakening its wording, moving it out of a task list, or
+  replacing the section with a completion summary.
+- Treat `- [x]` and `- [X]` as equivalent checked markers. Linear may normalize the stored form to
+  uppercase; marker case is not an invariant.
+
+## Non-checklist evidence sections
+
+A plain bullet list has no per-item completion state even when its heading says `Completion
+evidence` or similar. Never report such a section as reconciled merely because its claims appear in
+the issue.
+
+When the user authorized evidence reconciliation for the whole section, convert each plain evidence
+bullet to a task-list item without changing its text, then apply the evidence oracle: checked only
+when proven, unchecked otherwise. When the request covers only existing checkboxes, the bullets are
+ambiguous, or preserving their meaning is uncertain, leave the section unchanged and report that it
+has no checkable state.
+
+## Safe description edits
+
+1. Retrieve the latest issue description immediately before editing.
+2. Inspect the selected Linear transport's current schema. Use `save_issue.patch` when it exposes
+   targeted operations shaped like:
+
+   ```json
+   {
+     "id": "ISSUE-ID",
+     "patch": [
+       {
+         "op": "replace",
+         "old_string": "- [ ] Exact claim",
+         "new_string": "- [X] Exact claim"
+       }
+     ]
+   }
+   ```
+
+3. Give every `replace` a non-empty `old_string` that occurs exactly once in the latest description.
+   Include enough surrounding text to make the anchor unique; never set `replace_all` for a
+   checkbox edit.
+4. Patch only the intended list markers or bullet prefixes. Preserve all untouched serialized
+   content byte-for-byte, especially issue mentions shaped as
+   `<issue id="…" href="…">TEAM-123</issue>`.
+5. If the transport lacks targeted patching, stop and report the limitation instead of manually
+   reconstructing and overwriting the entire description.
+6. Retrieve the issue again after the write. Verify every intended item, all remaining residue, and
+   the preservation of surrounding text and serialized mentions. Treat Linear's `[X]` normalization
+   as equivalent to the submitted checked marker.
+
+## Constraints
+
+- Never check an item without evidence that establishes that exact item.
+- Never derive checkbox state from issue or pull-request state.
+- Never overwrite the complete description for a marker-only edit.
+- Never claim a plain bullet list has been reconciled as completion state.


### PR DESCRIPTION
## Description

- Route Linear checkbox evidence reconciliation through `linear-sync`.
- Keep issue status independent from per-item proof, including legitimate unchecked residue on `Done` issues.
- Document safe `save_issue.patch` edits and preserve serialized issue mentions.
- Add the new reference and the workflow itself to the existing Prettier and cspell gates.

## Useful Links

- Issue: N/A

## How to Test

- Run the `skill-manager doctor linear-sync` checks.
- Run the text-formatting gates from `.github/workflows/lint.yml`.
- Run the cspell gate from `.github/workflows/lint.yml`.
- Push normally and let the pre-push hook run lint TypeScript and typecheck on the exact commit.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
