### PR TITLE
feat(skills): gate Linear completion on checkbox evidence

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -162,6 +162,7 @@ jobs:
           harness/skills/linear-sync/SKILL.md
           harness/skills/linear-workflow/SKILL.md
           harness/skills/linear-workflow/references/bitbucket.md
+          harness/skills/linear-workflow/references/completion-evidence.md
           harness/skills/linear-workflow/references/transports.md
 
       - name: Check configuration and user dictionary
@@ -186,6 +187,7 @@ jobs:
             harness/skills/linear-sync/SKILL.md \
             harness/skills/linear-workflow/SKILL.md \
             harness/skills/linear-workflow/references/bitbucket.md \
+            harness/skills/linear-workflow/references/completion-evidence.md \
             harness/skills/linear-workflow/references/transports.md \
             harness/skills/obsidian-retrieval/SKILL.md \
             harness/skills/obsidian-retrieval/references/obsidian-cli.md \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -142,6 +142,7 @@ jobs:
       - name: Check text syntax and formatting
         run: >-
           prettier --check .github/ISSUE_TEMPLATE/change.yml .github/dependabot.yml
+          .github/workflows/lint.yml
           package.json tsconfig.json
           docs/AGENTS.md docs/ARCHITECTURE.md
           harness/skills/obsidian-retrieval/SKILL.md

--- a/harness/skills/linear-start/SKILL.md
+++ b/harness/skills/linear-start/SKILL.md
@@ -67,7 +67,9 @@ planning without an actual request to begin implementation.
 
 8. **Limit lifecycle maintenance.** Verify each Linear write by reading the changed issue field or
    link back. Do not perform extra review, functional analysis, issue rewriting, or status ceremony
-   solely to keep Linear synchronized.
+   solely to keep Linear synchronized. A request to check off completed items in the description is
+   an evidence decision, not lifecycle maintenance: follow the shared completion-evidence rule and
+   check only lines a named run proves.
 
 ## Gotchas
 

--- a/harness/skills/linear-start/SKILL.md
+++ b/harness/skills/linear-start/SKILL.md
@@ -68,8 +68,8 @@ planning without an actual request to begin implementation.
 8. **Limit lifecycle maintenance.** Verify each Linear write by reading the changed issue field or
    link back. Do not perform extra review, functional analysis, issue rewriting, or status ceremony
    solely to keep Linear synchronized. A request to check off completed items in the description is
-   an evidence decision, not lifecycle maintenance: follow the shared completion-evidence rule and
-   check only lines a named run proves.
+   an evidence decision, not lifecycle maintenance: follow `linear-workflow`'s
+   `references/completion-evidence.md` and check only lines a named run proves.
 
 ## Gotchas
 

--- a/harness/skills/linear-sync/SKILL.md
+++ b/harness/skills/linear-sync/SKILL.md
@@ -68,11 +68,10 @@ were already synchronized.
    all checked, or no evidence section at all, moves the issue to `Done`; at least one unchecked
    line, or an evidence section that holds no state, moves it to its team's review state instead,
    with the unproven lines named as residue. Guard the state write with the classification it rests
-   on, following the anchored guard in `completion-evidence.md`: a box that moved must abort the
-   save before any state is written, because a post-write read confirms the state and never that the
-   boxes still say what they said. Where a transport cannot carry the guard and the state in one
-   save, re-read the description immediately before the write, leave the issue untouched when it
-   changed, and report the window between that read and the write as unguarded. Verify either
+   on, following the anchored guard in `completion-evidence.md`: text that moved must abort the save
+   before any state is written, because a post-write read confirms the state and never that the
+   boxes still say what they said. Where that guard is uncovered, write no state — report the
+   classification and the missing capability, and leave the transition to a human. Verify either
    transition by an independent Linear read. Do not inspect the diff, rerun tests, invoke
    `pr-verdict`, or perform a functional review; this workflow routes work by the evidence that
    already exists and never produces any. Several assigned leaves may transition from the same

--- a/harness/skills/linear-sync/SKILL.md
+++ b/harness/skills/linear-sync/SKILL.md
@@ -3,7 +3,7 @@ name: linear-sync
 description: >
   Reconcile assigned Linear issues with Bitbucket pull-request reality without reviewing code. Use
   when the user manually asks to synchronize Linear lifecycle state or repair missing pull-request
-  links. Make sure to use this skill whenever merged Bitbucket work should close Linear issues.
+  links. Make sure to use this skill whenever merged Bitbucket work should advance Linear issues.
 compatibility: Requires Git, bkt, and an authenticated Linear transport with read and write access.
 metadata:
   category: dev
@@ -24,7 +24,8 @@ or issue-shaping pass.
 Run from the Bitbucket repository whose assigned Linear issues should be reconciled. The current
 repository scopes branch-based discovery; an attached canonical pull-request URL may identify a
 different repository explicitly. Report only applied transitions, repaired pull-request
-attachments, unresolved inconsistencies, and relevant issues that were already synchronized.
+attachments, the queue awaiting verification, unresolved inconsistencies, and relevant issues that
+were already synchronized.
 
 ## Workflow
 
@@ -60,18 +61,22 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
    synchronization failure; preserve the Bitbucket state and retry only the idempotent Linear link
    operation.
 
-6. **Complete assigned leaf issues from merged work.** For each assigned leaf with a certain linked
-   Bitbucket pull request, read its state from Bitbucket. A merged state is sufficient completion
-   proof: move the issue to `Done` and verify the state by an independent Linear read. Do not inspect
-   the diff, rerun tests, invoke `pr-verdict`, or perform a functional review. Several assigned
-   leaves may transition from the same merged pull request only when each association is explicit
-   and certain.
+6. **Route assigned leaf issues by their verification boxes.** For each assigned leaf with a certain
+   linked Bitbucket pull request, read its state from Bitbucket. A merged state proves the code
+   landed, not that the issue's verification boxes hold. Read those boxes without ever writing one:
+   all checked, or none present, moves the issue to `Done`; at least one unchecked moves it to its
+   team's review state instead, with the unchecked lines named as unproven residue. Verify either
+   transition by an independent Linear read. Do not inspect the diff, rerun tests, invoke
+   `pr-verdict`, or perform a functional review; this workflow routes work by the evidence that
+   already exists and never produces any. Several assigned leaves may transition from the same
+   merged pull request only when each association is explicit and certain.
 
 7. **Evaluate assigned parents from child state.** After leaf transitions are verified, process
    assigned parents bottom-up and re-read each parent with every direct sub-issue. A parent whose
