### PR TITLE
fix(skills): require manual pr-verdict invocation

### DIFF
--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -28,8 +28,8 @@ Before implementing any request:
 - Never record a workaround for a defect in code we own as intended behavior: fix it, or
   open a ticket and reference it.
 - Before writing code that parses an external value, joins, maps errors or adds a persisted
-  field, apply the `pr-verdict` skill's `references/failure-classes.md` to the design; the
-  failure-path test ships in the same commit.
+  field, make every affected failure path explicit in the design; the corresponding failure-path
+  test ships in the same commit.
 
 Keep unrelated inconsistencies out of scope. Follow `USER.md` for validation and workflow.
 

--- a/harness/USER.md
+++ b/harness/USER.md
@@ -156,8 +156,7 @@ transactions). Aucun rappel de fondamentaux sur ces sujets : aller au fait.
   préférer une issue et un prompt concis pour une nouvelle session. ~60 % de contexte visible
   est un signal d'alerte, pas une limite absolue.
 - **Barre de vérification.** Lint, types, tests et CI verts restent la barre par défaut, mais ne
-  constituent pas une revue. Avant de demander une revue sur une PR que vous ouvrez, passez
-  `pr-verdict` sur votre propre PR et corrigez ses constats bloquants avant de solliciter quiconque.
+  constituent pas une revue.
 
 ## Review
 

--- a/harness/skills/pr-verdict/SKILL.md
+++ b/harness/skills/pr-verdict/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: pr-verdict
 description: >
-  Deliver a PR verdict on an open pull request, yours or another author's. Use when asked to
-  review a PR, whether it is safe to merge or approve, for a blocking review, or a re-review after
-  fixes. Make sure to use it whenever a merge decision is at stake, even if the request only says
-  "look at this PR".
+  Deliver a PR verdict on an open pull request, yours or another author's. Use only when the user
+  explicitly invokes `$pr-verdict` or `/pr-verdict`; never select it implicitly from a review,
+  merge, approval, re-review, push, or pull-request-authoring request.
+disable-model-invocation: true
 compatibility: >
   Authenticated `gh` (GitHub) or `bkt` (Bitbucket) CLI, plus an issue tracker CLI (`linear`,
   `gh issue create`) when a blocking defect needs a fix ticket.
@@ -30,12 +30,14 @@ GitHub refuses a blocking review on your own PR.
 
 ## Usage
 
-`/pr-verdict <pr-number|pr-url>` — the forge is detected from `git remote get-url origin`.
+Invoke `$pr-verdict <pr-number|pr-url>` in Codex or `/pr-verdict <pr-number|pr-url>` in Claude Code
+and Cursor. The forge is detected from `git remote get-url origin`.
 
-Typical cases: "is #1042 safe to merge?" (phase 1 finds the branch stacked and the shown diff twice
-its real size), "review this PR before I approve it" (phase 3 turns a vague unease into a named
-mechanism, or drops it), "they pushed the fixes, re-review" (phase 6 finds the previous marker,
-sees a new SHA, and publishes a second verdict rather than editing the first).
+After explicit invocation, typical cases are: "is #1042 safe to merge?" (phase 1 finds the branch
+stacked and the shown diff twice its real size), "review this PR before I approve it" (phase 3
+turns a vague unease into a named mechanism, or drops it), "they pushed the fixes, re-review"
+(phase 6 finds the previous marker, sees a new SHA, and publishes a second verdict rather than
+editing the first).
 
 Run the six phases in order; phase 4 precedes phase 5 because a verdict without an executed barrier
 is an opinion. When `pr-fix` composes this skill before changing the head, stop after phase 5 and

