### PR TITLE
feat(harness): restore Superpowers plugins

### DIFF
--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -114,11 +114,309 @@ external:
       scope: user
       origin: system
       location: { root: home, path: .codex/skills/.system }
+  plugins:
+    - { agent: claude, scope: user, id: superpowers@claude-plugins-official }
+    - { agent: cursor, scope: user, id: superpowers }
+    - { agent: codex, scope: user, id: superpowers@openai-curated }
   skills:
     - agent: codex
       scope: user
       origin: system
       slug: openai-docs
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: brainstorming,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: dispatching-parallel-agents,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: executing-plans,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: finishing-a-development-branch,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: receiving-code-review,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: requesting-code-review,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: subagent-driven-development,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: systematic-debugging,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: test-driven-development,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: using-git-worktrees,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: using-superpowers,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: verification-before-completion,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: writing-plans,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@claude-plugins-official,
+        slug: writing-skills,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: brainstorming,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: dispatching-parallel-agents,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: executing-plans,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: finishing-a-development-branch,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: receiving-code-review,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: requesting-code-review,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: subagent-driven-development,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: systematic-debugging,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: test-driven-development,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: using-git-worktrees,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: using-superpowers,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: verification-before-completion,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: writing-plans,
+      }
+    - {
+        agent: cursor,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers,
+        slug: writing-skills,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: brainstorming,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: dispatching-parallel-agents,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: executing-plans,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: finishing-a-development-branch,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: receiving-code-review,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: requesting-code-review,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: subagent-driven-development,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: systematic-debugging,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: test-driven-development,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: using-git-worktrees,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: using-superpowers,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: verification-before-completion,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: writing-plans,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: superpowers@openai-curated,
+        slug: writing-skills,
+      }
 resources:
   - id: claude-user-instructions
     kind: instructions


### PR DESCRIPTION
## Summary

- allow Superpowers as an external user plugin for Claude, Cursor, and Codex
- allow the 14 skills currently exposed by each marketplace package
- keep Arnes responsible for auditing the external capabilities without adopting their source

## Rationale

This is a deliberate exception to ADR-029: removing Superpowers was premature because the shared development workflow still benefits from its planning, TDD, debugging, verification, and review discipline. The exception remains bounded to one audited plugin and its current 14 skills per agent.

## Validation

- `cargo fmt --manifest-path tooling/arnes/Cargo.toml --check`
- `cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/superpowers-arnes-target.hOcM4u cargo test --manifest-path tooling/arnes/Cargo.toml -q`
- `bunx prettier --check home/.arnes.yaml`
- `arnes doctor manifest --format json`
- Claude 6.3.0 and Codex 6.3.0: plugin and 14 skills reported enabled, healthy, and allowed

## Limits

- Cursor marketplace activation has no stable filesystem registry exposed to Arnes; installation remains interactive through `/add-plugin superpowers`.