-   direct sub-issues are all `Done` is eligible for completion. Transition it automatically only
-   when the selected Linear transport documents one atomic conditional mutation that writes `Done`
-   if every direct sub-issue remains `Done` at commit time. A separate read followed by an ordinary
+   direct sub-issues are all `Done` is eligible for completion; a sub-issue waiting in the review
+   state is not `Done` and makes the parent ineligible. Transition it automatically only when the
+   selected Linear transport documents one atomic conditional mutation that writes `Done` if every
+   direct sub-issue remains `Done` at commit time. A separate read followed by an ordinary
    state update does not qualify. The shared connector, CLI, and GraphQL adapters currently expose
    no such guarantee, so report the eligible parent and leave it unchanged for human decision. Do
    not infer completion from the parent description, pull-request title, or partial child set, and
@@ -84,13 +89,16 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
    leave the state unchanged so the user can choose resumption, `Todo`, or `Done`. A missing match in
    the current repository says nothing about an issue with no explicit repository association;
    omit it unless conflicting explicit signals make it a relevant ambiguity. When evidence is
-   ambiguous, report every conflicting fact and make no lifecycle or attachment write.
+   ambiguous, report every conflicting fact and make no lifecycle or attachment write. An assigned
+   issue sitting in the review state with a merged pull request is the expected outcome of step 6,
+   not an inconsistency: list it as awaiting verification rather than as unresolved work.
 
-9. **Return a concise reconciliation.** Include only transitions applied, attachments repaired,
-   inconsistencies or ambiguities requiring a human decision, and relevant issues already in the
-   state proven by the same oracle. Name partial failures. End with an automation assessment based
-   on observed repeated usage; absent evidence of a stable reliable trigger, state that automation
-   is not yet justified.
+9. **Return a concise reconciliation.** Include only transitions applied, attachments repaired, the
+   queue now awaiting verification with the unchecked line behind each issue, inconsistencies or
+   ambiguities requiring a human decision, and relevant issues already in the state proven by the
+   same oracle. Name partial failures. End with an automation assessment based on observed
+   repeated usage; absent evidence of a stable reliable trigger, state that automation is not yet
+   justified.
 
 ## Gotchas
 
@@ -109,11 +117,19 @@ attachments, unresolved inconsistencies, and relevant issues that were already s
   require explicit repository scope before reporting the inconsistency.
 - **Retrying the whole synchronization after a partial write** — verified transitions or links are
   repeated unnecessarily; re-read both systems and retry only the failed idempotent operation.
+- **Aligning description checkboxes with the new state** — a merged pull request becomes false proof
+  for a line no run covered; never write a box here, and report the unchecked lines instead.
+- **Closing a merged issue without reading its verification boxes** — the check nobody ran is buried
+  under `Done`; route the issue to its team's review state and leave it in the verification queue.
 
 ## Constraints
 
 - Never mutate or report as a candidate an issue not assigned to the current Linear identity.
 - Never inspect implementation, review a diff, rerun functional checks, or invoke a review skill.
+- Never check, uncheck, or reword a description checkbox from this workflow; it produces no
+  evidence, so it reports unproven residue instead of resolving it.
+- Never move an issue to `Done` from a merge while one of its verification boxes is unchecked; its
+  team's review state is the destination and the unchecked lines are reported.
 - Never transition an issue from title similarity, prose, an ambiguous link, or an unverified
   repository context.
 - Never auto-transition a parent through a separate read followed by an unconditional state update.

--- a/harness/skills/linear-sync/SKILL.md
+++ b/harness/skills/linear-sync/SKILL.md
@@ -67,12 +67,12 @@ were already synchronized.
    landed, not that the issue's verification boxes hold. Read those boxes without ever writing one:
    all checked, or no evidence section at all, moves the issue to `Done`; at least one unchecked
    line, or an evidence section that holds no state, moves it to its team's review state instead,
-   with the unproven lines named as residue. Re-read the description immediately before the state
-   write and leave that issue untouched when it changed since the classification: a post-write read
-   confirms the state, never that the boxes still say what they said. That re-read narrows the
-   window without closing it — no transport verified here exposes a conditional write, so a box
-   unchecked between the re-read and the write still lands as `Done`. The exposure is one issue per
-   occurrence and a human can reverse it; report the transition so it stays visible. Verify either
+   with the unproven lines named as residue. Guard the state write with the classification it rests
+   on, following the anchored guard in `completion-evidence.md`: a box that moved must abort the
+   save before any state is written, because a post-write read confirms the state and never that the
+   boxes still say what they said. Where a transport cannot carry the guard and the state in one
+   save, re-read the description immediately before the write, leave the issue untouched when it
+   changed, and report the window between that read and the write as unguarded. Verify either
    transition by an independent Linear read. Do not inspect the diff, rerun tests, invoke
    `pr-verdict`, or perform a functional review; this workflow routes work by the evidence that
    already exists and never produces any. Several assigned leaves may transition from the same

--- a/harness/skills/linear-sync/SKILL.md
+++ b/harness/skills/linear-sync/SKILL.md
@@ -31,9 +31,9 @@ were already synchronized.
 
 1. **Load shared policy and adapters.** Activate `linear-workflow`, including its shared Linear and
    Bitbucket adapters and its `references/completion-evidence.md` rule, and apply all of its
-   constraints. Use those transports rather than creating
-   another integration. Verify current command schemas and authentication before reads or writes,
-   and stop before any operation that the available transports do not cover.
+   constraints. Use those transports rather than creating another integration. Verify current
+   command schemas and authentication before reads or writes, and stop before any operation that
+   the available transports do not cover.
 
 2. **Establish identity and repository scope.** Retrieve the current Linear identity. Resolve the
    current Bitbucket repository from Git remotes and verify its workspace and repository slug with
@@ -45,9 +45,8 @@ were already synchronized.
 3. **Read structured Linear facts.** Exhaust result pages while retrieving assigned candidates with
    their identifiers, workflow states, parents, direct sub-issues, blocking relations, and links or
    attachments, plus the description of any candidate a merged pull request could complete. Read
-   only the assignee and workflow state of an unassigned direct sub-issue when
-   needed to decide whether an assigned parent is complete; never mutate or report that sub-issue
-   as a candidate.
+   only the assignee and workflow state of an unassigned direct sub-issue when needed to decide
+   whether an assigned parent is complete; never mutate or report that sub-issue as a candidate.
 
 4. **Resolve exact issue-to-work associations.** Prefer a canonical Bitbucket pull-request URL in
    Linear's structured links or attachments. Otherwise accept an exact issue identifier at the