--- a/harness/skills/pr-verdict/agents/openai.yaml
+++ b/harness/skills/pr-verdict/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/harness/skills/pr-verdict/evals/trigger-queries.json
+++ b/harness/skills/pr-verdict/evals/trigger-queries.json
@@ -1,46 +1,51 @@
 {
   "skill": "pr-verdict",
-  "version": "1.0",
+  "version": "2.0",
   "queries": [
+    {
+      "query": "$pr-verdict 1042",
+      "should_activate": true,
+      "reason": "Explicit Codex invocation of the pull request verdict"
+    },
     {
       "query": "/pr-verdict 1042",
       "should_activate": true,
-      "reason": "Explicit invocation of the non-mutating pull request verdict"
+      "reason": "Explicit Claude Code or Cursor invocation of the pull request verdict"
     },
     {
       "query": "Review this PR: https://github.com/acme/api/pull/1042",
-      "should_activate": true,
-      "reason": "Review of another author's pull request; a merge decision follows"
+      "should_activate": false,
+      "reason": "Natural-language review requests do not activate this manual-only skill"
     },
     {
       "query": "Est-ce que la PR 1042 est sûre à fusionner ?",
-      "should_activate": true,
-      "reason": "Safe to merge; the answer is a verdict"
+      "should_activate": false,
+      "reason": "A merge decision does not replace the required manual invocation"
     },
     {
       "query": "Should I approve this PR?",
-      "should_activate": true,
-      "reason": "Approval decision on someone else's work"
+      "should_activate": false,
+      "reason": "An approval decision does not replace the required manual invocation"
     },
     {
       "query": "Donne-moi un verdict sur la PR #17, elle touche la clôture comptable",
-      "should_activate": true,
-      "reason": "Verdict asked for explicitly"
+      "should_activate": false,
+      "reason": "Naming the desired output in prose is not a manual skill invocation"
     },
     {
       "query": "The author pushed the fixes, re-review PR 1042",
-      "should_activate": true,
-      "reason": "Re-review after fixes; the marker and the new head SHA govern"
+      "should_activate": false,
+      "reason": "A re-review does not replace the required manual invocation"
     },
     {
       "query": "Jette un œil à cette PR avant que je l'approuve",
-      "should_activate": true,
-      "reason": "Merge decision at stake even though no review vocabulary is used"
+      "should_activate": false,
+      "reason": "An implicit merge decision must not select this skill"
     },
     {
       "query": "Ma PR est ouverte, dis-moi si elle est fusionnable",
-      "should_activate": true,
-      "reason": "Own pull request, but open: the verdict is unchanged, only its enforcement differs"
+      "should_activate": false,
+      "reason": "Opening or judging one's own PR does not replace manual invocation"
     },
     {
       "query": "/pr-fix 1042",

--- a/harness/skills/skill-manager/references/conventions.md
+++ b/harness/skills/skill-manager/references/conventions.md
@@ -56,6 +56,16 @@ local convention.
 Do not move an unknown field under `metadata` automatically. Preserve it there only when its meaning
 is scalar metadata, its value is a string, and the user approves the semantic change.
 
+### Manual-only invocation exception
+
+`disable-model-invocation: true` is the sole approved top-level host extension. Use it only after
+the user explicitly chooses manual activation for a skill, and pair it with an
+`agents/openai.yaml` file setting `policy.allow_implicit_invocation: false`. Claude Code and Cursor
+consume the frontmatter field; Codex consumes the paired product metadata. The skill description
+must permit only explicit `$<slug>` or `/<slug>` invocation, and every true activation eval must
+use one of those two forms. This exception intentionally targets the three supported hosts rather
+than arbitrary Agent Skills implementations; no other non-standard top-level field is allowed.
+
 ### Description format
 
 Descriptions determine discovery. Put the distinguishing case first and use this local pattern:
@@ -68,6 +78,13 @@ cases>, even if <the user does not name the domain>.
 Aim below 400 characters because host skill lists truncate descriptions or omit entries before the
 standard's 1024-character ceiling. Avoid generic descriptions, passive labels, and appended trigger
 keyword dumps.
+
+For a manual-only skill, replace the implicit-trigger pattern with:
+
+```text
+<What it handles>. Use only when the user explicitly invokes `$<slug>` or `/<slug>`; never select
+it implicitly from <natural-language cases>.
+```
 
 ## 3. Canonical collections and adapters
 

--- a/harness/skills/skill-manager/references/doctor.md
+++ b/harness/skills/skill-manager/references/doctor.md
@@ -13,6 +13,8 @@ Doctor is read-only. It reports findings for a later `fix` operation.
 - **FAIL**: a standard rule or mandatory local convention fails.
 - **WARN**: only a qualitative, non-blocking weakness exists.
 - **PASS**: no FAIL or WARN exists.
+- **Approved extension**: a declared local host extension replaces one standard portability rule;
+  report it explicitly, but do not downgrade an otherwise conforming skill.
 - Missing optional tooling is an environment limitation, not a status downgrade.
 
 ## Procedure
@@ -38,7 +40,12 @@ these checks manually:
 - `allowed-tools`, if present, is a space-separated string and is reported as experimental;
 - `metadata`, if present, is a map whose keys and values are strings;
 - no top-level field exists outside `name`, `description`, `license`, `compatibility`,
-  `allowed-tools`, and `metadata`.
+  `allowed-tools`, and `metadata`, except the approved manual-only extension below.
+
+When `disable-model-invocation: true` is the only extra top-level field and every paired local check
+passes, report `approved extension: disable-model-invocation` instead of a standard failure. If
+`skills-ref` rejects only that field, preserve its diagnostic beside the approved-extension status.
+Any other validator failure remains FAIL.
 
 ## Local checks
 
@@ -46,9 +53,17 @@ these checks manually:
 
 - `metadata.category` exists and is `dev`, `support`, `product`, or `ops`;
 - the skill appears exactly once under the matching README section;
-- description starts with the distinguishing case, contains concrete `Use when` conditions, and
-  stays below the local 400-character target;
+- description starts with the distinguishing case, contains concrete `Use when` conditions or the
+  approved manual-only `Use only when` form, and stays below the local 400-character target;
 - a weak but valid description is WARN, not FAIL.
+
+For the manual-only invocation exception, require all of these or report FAIL:
+
+- `disable-model-invocation` is exactly `true`;
+- `agents/openai.yaml` sets `policy.allow_implicit_invocation` to exactly `false`;
+- the description requires explicit `$<slug>` or `/<slug>` invocation and rejects implicit use;
+- true eval queries use only `$<slug>` or `/<slug>`; both forms are represented;
+- no always-loaded shared instruction mandates invoking the skill.
 
 ### Body structure
 
@@ -97,7 +112,7 @@ An absent eval file is not a finding unless an approved requirement explicitly d
 ```text
 ### <slug> [PASS | WARN | FAIL]
 
-Standard validation: PASS | FAIL: <finding> | unavailable (skills-ref not installed)
+Standard validation: PASS | approved extension: <field> | FAIL: <finding> | unavailable (skills-ref not installed)
 Local conventions: PASS | WARN: <finding> | FAIL: <finding>
 Frontmatter: PASS | <exact finding>
 Body: PASS | <exact finding>
@@ -113,7 +128,7 @@ Global summary:
 ```text
 | Skill | Status | Standard | Local | Action |
 | --- | --- | --- | --- | --- |
-| <slug> | PASS | unavailable | PASS | none |
+| <slug> | PASS | unavailable or approved extension | PASS | none |
 ```
 
 List environment limitations after the table once, rather than repeating them as failures.
@@ -122,7 +137,8 @@ List environment limitations after the table once, rather than repeating them as
 
 | Finding                               | Exact correction                                                                             |
 | ------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Non-standard field                    | Remove it; preserve approved scalar metadata under `metadata` only when semantically correct |
+| Unsupported non-standard field        | Remove it; preserve approved scalar metadata under `metadata` only when semantically correct |
+| Incomplete manual-only extension      | Restore every paired field, explicit eval and shared-instruction check                       |
 | Invalid `allowed-tools` type          | Replace it with a space-separated string or remove it                                        |
 | Description above local target        | Keep the specific first clause and concrete triggers; move process detail to the body        |
 | Missing `Gotchas`                     | Add three repository-specific cause/consequence/correction entries                           |

--- a/tooling/pr-verdict-invocation.test.ts
+++ b/tooling/pr-verdict-invocation.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+
+const repositoryRoot = join(import.meta.dir, "..");
+const prVerdictRoot = join(repositoryRoot, "harness/skills/pr-verdict");
+const explicitInvocationPattern = /^(?:\$|\/)pr-verdict(?:\s|$)/u;
+const frontmatterPattern = /^---\n(?<yaml>[\s\S]*?)\n---\n/u;
+
+const prVerdictFrontmatterSchema = z.looseObject({
+  description: z.string(),
+  "disable-model-invocation": z.literal(true),
+});
+const openAiMetadataSchema = z.looseObject({
+  policy: z.object({ allow_implicit_invocation: z.literal(false) }).strict(),
+});
+const querySchema = z
+  .object({
+    query: z.string(),
+    reason: z.string(),
+    should_activate: z.boolean(),
+  })
+  .strict();
+const evalsSchema = z
+  .object({
+    queries: z.array(querySchema).min(1),
+    skill: z.literal("pr-verdict"),
+    version: z.string(),
+  })
+  .strict();
+
+function readYaml(path: string): unknown {
+  return Bun.YAML.parse(readFileSync(path, "utf8"));
+}
+
+function readFrontmatter(path: string): unknown {
+  const contents = readFileSync(path, "utf8");
+  const yaml = frontmatterPattern.exec(contents)?.groups?.yaml;
+
+  if (yaml === undefined) {
+    throw new Error(`Missing YAML frontmatter in ${path}`);
+  }
+  return Bun.YAML.parse(yaml);
+}
+
+test("keeps pr-verdict manual-only across supported agents", () => {
+  const frontmatter = prVerdictFrontmatterSchema.parse(
+    readFrontmatter(join(prVerdictRoot, "SKILL.md")),
+  );
+  const openAiMetadata = openAiMetadataSchema.parse(
+    readYaml(join(prVerdictRoot, "agents/openai.yaml")),
+  );
+  const evals = evalsSchema.parse(
+    JSON.parse(
+      readFileSync(join(prVerdictRoot, "evals/trigger-queries.json"), "utf8"),
+    ),
+  );
+  const implicitActivations = evals.queries.filter(
+    ({ query, should_activate }) =>
+      should_activate && !explicitInvocationPattern.test(query),
+  );
+  const explicitActivations = evals.queries
+    .filter(({ should_activate }) => should_activate)
+    .map(({ query }) => query);
+  const alwaysLoadedInstructions = ["AGENTS.md", "USER.md"]
+    .map((name) => readFileSync(join(repositoryRoot, "harness", name), "utf8"))
+    .join("\n");
+  const prFix = readFileSync(
+    join(repositoryRoot, "harness/skills/pr-fix/SKILL.md"),
+    "utf8",
+  );
+
+  expect(frontmatter["disable-model-invocation"]).toBeTrue();
+  expect(frontmatter.description).toContain("explicitly invokes");
+  expect(openAiMetadata.policy.allow_implicit_invocation).toBeFalse();
+  expect(implicitActivations).toEqual([]);
+  expect(explicitActivations).toContain("$pr-verdict 1042");
+  expect(explicitActivations).toContain("/pr-verdict 1042");
+  expect(alwaysLoadedInstructions).not.toContain("pr-verdict");
+  expect(prFix).toContain("Activate `pr-verdict`");
+});
+
+test("doctors the manual-only host metadata as one paired exception", () => {
+  const skillManagerReferences = join(
+    repositoryRoot,
+    "harness/skills/skill-manager/references",
+  );
+  const conventions = readFileSync(
+    join(skillManagerReferences, "conventions.md"),
+    "utf8",
+  );
+  const doctor = readFileSync(
+    join(skillManagerReferences, "doctor.md"),
+    "utf8",
+  );
+
+  expect(conventions).toContain(
+    "`disable-model-invocation: true` is the sole approved top-level host extension",
+  );
+  expect(conventions).toContain("`policy.allow_implicit_invocation: false`");
+  expect(doctor).toContain("approved extension: disable-model-invocation");
+  expect(doctor).toContain("true eval queries use only `$<slug>` or `/<slug>`");
+});


### PR DESCRIPTION
## Description

- Require explicit `$pr-verdict` invocation in Codex or `/pr-verdict` in Claude Code and Cursor.
- Remove always-loaded instructions that could select the skill during PR authoring or unrelated implementation work.
- Keep explicit `pr-fix` composition while making every natural-language activation eval negative.
- Document the paired host-specific portability exception and enforce it with a regression contract test.

This intentionally changes `pr-verdict` activation semantics: the workflow remains available, but agents must not select it implicitly.

## Useful Links

- [Codex skill configuration](https://learn.chatgpt.com/docs/build-skills)
- [Claude Code skill invocation controls](https://code.claude.com/docs/en/slash-commands#control-who-invokes-a-skill)
- [Cursor automatic invocation controls](https://cursor.com/docs/skills#disabling-automatic-invocation)

## How to Test

On macOS with Bun 1.4.0 and Node 24.20.0:

```sh
bun --config=/dev/null --no-env-file test --timeout 15000
bun --config=/dev/null --no-env-file tooling/lint-typescript.ts
bun --config=/dev/null --no-env-file run typecheck
bun --config=/dev/null --no-env-file run format:typescript:check
```

Result: 370 tests passed; 4 optional integration tests skipped; lint, typecheck, and formatting passed. `skills-ref` was unavailable, so the skill-manager doctor contract was validated locally by the regression test and manual audit.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