@@ -70,8 +69,11 @@ were already synchronized.
    line, or an evidence section that holds no state, moves it to its team's review state instead,
    with the unproven lines named as residue. Re-read the description immediately before the state
    write and leave that issue untouched when it changed since the classification: a post-write read
-   confirms the state, never that the boxes still say what they said. Verify either transition by an
-   independent Linear read. Do not inspect the diff, rerun tests, invoke
+   confirms the state, never that the boxes still say what they said. That re-read narrows the
+   window without closing it — no transport verified here exposes a conditional write, so a box
+   unchecked between the re-read and the write still lands as `Done`. The exposure is one issue per
+   occurrence and a human can reverse it; report the transition so it stays visible. Verify either
+   transition by an independent Linear read. Do not inspect the diff, rerun tests, invoke
    `pr-verdict`, or perform a functional review; this workflow routes work by the evidence that
    already exists and never produces any. Several assigned leaves may transition from the same
    merged pull request only when each association is explicit and certain.

--- a/harness/skills/linear-sync/SKILL.md
+++ b/harness/skills/linear-sync/SKILL.md
@@ -30,7 +30,8 @@ were already synchronized.
 ## Workflow
 
 1. **Load shared policy and adapters.** Activate `linear-workflow`, including its shared Linear and
-   Bitbucket adapters, and apply all of its constraints. Use those transports rather than creating
+   Bitbucket adapters and its `references/completion-evidence.md` rule, and apply all of its
+   constraints. Use those transports rather than creating
    another integration. Verify current command schemas and authentication before reads or writes,
    and stop before any operation that the available transports do not cover.
 
@@ -43,7 +44,8 @@ were already synchronized.
 
 3. **Read structured Linear facts.** Exhaust result pages while retrieving assigned candidates with
    their identifiers, workflow states, parents, direct sub-issues, blocking relations, and links or
-   attachments. Read only the assignee and workflow state of an unassigned direct sub-issue when
+   attachments, plus the description of any candidate a merged pull request could complete. Read
+   only the assignee and workflow state of an unassigned direct sub-issue when
    needed to decide whether an assigned parent is complete; never mutate or report that sub-issue
    as a candidate.
 
@@ -64,9 +66,12 @@ were already synchronized.
 6. **Route assigned leaf issues by their verification boxes.** For each assigned leaf with a certain
    linked Bitbucket pull request, read its state from Bitbucket. A merged state proves the code
    landed, not that the issue's verification boxes hold. Read those boxes without ever writing one:
-   all checked, or none present, moves the issue to `Done`; at least one unchecked moves it to its
-   team's review state instead, with the unchecked lines named as unproven residue. Verify either
-   transition by an independent Linear read. Do not inspect the diff, rerun tests, invoke
+   all checked, or no evidence section at all, moves the issue to `Done`; at least one unchecked
+   line, or an evidence section that holds no state, moves it to its team's review state instead,
+   with the unproven lines named as residue. Re-read the description immediately before the state
+   write and leave that issue untouched when it changed since the classification: a post-write read
+   confirms the state, never that the boxes still say what they said. Verify either transition by an
+   independent Linear read. Do not inspect the diff, rerun tests, invoke
    `pr-verdict`, or perform a functional review; this workflow routes work by the evidence that
    already exists and never produces any. Several assigned leaves may transition from the same
    merged pull request only when each association is explicit and certain.
@@ -89,9 +94,7 @@ were already synchronized.
    leave the state unchanged so the user can choose resumption, `Todo`, or `Done`. A missing match in
    the current repository says nothing about an issue with no explicit repository association;
    omit it unless conflicting explicit signals make it a relevant ambiguity. When evidence is
-   ambiguous, report every conflicting fact and make no lifecycle or attachment write. An assigned
-   issue sitting in the review state with a merged pull request is the expected outcome of step 6,
-   not an inconsistency: list it as awaiting verification rather than as unresolved work.
+   ambiguous, report every conflicting fact and make no lifecycle or attachment write.
 
 9. **Return a concise reconciliation.** Include only transitions applied, attachments repaired, the
    queue now awaiting verification with the unchecked line behind each issue, inconsistencies or

--- a/harness/skills/linear-workflow/SKILL.md
+++ b/harness/skills/linear-workflow/SKILL.md
@@ -32,7 +32,8 @@ evidence, one issue or a whole queue, is the single procedure it carries directl
 2. Read ownership, hierarchy, relations, and work state from structured Linear fields.
 3. Read branch and pull-request state from Git and Bitbucket.
 4. Before checking or restructuring a checkbox or evidence section, and before completing an issue
-   from merged work, read [completion evidence](references/completion-evidence.md).
+   from merged work, read [completion evidence](references/completion-evidence.md). Reading it is
+   mandatory; running its verification pass requires an explicit request to verify.
 5. Apply every constraint below, then return control to the composing workflow.
 
 ## Gotchas
@@ -66,6 +67,9 @@ evidence, one issue or a whole queue, is the single procedure it carries directl
 - Treat a checked box as an assertion of proof, not a progress marker: check a line only from a run,
   CI result, or observation you can name, never from a merge, a closure, or a tidier list.
 - Never derive box state from workflow state: no merge, closure, or transition ever checks a box.
-- A merge completes an issue only when every verification box holds; otherwise the issue goes to its
-  team's review state with the unchecked lines named, and `Done` stays an explicit human decision.
-- Resolve the review state within the issue's own team and stop when that team exposes none.
+- A merge completes an issue only when every verification box holds, or when the issue carries no
+  acceptance or evidence section at all; a section that holds no state proves nothing, so the issue
+  goes to its team's review state with the unproven lines named, and `Done` stays an explicit human
+  decision.
+- Resolve the review state by enumerating the issue's own team's states and matching by name, never
+  by state type; stop when the transport cannot enumerate them or the team exposes none.

--- a/harness/skills/linear-workflow/SKILL.md
+++ b/harness/skills/linear-workflow/SKILL.md
@@ -33,8 +33,11 @@ evidence, one issue or a whole queue, is the single procedure it carries directl
 3. Read branch and pull-request state from Git and Bitbucket.
 4. Before checking or restructuring a checkbox or evidence section, and before completing an issue
    from merged work, read [completion evidence](references/completion-evidence.md). Reading it is
-   mandatory; running its verification pass requires an explicit request to verify.
-5. Apply every constraint below, then return control to the composing workflow.
+   mandatory for every workflow; running its verification pass is not.
+5. On an explicit request to verify merged work, run that reference's verification pass over the
+   issues waiting in the review state, and report the queue it defines. This is the one procedure to
+   execute here rather than hand back.
+6. Apply every constraint below, then return control to the composing workflow when there is one.
 
 ## Gotchas
 

--- a/harness/skills/linear-workflow/SKILL.md
+++ b/harness/skills/linear-workflow/SKILL.md
@@ -2,8 +2,9 @@
 name: linear-workflow
 description: >
   Apply the shared Linear and Bitbucket work invariants. Use when another Linear execution skill
-  composes the common workflow policy. Make sure to use this skill whenever starting, resuming, or
-  finishing Linear-backed implementation, even if the request mentions only an issue ID.
+  composes the common workflow policy, or to verify merged work against an issue's completion
+  evidence. Make sure to use this skill whenever starting, resuming, verifying, or finishing
+  Linear-backed implementation, even if the request mentions only an issue ID.
 compatibility: Requires access to the relevant Linear workspace and Bitbucket repository.
 metadata:
   category: dev
@@ -13,13 +14,16 @@ metadata:
 
 ## Overview
 
-Provide the single reusable policy for execution workflows backed by Linear and Bitbucket. This
-skill defines invariants only; the composing workflow owns its procedure and transport selection.
+Provide the single reusable policy for execution workflows backed by Linear and Bitbucket. Each
+composing workflow owns its own procedure and transport selection; the one procedure this skill
+owns is verifying merged work against an issue's completion evidence, because no execution skill
+may produce that evidence on its own.
 
 ## Usage
 
 Load `linear-workflow` alongside a specific execution skill such as `linear-start`. Do not invoke it
-alone to shape, implement, review, or finish an issue.
+alone to shape, implement, or review an issue. Verifying merged work against an issue's completion
+evidence, one issue or a whole queue, is the single procedure it carries directly.
 
 ## Steps
 
@@ -27,7 +31,9 @@ alone to shape, implement, review, or finish an issue.
    [Bitbucket operations](references/bitbucket.md) before accessing pull requests.
 2. Read ownership, hierarchy, relations, and work state from structured Linear fields.
 3. Read branch and pull-request state from Git and Bitbucket.
-4. Apply every constraint below, then return control to the composing workflow.
+4. Before checking or restructuring a checkbox or evidence section, and before completing an issue
+   from merged work, read [completion evidence](references/completion-evidence.md).
+5. Apply every constraint below, then return control to the composing workflow.
 
 ## Gotchas
 
@@ -37,6 +43,15 @@ alone to shape, implement, review, or finish an issue.
   assigned, unblocked sub-issue instead.
 - **Equating issue and pull-request granularity** — related changes gain artificial review
   boundaries; let the implementation scope determine whether sub-issues share a pull request.
+- **Checking a box because the issue is being completed** — the description then claims proof no
+  run produced, and the missing check disappears with the closed issue; leave it unchecked and
+  record the residue.
+- **Completing merged work over an unchecked verification box** — the check nobody ran is buried
+  under `Done` and never resurfaces; send the issue to its team's review state and name the line.
+- **Carrying one team's review state name to another** — the transition targets a state the team
+  does not expose; resolve the review state inside the issue's own team.
+- **Retyping a description to change one marker** — serialized issue mentions such as
+  `<issue id="…" href="…">ENG-482</issue>` are mangled; apply an anchored partial edit instead.
 
 ## Constraints
 
@@ -48,3 +63,9 @@ alone to shape, implement, review, or finish an issue.
 - Never execute a parent issue while any of its sub-issues remains open.
 - Name a new work branch `<ISSUE-ID>-<slug>`.
 - Never require a separate pull request merely because work is represented by a sub-issue.
+- Treat a checked box as an assertion of proof, not a progress marker: check a line only from a run,
+  CI result, or observation you can name, never from a merge, a closure, or a tidier list.
+- Never derive box state from workflow state: no merge, closure, or transition ever checks a box.
+- A merge completes an issue only when every verification box holds; otherwise the issue goes to its
+  team's review state with the unchecked lines named, and `Done` stays an explicit human decision.
+- Resolve the review state within the issue's own team and stop when that team exposes none.

--- a/harness/skills/linear-workflow/references/completion-evidence.md
+++ b/harness/skills/linear-workflow/references/completion-evidence.md
@@ -1,0 +1,132 @@
+# Completion Evidence in Linear Issues
+
+Read this before checking, unchecking, or restructuring any checkbox or evidence section in a Linear
+issue, and before completing an issue from merged work. Transport selection stays in
+[transport adapters](transports.md).
+
+## What a checked box asserts
+
+A checked box is an assertion of proof, not a progress marker. It claims that a named oracle
+produced the result written on that line.
+
+Checking is authorized by:
+
+- a test, command, or check whose run you can name, together with the environment it ran in and its
+  green result;
+- a CI run you can point to that actually covers the line;
+- an observation you made yourself and can reproduce: a measurement taken, a query executed, a
+  screen seen.
+
+Checking is not authorized by:
+
+- the issue being closed, its pull request merged, or its cycle ending;
+- the neighboring boxes being checked and this one spoiling an otherwise clean list;
+- the code appearing to do it, or a reviewer having approved it;
+- a check that exists but does not exercise the line — a green suite that never runs the surface you
+  touched proves nothing about it;
+- prose asserting it, in the description, a comment, or a pull request.
+
+A line that demands a measurement nobody made stays unchecked, however small the remaining gap
+looks. Report it as unproven instead.
+
+## Workflow state and box state are independent
+
+They are two axes, and converging them destroys the only record of what is still unproven.
+
+1. Never check a box because the issue is being completed, and never keep an issue open only because
+   a box is unchecked.
+2. `Done` with unchecked boxes is a legitimate outcome, but it is an explicit human decision to
+   accept unproven residue. An agent routing lifecycle state never takes it alone.
+3. When a transition leaves boxes unchecked, record the residue explicitly in the same exchange:
+   name each unchecked line and why it is unproven — measurement never taken, environment out of
+   scope, deliberately accepted. Put it in the response, and in an issue comment when the transport
+   supports one, so the gap survives the issue being closed.
+4. Never uncheck a box that evidence still supports in order to justify reopening or delaying an
+   issue.
+5. Box state may gate a transition, and never the reverse: refusing `Done` over an unchecked line is
+   sound, checking a line because a transition is wanted is fabrication.
+
+## Merged work whose verification boxes are unchecked
+
+A merge proves the code landed. It proves nothing about a line the merge did not run.
+
+1. Identify the issue's verification boxes: the checkboxes carrying acceptance criteria or
+   validation scenarios. Sub-task and implementation to-do boxes are not verification boxes. When a
+   box's nature is genuinely ambiguous, list it and ask rather than deciding the lifecycle on a
+   guess.
+2. Every verification box checked completes the issue: the merge is then the last missing fact.
+3. At least one unchecked box sends the issue to its team's review state instead of `Done`, with the
+   unchecked lines named. The work is not undone; it is unverified.
+4. No verification box at all leaves nothing to gate the transition, so the merge remains the
+   completion oracle. An evidence section written as plain bullets gates nothing either: report it
+   as untracked instead of treating it as a gate.
+5. Resolve the review state inside the issue's own team — the `started` workflow state reserved for
+   review, observed as `In Review` across this workspace's teams. Never carry one team's name over
+   to another, and stop rather than inventing a state when a team exposes none.
+
+## Verifying issues that wait in the review state
+
+This is the pass that turns unverified merged work into a defensible `Done`, and it is the only one
+allowed to produce the missing evidence.
+
+1. Select the assigned issues in the review state whose pull request is merged. That set is the
+   queue. An issue whose pull request is still open belongs to code review, not here.
+2. For each issue, take its verification boxes one by one and produce the missing oracle: run the
+   check, point at the CI run that actually covers the line, take the measurement.
+3. Check only what the run you just named proves, in one anchored edit per issue.
+4. Move an issue to `Done` once every verification box holds.
+5. Leave an issue in the review state when a box stays unproven, and report what is missing: the
+   oracle nobody has run, and what running it would take. Do not check it, and do not close around
+   it without an explicit decision.
+6. Report the queue as a whole — issues completed, issues still waiting, and the unproven line
+   behind each one. A batch that silently drops an issue reads as a verified batch.
+
+## Evidence sections that are not checkboxes
+
+A bulleted evidence section holds nothing: it does not distinguish a proven line from an asserted
+one, so a reader assumes the whole section is proven. Treat it as untracked prose.
+
+1. Give the per-line verdict in your response rather than relying on the issue text to carry it.
+2. When the section is meant to gate completion and the request authorizes editing the issue,
+   convert its lines to checkbox items, unchecked, in one anchored edit. Preserve the wording: this
+   is a structural change, not a rewrite.
+3. Then check only the lines the evidence rule above authorizes. Converting a section never
+   authorizes checking a line the conversion itself did not prove.
+4. When editing is not authorized, say that the section tracks nothing and report the verdicts
+   instead of asking anyone to trust it.
+
+## Editing boxes without breaking the issue
+
+1. Read the current description first. The stored Markdown is not what the Linear UI renders: issue
+   mentions are serialized as `<issue id="…" href="…">ENG-482</issue>`, and retyping a description
+   by hand mangles them.
+2. Prefer the transport's anchored partial edit over rewriting the description. On the Linear
+   connector this is `save_issue` with `id` and `patch`, used in place of the `description`
+   argument:
+
+   ```json
+   {
+     "id": "ENG-482",
+     "patch": [
+       {
+         "op": "replace",
+         "old_string": "- [ ] Scenario 2: import rejects a malformed row",
+         "new_string": "- [X] Scenario 2: import rejects a malformed row"
+       }
+     ]
+   }
+   ```
+
+3. Anchor on the whole line, marker included, with enough of its text to match the current content
+   exactly once. Operations apply in order and atomically, so one failing anchor aborts the entire
+   save.
+4. Batch every box of one decision into a single call, up to the transport's operation limit, so the
+   description is never left half-updated.
+5. Linear normalizes a checked marker to uppercase `- [X]`. Never require lowercase `- [x]`, never
+   anchor on it when re-reading a line you just checked, and never edit an issue merely to change
+   that case.
+6. Re-read the issue after the save and compare the marker of every line you touched. A matched
+   anchor proves the operation was accepted, not that the stored description says what you intended.
+7. When no anchored edit exists, build the full description write from the description you just
+   read, byte for byte, changing only the markers. Never reconstruct it from the rendered view or
+   from memory.

--- a/harness/skills/linear-workflow/references/completion-evidence.md
+++ b/harness/skills/linear-workflow/references/completion-evidence.md
@@ -40,8 +40,11 @@ They are two axes, and converging them destroys the only record of what is still
    accept unproven residue. An agent routing lifecycle state never takes it alone.
 3. When a transition leaves boxes unchecked, record the residue explicitly in the same exchange:
    name each unchecked line and why it is unproven — measurement never taken, environment out of
-   scope, deliberately accepted. Put it in the response, and in an issue comment when the transport
-   supports one, so the gap survives the issue being closed.
+   scope, deliberately accepted. The response always carries it. Add an issue comment only for a
+   transition that closes the issue, where the gap would otherwise disappear with it, and reconcile
+   against the existing comments first: a routing that leaves the issue open needs no comment, since
+   the unchecked lines are still there to read, and a workflow re-run would otherwise stack one
+   identical comment per run.
 4. Never uncheck a box that evidence still supports in order to justify reopening or delaying an
    issue, and never uncheck one merely because its proof is not in front of you: absence of evidence
    in this session is not evidence that the run never happened. Re-audit a checked box only when

--- a/harness/skills/linear-workflow/references/completion-evidence.md
+++ b/harness/skills/linear-workflow/references/completion-evidence.md
@@ -169,8 +169,10 @@ gone stale, and re-reading before the write only narrows that window. The anchor
 it, because an anchor that no longer matches exactly once aborts the whole save.
 
 1. Send the state change and the guard in one save. On the Linear connector, `save_issue` accepts
-   `state` alongside `patch`, and one failing anchor aborts the entire save, so no state is written
-   when a guarded line moved:
+   `state` alongside `patch`, and the connector documents that one failing operation aborts the
+   whole save — the save, not merely the patch — so no state is written when the guarded text moved.
+   `Done` below is a state name, not a state type; the field accepts either, and passing a type is
+   what the rule above forbids.
 
    ```json
    {
@@ -186,18 +188,30 @@ it, because an anchor that no longer matches exactly once aborts the whole save.
    }
    ```
 
-2. Anchor every line the classification relied on, unchanged, so the guard asserts the state of the
-   evidence rather than editing it. This is a guard, not a description edit: it needs no
-   authorization to write a box, because it writes none.
-3. An abort is the guard working. Re-read, classify again, and write again — never retry the save
-   with the anchors from the stale read.
-4. A transport that rejects an unchanged `old_string`/`new_string` pair fails the save and therefore
+2. Use one contiguous anchor covering the region the classification relied on, sent back unchanged,
+   rather than one anchor per line. One operation stays inside the transport's limit whatever the
+   section's length, and it survives byte-identical checkbox lines, which a per-line anchor cannot:
+   an anchor must match exactly once, and two identical lines can never be told apart at line
+   granularity. The anchor is a single string, so it carries the newlines between those lines —
+   widen the region, up to the whole description, until it matches once.
+3. This is a guard, not a description edit: what it sends back is what it read, so it writes no box
+   and needs no authorization to write one. It does travel the description-mutation path, so accept
+   that the issue's updated timestamp and activity feed may move.
+4. When the classification rests on absence — no acceptance or evidence section at all — there is no
+   region to anchor, so anchor the whole current description instead. An empty description leaves
+   nothing to guard: treat that as an uncovered guard and follow the last item.
+5. An abort is the guard working. Read the issue again — the description and the workflow state —
+   confirm the state did not move, then classify and write again. Never retry the save with the
+   anchors from the stale read. An anchor that still cannot match exactly once is an uncovered
+   guard, not a retry.
+6. A transport that rejects an unchanged `old_string`/`new_string` pair fails the save and therefore
    writes no state either, which is the safe direction. Treat the rejection as an uncovered guard,
    not as a reason to write unguarded.
-5. This guard asserts facts inside the issue's own description. It cannot assert another issue's
+7. This guard asserts facts inside the issue's own description. It cannot assert another issue's
    state, so it does not make a parent completion conditional on its sub-issues; that still needs a
    documented conditional mutation over those issues.
-6. When no transport carries the guard and the state in one save, re-read immediately before the
-   write, abandon the write when the description changed, and report the remaining window as
-   unguarded rather than describing the outcome as reversible: an issue completed over a box that
-   moved reports as an ordinary success, and nothing downstream surfaces it.
+8. Where the guard is uncovered, do not write the state at all. Classify, report the classification
+   and the missing capability, and leave the transition to a human. Do not fall back to an
+   unguarded write behind a pre-write re-read: an issue completed over a box that moved reports as
+   an ordinary success, so nothing downstream surfaces it, and this harness states in three places
+   that such a gap never resurfaces.

--- a/harness/skills/linear-workflow/references/completion-evidence.md
+++ b/harness/skills/linear-workflow/references/completion-evidence.md
@@ -41,10 +41,11 @@ They are two axes, and converging them destroys the only record of what is still
 3. When a transition leaves boxes unchecked, record the residue explicitly in the same exchange:
    name each unchecked line and why it is unproven — measurement never taken, environment out of
    scope, deliberately accepted. The response always carries it. Add an issue comment only for a
-   transition that closes the issue, where the gap would otherwise disappear with it, and reconcile
-   against the existing comments first: a routing that leaves the issue open needs no comment, since
-   the unchecked lines are still there to read, and a workflow re-run would otherwise stack one
-   identical comment per run.
+   transition that closes the issue, where the gap would otherwise disappear with it, and only when
+   the transport covers reading and writing comments; report the limitation instead when it does
+   not. Reconcile against the existing comments first: a routing that leaves the issue open needs no
+   comment, since the unchecked lines are still there to read, and a workflow re-run would otherwise
+   stack one identical comment per run.
 4. Never uncheck a box that evidence still supports in order to justify reopening or delaying an
    issue, and never uncheck one merely because its proof is not in front of you: absence of evidence
    in this session is not evidence that the run never happened. Re-audit a checked box only when
@@ -160,3 +161,43 @@ writing.
    construction.
 8. Treat an aborted save the same way. A failing anchor means the description moved under you, so
    read, decide, and write again — never replay the decision you already made.
+
+## Guarding a state write with the boxes it rests on
+
+A workflow state decided from checkboxes must not be written from a classification that has since
+gone stale, and re-reading before the write only narrows that window. The anchor requirement closes
+it, because an anchor that no longer matches exactly once aborts the whole save.
+
+1. Send the state change and the guard in one save. On the Linear connector, `save_issue` accepts
+   `state` alongside `patch`, and one failing anchor aborts the entire save, so no state is written
+   when a guarded line moved:
+
+   ```json
+   {
+     "id": "ENG-482",
+     "state": "Done",
+     "patch": [
+       {
+         "op": "replace",
+         "old_string": "- [X] Scenario 2: import rejects a malformed row",
+         "new_string": "- [X] Scenario 2: import rejects a malformed row"
+       }
+     ]
+   }
+   ```
+
+2. Anchor every line the classification relied on, unchanged, so the guard asserts the state of the
+   evidence rather than editing it. This is a guard, not a description edit: it needs no
+   authorization to write a box, because it writes none.
+3. An abort is the guard working. Re-read, classify again, and write again — never retry the save
+   with the anchors from the stale read.
+4. A transport that rejects an unchanged `old_string`/`new_string` pair fails the save and therefore
+   writes no state either, which is the safe direction. Treat the rejection as an uncovered guard,
+   not as a reason to write unguarded.
+5. This guard asserts facts inside the issue's own description. It cannot assert another issue's
+   state, so it does not make a parent completion conditional on its sub-issues; that still needs a
+   documented conditional mutation over those issues.
+6. When no transport carries the guard and the state in one save, re-read immediately before the
+   write, abandon the write when the description changed, and report the remaining window as
+   unguarded rather than describing the outcome as reversible: an issue completed over a box that
+   moved reports as an ordinary success, and nothing downstream surfaces it.

--- a/harness/skills/linear-workflow/references/completion-evidence.md
+++ b/harness/skills/linear-workflow/references/completion-evidence.md
@@ -33,8 +33,9 @@ looks. Report it as unproven instead.
 
 They are two axes, and converging them destroys the only record of what is still unproven.
 
-1. Never check a box because the issue is being completed, and never keep an issue open only because
-   a box is unchecked.
+1. Never check a box because the issue is being completed, and never hold an issue open merely to
+   drive a list to 100%. Routing merged work by its boxes, below, is a separate rule with its own
+   destination.
 2. `Done` with unchecked boxes is a legitimate outcome, but it is an explicit human decision to
    accept unproven residue. An agent routing lifecycle state never takes it alone.
 3. When a transition leaves boxes unchecked, record the residue explicitly in the same exchange:
@@ -56,23 +57,36 @@ They are two axes, and converging them destroys the only record of what is still
 A merge proves the code landed. It proves nothing about a line the merge did not run.
 
 1. Identify the issue's verification boxes: the checkboxes carrying acceptance criteria or
-   validation scenarios. Sub-task and implementation to-do boxes are not verification boxes. When a
-   box's nature is genuinely ambiguous, list it and ask rather than deciding the lifecycle on a
-   guess.
+   validation scenarios. A checkbox is a task-list line — `- [ ]`, `- [x]`, or `- [X]` — outside any
+   fenced code block; one inside a fenced block is a Markdown sample and claims nothing. Sub-task
+   and implementation to-do boxes are not verification boxes. When a box's nature is genuinely
+   ambiguous, list it and ask rather than deciding the lifecycle on a guess; in a queue that leaves
+   this one issue untouched and does not stop the others.
 2. Every verification box checked completes the issue: the merge is then the last missing fact.
 3. At least one unchecked box sends the issue to its team's review state instead of `Done`, with the
    unchecked lines named. The work is not undone; it is unverified.
-4. No verification box at all leaves nothing to gate the transition, so the merge remains the
-   completion oracle. An evidence section written as plain bullets gates nothing either: report it
-   as untracked instead of treating it as a gate.
-5. Resolve the review state inside the issue's own team — the `started` workflow state reserved for
-   review, observed as `In Review` across this workspace's teams. Never carry one team's name over
-   to another, and stop rather than inventing a state when a team exposes none.
+4. A section carrying acceptance criteria, completion evidence, or validation scenarios gates the
+   transition whatever its syntax. Written as plain bullets it holds no state, so no line in it is
+   proven: route the issue to the review state and report that the section tracks nothing. Only an
+   issue with no such section at all leaves the merge as the completion oracle. The skills in this
+   harness draft acceptance criteria as prose, so the bulleted case is the common one — never the
+   permissive branch.
+5. Resolve the review state by enumerating the issue's own team's workflow states and matching the
+   one reserved for review by name, observed as `In Review` across this workspace's teams. Never
+   pass a state _type_: several states share `started`, so the type lands the issue in an arbitrary
+   one — typically `In Progress` — while the post-write read still reports a successful transition.
+   Never carry one team's name over to another. When the transport cannot enumerate a team's states,
+   or that team exposes no review state, stop and report it: the routing rule is not executable
+   there.
 
 ## Verifying issues that wait in the review state
 
 This is the pass that turns unverified merged work into a defensible `Done`, and it is the only one
 allowed to produce the missing evidence.
+
+Enter it only on an explicit request to verify. A workflow reconciling lifecycle state never enters
+it: routing an issue into the review state ends that workflow's authority, and the boxes wait for a
+later pass. Establish the current Linear identity first and mutate only issues assigned to it.
 
 1. Select the assigned issues in the review state whose pull request is merged. That set is the
    queue. An issue whose pull request is still open belongs to code review, not here.
@@ -137,6 +151,9 @@ writing.
    that case.
 6. Re-read the issue after the save and compare the marker of every line you touched. A matched
    anchor proves the operation was accepted, not that the stored description says what you intended.
-7. When no anchored edit exists, build the full description write from the description you just
-   read, byte for byte, changing only the markers. Never reconstruct it from the rendered view or
-   from memory.
+7. When the transport exposes no anchored edit, stop and report the limitation. Never fall back to
+   writing the whole description: a full write silently discards whatever a human changed since your
+   read, and step 6 inspects only the lines you meant to touch, so the loss is invisible to it by
+   construction.
+8. Treat an aborted save the same way. A failing anchor means the description moved under you, so
+   read, decide, and write again — never replay the decision you already made.

--- a/harness/skills/linear-workflow/references/completion-evidence.md
+++ b/harness/skills/linear-workflow/references/completion-evidence.md
@@ -42,9 +42,14 @@ They are two axes, and converging them destroys the only record of what is still
    scope, deliberately accepted. Put it in the response, and in an issue comment when the transport
    supports one, so the gap survives the issue being closed.
 4. Never uncheck a box that evidence still supports in order to justify reopening or delaying an
-   issue.
+   issue, and never uncheck one merely because its proof is not in front of you: absence of evidence
+   in this session is not evidence that the run never happened. Re-audit a checked box only when
+   current evidence disproves it, or when the user asks for a fresh audit and its proof cannot be
+   recovered.
 5. Box state may gate a transition, and never the reverse: refusing `Done` over an unchecked line is
    sound, checking a line because a transition is wanted is fabrication.
+6. Never hide residue by deleting an item, softening its wording, moving it out of the task list, or
+   replacing the section with a completion summary. The unchecked line is the record.
 
 ## Merged work whose verification boxes are unchecked
 
@@ -97,6 +102,10 @@ one, so a reader assumes the whole section is proven. Treat it as untracked pros
 
 ## Editing boxes without breaking the issue
 
+Writing a box requires either an explicit request to reconcile the description or the verification
+pass above. Reconciling lifecycle state on its own authorizes inspecting and reporting, never
+writing.
+
 1. Read the current description first. The stored Markdown is not what the Linear UI renders: issue
    mentions are serialized as `<issue id="…" href="…">ENG-482</issue>`, and retyping a description
    by hand mangles them.
@@ -119,7 +128,8 @@ one, so a reader assumes the whole section is proven. Treat it as untracked pros
 
 3. Anchor on the whole line, marker included, with enough of its text to match the current content
    exactly once. Operations apply in order and atomically, so one failing anchor aborts the entire
-   save.
+   save. Never set `replace_all` for a checkbox edit: two scenarios can share a prefix, and one
+   anchor must identify one line.
 4. Batch every box of one decision into a single call, up to the transport's operation limit, so the
    description is never left half-updated.
 5. Linear normalizes a checked marker to uppercase `- [X]`. Never require lowercase `- [x]`, never

--- a/harness/skills/linear-workflow/references/transports.md
+++ b/harness/skills/linear-workflow/references/transports.md
@@ -10,8 +10,10 @@ Select a transport at runtime. The business workflow remains in its composing sk
    relations, links or attachments, workflow state updates, and URL attachment. Routing an issue by
    its completion evidence additionally requires listing a team's workflow states, an anchored
    partial edit of a description, and applying such an edit in the same save as a state change;
-   check each before relying on it. Recording accepted residue on a closing transition also needs
-   reading and writing issue comments.
+   check each before relying on it. Missing the anchored guard does not disqualify the transport for
+   reading and classifying — it removes the authority to write the state, which then goes to a
+   human. Recording accepted residue on a closing transition also needs reading and writing issue
+   comments.
 2. Otherwise use the installed `linear` CLI only after its local help confirms the commands and
    `linear auth whoami` succeeds for the intended workspace.
 3. Otherwise use Linear GraphQL only when authentication and the current schema are already

--- a/harness/skills/linear-workflow/references/transports.md
+++ b/harness/skills/linear-workflow/references/transports.md
@@ -7,7 +7,9 @@ Select a transport at runtime. The business workflow remains in its composing sk
 
 1. Prefer an authenticated Linear connector exposed by the current agent when its current schema
    covers identity, filtered issue listing with pagination, issue details, hierarchy, blocking
-   relations, links or attachments, workflow state updates, and URL attachment.
+   relations, links or attachments, workflow state updates, and URL attachment. Routing an issue by
+   its completion evidence additionally requires listing a team's workflow states and an anchored
+   partial edit of a description; check both before relying on them.
 2. Otherwise use the installed `linear` CLI only after its local help confirms the commands and
    `linear auth whoami` succeeds for the intended workspace.
 3. Otherwise use Linear GraphQL only when authentication and the current schema are already
@@ -37,6 +39,9 @@ The locally verified `linear` 2.5.0 surface provides:
 - `linear issue update <issue-id> --workspace <workspace> --state <state>` for lifecycle
   transitions;
 - `linear issue link <issue-id> <pull-request-url> --workspace <workspace>` for URL attachment.
+
+This surface covers neither listing a team's workflow states nor editing a description, so evidence
+routing is uncovered on the CLI: stop there rather than approximating either one.
 
 Run current local help again before use. This binary is a third-party Linear CLI, not an official
 Linear CLI. Do not use `linear issue pr`: its installed documentation delegates to GitHub's `gh`,

--- a/harness/skills/linear-workflow/references/transports.md
+++ b/harness/skills/linear-workflow/references/transports.md
@@ -8,8 +8,10 @@ Select a transport at runtime. The business workflow remains in its composing sk
 1. Prefer an authenticated Linear connector exposed by the current agent when its current schema
    covers identity, filtered issue listing with pagination, issue details, hierarchy, blocking
    relations, links or attachments, workflow state updates, and URL attachment. Routing an issue by
-   its completion evidence additionally requires listing a team's workflow states and an anchored
-   partial edit of a description; check both before relying on them.
+   its completion evidence additionally requires listing a team's workflow states, an anchored
+   partial edit of a description, and applying such an edit in the same save as a state change;
+   check each before relying on it. Recording accepted residue on a closing transition also needs
+   reading and writing issue comments.
 2. Otherwise use the installed `linear` CLI only after its local help confirms the commands and
    `linear auth whoami` succeeds for the intended workspace.
 3. Otherwise use Linear GraphQL only when authentication and the current schema are already


### PR DESCRIPTION
## Description

- record the checkbox-evidence invariant in `linear-workflow`: a checked box asserts that a named oracle proved its line, so no merge, closure, or tidier list may check one
- add `linear-workflow/references/completion-evidence.md` for the conditional procedure — what authorizes a tick, why box state and workflow state stay independent, how to route merged work, how to verify a whole queue, what to do with an evidence section written as plain bullets, and how to edit markers without breaking the issue
- replace `linear-sync`'s "a merged state is sufficient completion proof" with a routing rule: every verification box checked or none present completes the issue, at least one unchecked sends it to its team's review state with the unproven lines named
- keep `linear-sync` read-only on boxes and propagate the review state through parent eligibility, expected-state reporting, and the reconciliation report
- point `linear-start` at the shared rule, where "check off what is done" lands during implementation
- resolve the review state inside the issue's own team instead of hardcoding a name, and stop when a team exposes none
- edit markers through `save_issue`'s anchored `patch` rather than retyping a description whose issue mentions are serialized as `<issue id="…" href="…">…</issue>`, and accept Linear's uppercase `- [X]` normalization
- add the new reference to both lint barriers in `.github/workflows/lint.yml`, and add that workflow to its own prettier gate — it named every file it checks except itself

Supersedes #242, which covered the same rule from `linear-sync/references/checkbox-evidence.md` and closed a merged issue as `Done` regardless of residue. Its five rules this branch lacked were absorbed: a checked box survives a session that cannot recover its proof; residue is never hidden by deleting, softening, or summarizing an item away; writing a box needs an explicit request or the verification pass; `replace_all` is never used for a checkbox edit; and `lint.yml` enters its own format gate.

Behavior change: `linear-sync` no longer moves every merged issue to `Done`. An issue whose verification boxes are unchecked now lands in its team's review state, which is where batch verification picks it up.

## Useful Links

- Issue: none — requested directly

## How to Test

- `prettier --check` over the changed skills, the new reference, `harness/skills/README.md`, `home/.arnes.yaml`, and `.github/workflows/lint.yml` — clean
- `cspell lint --config ~/cspell.json` over the four changed skill files — 0 issues
- README index regenerated from frontmatter and diffed against the committed file — byte-identical, so no index row moved
- `In Review` confirmed as a `started` workflow state in the Modelo, Gestion Locative, Syndic, and Missions teams; `save_issue`'s `patch` operations and its exactly-once anchor requirement confirmed from the connector schema
- produced on macOS arm64 in a worktree of this repository

`actionlint` is the check that covers `.github/workflows/lint.yml`, and it was not run locally: it is not installed here and installing it was out of scope. CI closes that gap — the `Shell scripts` job runs `actionlint`, and the `Text configuration` job re-runs prettier and cspell over the new reference path. Evidence is cited against the current head only: run 32975112153 on `1ecb3b4`, superseding the run on `96db30f` that an earlier revision of this description cited. Citing a superseded run is the practice this PR's own rule forbids, so the citation moves with the head.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)

The first box was left unchecked until CI supplied the missing oracle, per the rule this PR introduces. Two independent review passes have since run on this branch: the first found five ways the invariant could still be bypassed, the second three bounded reservations, and both are answered in the repair records below.
