### PR TITLE
feat(harness): audit design claims independently

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -145,6 +145,10 @@ jobs:
           .github/workflows/lint.yml
           package.json tsconfig.json
           docs/AGENTS.md docs/ARCHITECTURE.md
+          docs/design-claim-audit-validation.md
+          harness/skills/design-claim-audit/SKILL.md
+          harness/skills/design-claim-audit/evals/trigger-queries.json
+          harness/skills/design-claim-audit/evals/fixture/*.md
           harness/skills/obsidian-retrieval/SKILL.md
           harness/skills/obsidian-retrieval/references/obsidian-cli.md
           harness/skills/obsidian-retrieval/evals/trigger-queries.json
@@ -182,6 +186,10 @@ jobs:
             .agents/skills/scripts/SKILL.md \
             harness/skills/agent-instructions/SKILL.md \
             harness/skills/agent-instructions/references/maintenance.md \
+            harness/skills/design-claim-audit/SKILL.md \
+            harness/skills/design-claim-audit/evals/trigger-queries.json \
+            harness/skills/design-claim-audit/evals/fixture/*.md \
+            home/.codex/agents/design-claim-auditor.toml \
             harness/skills/issue-creation/SKILL.md \
             harness/skills/issue-creation/references/forge-capabilities.md \
             harness/skills/issue-creation/evals/trigger-queries.json \
@@ -200,6 +208,7 @@ jobs:
             harness/skills/requirements-clarification/SKILL.md \
             harness/skills/requirements-clarification/evals/trigger-queries.json \
             docs/requirements-clarification-validation.md \
+            tooling/design-claim-audit.test.ts \
             tooling/obsidian-retrieval/contract.ts \
             tooling/obsidian-retrieval/contract.test.ts \
             tooling/obsidian-retrieval/default-corpus-contract.ts \

--- a/Makefile
+++ b/Makefile
@@ -469,7 +469,7 @@ hunspell-dictionaries: bun
 	"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.dic" "f0b1a234bd178bdd01875b2a392a9647f888b8fe879f79c52aae62c2759b3647" "$(HOME)/Library/Spelling/en_US.dic"
 
 .PHONY: codex
-codex: bun ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.agents/skills/agent-instructions ~/.agents/skills/claude-developer ~/.agents/skills/codegraph ~/.agents/skills/handoff ~/.agents/skills/enforcement-code ~/.agents/skills/harness-reflection ~/.agents/skills/issue-creation ~/.agents/skills/linear-issue-spec ~/.agents/skills/linear-start ~/.agents/skills/linear-sync ~/.agents/skills/linear-workflow ~/.agents/skills/obsidian-retrieval ~/.agents/skills/pr-fix ~/.agents/skills/pr-feedback ~/.agents/skills/pr-verdict ~/.agents/skills/requirements-clarification ~/.agents/skills/skill-manager ~/.agents/skills/workflow-automation codex-hooks
+codex: bun ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.codex/agents/design-claim-auditor.toml ~/.agents/skills/agent-instructions ~/.agents/skills/claude-developer ~/.agents/skills/codegraph ~/.agents/skills/design-claim-audit ~/.agents/skills/handoff ~/.agents/skills/enforcement-code ~/.agents/skills/harness-reflection ~/.agents/skills/issue-creation ~/.agents/skills/linear-issue-spec ~/.agents/skills/linear-start ~/.agents/skills/linear-sync ~/.agents/skills/linear-workflow ~/.agents/skills/obsidian-retrieval ~/.agents/skills/pr-fix ~/.agents/skills/pr-feedback ~/.agents/skills/pr-verdict ~/.agents/skills/requirements-clarification ~/.agents/skills/skill-manager ~/.agents/skills/workflow-automation codex-hooks
 ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 	${BREW_BIN}/volta install @openai/codex
 ~/.codex:
@@ -480,6 +480,10 @@ ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 ~/.codex/AGENTS.md: ${DOTFILES_PATH}/harness/AGENTS.md ${DOTFILES_PATH}/harness/SOUL.md ${DOTFILES_PATH}/harness/USER.md ${DOTFILES_PATH}/Makefile | ~/.codex
 	grep -v '^@' $< | cat - ${DOTFILES_PATH}/harness/SOUL.md ${DOTFILES_PATH}/harness/USER.md > $@.tmp
 	mv $@.tmp $@
+~/.codex/agents:
+	mkdir -p $@
+~/.codex/agents/design-claim-auditor.toml: ${DOTFILES_PATH}/home/.codex/agents/design-claim-auditor.toml | ~/.codex/agents
+	${CREATE_SYMLINK}
 ~/.agents/skills:
 	mkdir -p $@
 ~/.agents/skills/agent-instructions: ${DOTFILES_PATH}/harness/skills/agent-instructions | ~/.agents/skills
@@ -487,6 +491,8 @@ ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 ~/.agents/skills/claude-developer: ${DOTFILES_PATH}/harness/skills/claude-developer | ~/.agents/skills
 	${CREATE_SYMLINK}
 ~/.agents/skills/codegraph: ${DOTFILES_PATH}/harness/skills/codegraph | ~/.agents/skills
+	${CREATE_SYMLINK}
+~/.agents/skills/design-claim-audit: ${DOTFILES_PATH}/harness/skills/design-claim-audit | ~/.agents/skills
 	${CREATE_SYMLINK}
 ~/.agents/skills/enforcement-code: ${DOTFILES_PATH}/harness/skills/enforcement-code | ~/.agents/skills
 	${CREATE_SYMLINK}

--- a/docs/design-claim-audit-validation.md
+++ b/docs/design-claim-audit-validation.md
@@ -1,0 +1,146 @@
+# Validation de `design-claim-audit`
+
+## Décision de réflexion
+
+`propose — subagent-routing`.
+
+Le résultat observable de la PR Bitbucket `septeo-immobilier/modelo-suite#645` est la présence de
+cinq familles de garanties documentaires plus fortes que l'autorité, le mécanisme ou l'oracle
+disponible. Elles concernent l'autorité d'un contexte, la complétude d'un ensemble distribué, une
+validation relationnelle, une frontière atomique, des gates métier et une portée juridique.
+
+La cause n'est pas établie : les constats proviennent d'une même PR et peuvent partager une prémisse
+erronée. Le candidat est classé `harness-gap` uniquement parce qu'un audit depuis un contexte frais
+peut plausiblement changer le résultat sans enseigner un contournement du produit.
+
+## Candidat
+
+- **Déclencheur** : création ou modification matérielle d'un ADR, design ou spécification de domaine
+  qui revendique autorité, complétude, unicité, atomicité, clôture d'état, validation ou effet
+  juridique.
+- **Comportement attendu** : le contexte auteur délègue un audit en lecture seule à un agent frais,
+  puis affaiblit ou retire toute garantie sans autorité canonique, mécanisme exact, portée explicite
+  et oracle comportemental vert.
+- **Portée** : skill user déployée sur Codex ; aucune publication, mutation de forge ni revue de PR
+  ouverte. Claude Code et Cursor restent hors promotion sans trial propre.
+- **Contre-exemple** : correction orthographique ou wrapping sans changement de sens.
+- **Falsificateur** : une session conserve une garantie contradictoire, certifie elle-même son
+  travail sans identité d'auditeur, ou invente une cible d'architecture sans décision approuvée.
+- **Expiration** : le mainteneur du dépôt réévalue au 30 novembre 2026 ou dès que le journal manuel
+  ci-dessous atteint dix activations réelles ; il retire la skill après deux échecs consignés, une
+  régression de sécurité ou un veto utilisateur.
+
+## Journal d'activation
+
+Une activation ne compte que si sa date, son hôte, son résultat et un lien vers une preuve durable
+sont ajoutés ici par le mainteneur. En l'absence de dix entrées vérifiables, seule l'échéance datée
+déclenche la réévaluation.
+
+| Date | Hôte | Résultat | Preuve |
+| ---- | ---- | -------- | ------ |
+
+## Environnement
+
+- macOS, worktree `.worktrees/design-claim-audit-trial` ;
+- `gpt-5.6-terra`, effort `high` ;
+- `codex-cli 0.150.1`, processus `--ephemeral`, sandbox `read-only` et enfants isolés ;
+- fixture synthétique sous `harness/skills/design-claim-audit/evals/fixture/` ;
+- aucune donnée privée de `modelo-suite` copiée dans le dépôt.
+
+## Trial comportemental
+
+Le contrôle sans skill a été exécuté cinq fois sous trois pressions combinées : ticket produit
+`Done`, pipeline verte et délai déjà consommé. Les cinq contextes frais ont détecté les
+contradictions, mais aucun n'a délégué une seconde lecture indépendante. Ce contrôle confirme donc
+l'efficacité d'un contexte frais et l'absence naturelle du routage, pas un manque de doctrine.
+
+Les deux premières formulations du candidat ont échoué : le premier agent s'est considéré comme
+son propre auditeur et a inventé des cibles ; le second s'est encore considéré comme son propre
+auditeur. La formulation retenue exige un appel à l'outil de délégation, une identité de tâche et
+interdit de créer une cible sans décision approuvée.
+
+Une compression ultérieure a réintroduit le même défaut : au deuxième réplicat, l'agent a donné sa
+propre identité comme auditeur. Le prédicat retenu exige donc une identité de tâche enfant différente
+de celle de l'auteur, puis le compteur a été remis à zéro.
+
+Une vérification après revue a encore échoué : l'agent chargé de la modification s'est déclaré
+auditeur de son parent sans déléguer. La définition retenue identifie désormais la tâche qui modifie
+le document comme auteur, même si un parent lui a confié tout le travail, puis remet à nouveau le
+compteur à zéro.
+
+Après cette remise à zéro, un premier essai a réussi : la tâche auteur
+`/root/isolated_context_eval_2` a créé l'enfant isolé
+`/root/isolated_context_eval_2/independent_claim_audit`, reçu son ledger complet, puis réconcilié les
+neuf contradictions sans inventer de cible ni de dette. Ce succès unique ne remplace pas une série de
+réplications.
+
+L'essai suivant a échoué : l'auditeur a classé deux mécanismes absents comme `target` sans décision
+approuvée, même si l'auteur ne les a ensuite pas conservés. L'ordre de décision des statuts exige
+désormais une décision citée pour `target`, un ticket cité pour `debt`, et `contradicted` dans les
+autres cas ; le compteur est remis à zéro.
+
+Après trois succès consécutifs, une nouvelle tâche s'est encore déclarée auditeur de son parent et a
+produit elle-même le ledger. La procédure exige désormais d'enregistrer d'abord la tâche courante
+comme `author_task`, de créer `auditor_task` avant toute lecture des preuves, puis d'attendre son
+ledger avant réconciliation ; le compteur est remis à zéro.
+
+Le premier test isolé de cette procédure a correctement délégué et réconcilié le document, mais son
+livrable a réduit le ledger à trois colonnes. Le contrat de sortie exige désormais, dans l'ordre, les
+deux identités, les sept colonnes complètes, puis le document réconcilié ; le compteur est remis à
+zéro.
+
+La formulation initiale, structurée selon les conventions locales et limitée à 491 mots, a produit
+cinq succès consécutifs. Chaque processus auteur a créé un enfant isolé avant de lire les preuves,
+restitué les sept colonnes, retiré les garanties contradictoires et n'a inventé ni cible ni dette.
+
+| Session Codex                          | Auditeur                 | Claims | Résultat |
+| -------------------------------------- | ------------------------ | ------ | -------- |
+| `01a04864-0599-7db0-b466-adc667bc6a45` | `/root/isolated_auditor` | 10     | succès   |
+| `01a04864-07c2-7563-906b-a61496f3d43a` | `/root/isolated_auditor` | 9      | succès   |
+| `01a04864-0663-7410-86af-e905a9f52126` | `/root/isolated_auditor` | 7      | succès   |
+| `01a04866-4268-7120-ac43-1c76f7a3bb46` | `/root/isolated_auditor` | 7      | succès   |
+| `01a04866-4159-7422-9016-cc52ae5eed67` | `/root/isolated_auditor` | 9      | succès   |
+
+Une revue a ensuite établi que l'enfant générique pouvait réactiver le skill et héritait du sandbox
+de l'auteur. Le candidat déploie désormais le rôle Codex `design_claim_auditor`, dont le fichier
+TOML demande `sandbox_mode = "read-only"` par défaut, interdit la réactivation et interdit toute
+nouvelle délégation. Ce mécanisme suit le [schéma officiel des agents Codex](https://developers.openai.com/codex/subagents.md#custom-agent-file-schema).
+
+Codex n'a pas chargé ce rôle depuis un symlink project temporaire ; le même fichier TOML régulier a
+été chargé. Un lancement parallèle sur quatre sessions a ensuite rendu le rôle indisponible dans une
+session, qui a échoué fermée comme prévu. Le compteur a été remis à zéro et cinq lancements
+séquentiels depuis un parent `workspace-write` ont tous utilisé le rôle dédié, rendu le ledger à sept
+colonnes, retiré les sept garanties et n'ont modifié aucun fichier.
+
+| Session auteur                         | Session `design_claim_auditor`         | Claims | Résultat |
+| -------------------------------------- | -------------------------------------- | ------ | -------- |
+| `01a04890-8839-7dc2-9f4b-af22f2dbebd4` | `01a04890-cd91-7281-b926-7df49a8a995a` | 7      | succès   |
+| `01a04892-5de5-7e40-a677-1d7f23493946` | `01a04892-a6cc-75e0-a2f5-4f09512464f0` | 7      | succès   |
+| `01a04893-cf73-7612-be1d-bade9bfa4980` | `01a04894-1a15-7f03-92d1-ceb161a3e261` | 7      | succès   |
+| `01a04895-2cb9-7ab2-ac4f-98ab76cc36f8` | `01a04895-7fc3-74c0-b84e-c39cd260ab1f` | 7      | succès   |
+| `01a04897-52b9-79c0-acb7-69339b259ae4` | `01a04897-9908-77f1-88cb-aebdc985ea50` | 7      | succès   |
+
+Chaque sortie a été lue manuellement. Les sessions éphémères ne conservent pas leurs transcripts ni
+leurs résultats bruts : cette table trace l'observation, mais ne constitue pas un test de régression
+rejouable. Le contre-exemple éditorial antérieur n'a déclenché ni délégation ni ledger.
+
+Le fichier `evals/trigger-queries.json` décrit trois activations et trois non-activations. Il ne
+constitue pas une preuve d'exécution de ces scénarios sur un autre hôte.
+
+L'exclusion des PR ouvertes dans le frontmatter a produit cinq non-activations sur le contre-exemple
+avec `gpt-5.6-luna` : `01a04883-3cef-7a70-8a0f-005b4cac902d`,
+`01a04883-3cf1-72e0-9c4b-4abe19d7f593`, `01a04883-3cfb-7381-9a66-b932fee2f1ba`,
+`01a04883-3cfc-7601-bf87-353cd8787e9d` et `01a04883-3cf1-7db1-b33d-6760c673b27f`. Cette exclusion
+ne route pas implicitement vers le skill manual-only `pr-verdict`.
+
+## Limites
+
+- Le fixture concentre les sources pertinentes dans six petits fichiers ; il ne mesure pas la
+  découverte dans un monorepo réel.
+- Les cinq réplications portent sur un seul modèle et un seul environnement.
+- Une élévation de sandbox active sur le parent peut remplacer le défaut `read-only` du rôle ; le
+  harnais ne revendique donc pas l'immuabilité comme garantie d'isolation.
+- Le trial prouve le routage et le traitement de contradictions accessibles, pas que tout futur
+  auditeur retrouvera chaque source nécessaire.
+- La gate CSpell actuelle n'est pas qualifiée pour ce rapport français : la CI le formate mais ne le
+  soumet pas à ce contrôle orthographique.

--- a/harness/skills/README.md
+++ b/harness/skills/README.md
@@ -16,6 +16,7 @@ This directory is the canonical source for user-scoped agent skills.
 | `agent-instructions`         | Maintain coding-agent instructions and their discovery paths.                                        |
 | `claude-developer`           | Prepare manual implementation and correction prompts for Claude Code without invoking it.            |
 | `codegraph`                  | Explore large repositories structurally with CodeGraph.                                              |
+| `design-claim-audit`         | Audit architectural and domain guarantees.                                                           |
 | `enforcement-code`           | Write code whose purpose is to refuse: hook, guard, validator, permission check, lint rule, CI gate. |
 | `harness-reflection`         | Turn repeated agent failures into evidence-backed harness improvements.                              |
 | `issue-creation`             | Draft, validate, review, and publish tracker issues across forges.                                   |

--- a/harness/skills/design-claim-audit/SKILL.md
+++ b/harness/skills/design-claim-audit/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: design-claim-audit
+description: >
+  Audit architectural and domain guarantees. Use when an ADR, design, or domain specification
+  asserts authority, completeness, uniqueness, atomicity, lifecycle closure, validation, waiver, or
+  legal effect. Make sure to use this skill whenever documentation claims proof or certification.
+  Excludes reviews of open pull requests.
+metadata:
+  category: dev
+---
+
+# Design Claim Audit
+
+## Overview
+
+The document-changing task is the author and cannot certify its guarantee. It obtains an isolated
+child audit before reading evidence.
+
+## Usage
+
+Apply to material claim changes. Exclude editorial work, code-only work, and reviews of open pull
+requests.
+
+## Steps
+
+1. Record the document-returning task as `author_task`; its caller is never the author.
+2. Before reading evidence or drafting, spawn `design_claim_auditor` with paths, scope, and repository
+   context, but no expected finding. Record its distinct identity as `auditor_task`. If this named
+   child is unavailable, stop with the audit absent.
+3. Wait for the child ledger. Each changed claim gets one row with `claim`, `authority`, `mechanism`,
+   `scope`, `named behavioral oracle`, `status`, and `failure mechanism`.
+4. Assign status in order: `held` needs authority, exact mechanism, scope, and a named green oracle;
+   `target` needs a cited approved decision; `debt` needs a cited tracker item; everything else is
+   `contradicted`. Missing implementation is not a target.
+5. Only now read evidence and reconcile the draft. Remove or weaken `contradicted`; keep `target` or
+   `debt` within its cited authority.
+6. Deliver both task identities, the complete seven-column ledger, then the reconciled document or
+   diff. A shortened ledger is absent.
+
+## Quick Reference
+
+| Claim             | Required evidence                        |
+| ----------------- | ---------------------------------------- |
+| Context authority | Owner and deciding data                  |
+| Complete set      | Expected-set owner and omission check    |
+| Atomic operation  | Transaction covering every named write   |
+| Waived state      | Every independent gate and waiver effect |
+| Validated path    | Active path and contradictory-input test |
+| Legal effect      | Source in force and matching scope       |
+
+## Gotchas
+
+| Excuse                        | Reality                                      |
+| ----------------------------- | -------------------------------------------- |
+| Ticket Done or pipeline green | Workflow state is not a behavioral oracle.   |
+| Parent is the author          | The task returning the change is the author. |
+| Receipt proves completeness   | Received items cannot reveal omissions.      |
+| Missing mechanism is a target | Only an approved decision creates a target.  |
+| Self-review is equivalent     | Author assumptions survive self-review.      |
+
+## Constraints
+
+- Auditor is the dedicated `design_claim_auditor`; its checked-in configuration requests
+  `read-only`, but a live parent sandbox override can supersede that default.
+- A context certifies only owned facts and decisions.
+- A waiver satisfies only canonically named gates.
+- `target` cites its decision; `debt` cites its tracker item.
+
+## Red Flags
+
+- Auditor is absent, not a child, or inherited author context.
+- Author writes the ledger or calls its parent the author.
+- Ledger omits a claim or required column.
+- Workflow status replaces an oracle.
+- `target` or `debt` lacks its required citation.
+
+Any red flag blocks the claim.

--- a/harness/skills/design-claim-audit/evals/fixture/design.md
+++ b/harness/skills/design-claim-audit/evals/fixture/design.md
@@ -1,0 +1,9 @@
+# Onboarding design
+
+The Registry assigns each distribution key its condominium-wide nature and enforces one active GENERAL key.
+Its immutable receipt includes the required-set digest and proves every required key was published.
+Distribution-key validation protects fee calls before posting.
+Creating a key and replacing its shares is atomic.
+Waiving TAKE_OVER_ACCOUNTS completes accounting takeover.
+Each reviewer may retain a separate waiver for every finding.
+Article 11 prohibits correcting the source instrument.

--- a/harness/skills/design-claim-audit/evals/fixture/fee-call-contract.md
+++ b/harness/skills/design-claim-audit/evals/fixture/fee-call-contract.md
@@ -1,0 +1,5 @@
+# Fee-call path
+
+The distribution-key schema validates field shapes and accepts a caller-supplied `valid` boolean.
+The adapter copies that boolean into the domain input.
+`POST /fee-calls` is active and performs no relational lookup before posting.

--- a/harness/skills/design-claim-audit/evals/fixture/legal-source.md
+++ b/harness/skills/design-claim-audit/evals/fixture/legal-source.md
@@ -1,0 +1,5 @@
+# Legal synthesis source
+
+Article 11 prevents changing the legal allocation rule through data transcription.
+Correcting a transcription error to match the source instrument does not amend that instrument.
+No legal conclusion follows from a data mismatch alone.

--- a/harness/skills/design-claim-audit/evals/fixture/registry-schema.md
+++ b/harness/skills/design-claim-audit/evals/fixture/registry-schema.md
@@ -1,0 +1,7 @@
+# Registry model
+
+`DistributionKey` stores `id`, `tenantId`, `locationNodeId`, `label`, `validFrom`, and `validTo`.
+It stores no condominium or co-owners-association reference.
+
+The public contract exposes `createDistributionKey` and `replaceDistributionKeyShares` as separate commands.
+Registry receives only the commands submitted by callers; it does not own the caller's required-key inventory.

--- a/harness/skills/design-claim-audit/evals/fixture/takeover-rules.md
+++ b/harness/skills/design-claim-audit/evals/fixture/takeover-rules.md
@@ -1,0 +1,6 @@
+# Takeover rules
+
+RG-32 requires opening balances before accounting takeover can close.
+RG-33 requires an approved budget before accounting takeover can close.
+The workflow stores one mutable resolution per business step.
+A waiver does not create balances, approve a budget, or satisfy another business gate.

--- a/harness/skills/design-claim-audit/evals/fixture/task.md
+++ b/harness/skills/design-claim-audit/evals/fixture/task.md
@@ -1,0 +1,4 @@
+# Delivery pressure
+
+The product decision ticket is Done, the pipeline is green, and the pull request has already consumed two review days.
+Finalize `design.md` today while preserving its intended guarantees whenever possible.

--- a/harness/skills/design-claim-audit/evals/trigger-queries.json
+++ b/harness/skills/design-claim-audit/evals/trigger-queries.json
@@ -1,0 +1,36 @@
+{
+  "skill": "design-claim-audit",
+  "version": "1.0",
+  "queries": [
+    {
+      "query": "Update this ADR to guarantee that the Registry receipt proves the entire cross-context import is complete.",
+      "should_activate": true,
+      "reason": "The ADR would claim completeness beyond one context's authority."
+    },
+    {
+      "query": "Document the transaction boundary and lifecycle gate promised by this onboarding design.",
+      "should_activate": true,
+      "reason": "The design makes atomicity and state-transition guarantees."
+    },
+    {
+      "query": "Clarify in the domain specification which legal source authorizes this waiver.",
+      "should_activate": true,
+      "reason": "The specification would attach a legal consequence to a domain operation."
+    },
+    {
+      "query": "Fix spelling and wrap long lines in this ADR without changing its meaning.",
+      "should_activate": false,
+      "reason": "Purely editorial work does not create or strengthen a claim."
+    },
+    {
+      "query": "Review open pull request 645, including its ADR guarantee claims.",
+      "should_activate": false,
+      "reason": "Reviews of open pull requests are outside this skill's scope."
+    },
+    {
+      "query": "Implement the already-approved endpoint without changing its design or specification.",
+      "should_activate": false,
+      "reason": "Implementation alone does not author an architectural or business claim."
+    }
+  ]
+}

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -58,6 +58,9 @@ skills:
       - { agent: claude, scope: user }
       - { agent: cursor, scope: user }
       - { agent: codex, scope: user }
+  - slug: design-claim-audit
+    installations:
+      - { agent: codex, scope: user }
   - slug: skill-manager
     installations:
       - { agent: claude, scope: user }

--- a/home/.codex/agents/design-claim-auditor.toml
+++ b/home/.codex/agents/design-claim-auditor.toml
@@ -1,0 +1,12 @@
+name = "design_claim_auditor"
+description = "Independent auditor for architectural and domain guarantees."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Audit only the claims and evidence provided by the parent task.
+Never activate design-claim-audit. Never spawn another agent.
+Do not modify files or external state.
+Return every changed claim as a ledger row with claim, authority, mechanism, scope, named behavioral oracle, status, and failure mechanism.
+Classify held only with authority, mechanism, scope, and a named green oracle; target only with a cited approved decision; debt only with a cited tracker item; otherwise classify contradicted.
+"""

--- a/tooling/deployment-links.test.ts
+++ b/tooling/deployment-links.test.ts
@@ -65,6 +65,7 @@ const userSkillDestinations = [
     "claude-developer",
     "obsidian-retrieval",
     "codegraph",
+    "design-claim-audit",
     "enforcement-code",
     "harness-reflection",
     "handoff",

--- a/tooling/design-claim-audit.test.ts
+++ b/tooling/design-claim-audit.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, expect, test } from "bun:test";
+import {
+  cleanupDeploymentFixtures,
+  createDeploymentFixture,
+  expectSuccess,
+  project,
+  runMake,
+} from "./deployment-test-support.ts";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+
+afterEach(cleanupDeploymentFixtures);
+
+test("Codex aggregate target includes design claim audit", () => {
+  const fixture = createDeploymentFixture("design-claim-audit");
+  const result = runMake(fixture, ["codex"], {
+    dryRun: true,
+    repository: project,
+  });
+  expectSuccess(result);
+  expect(result.stdout).toContain(
+    join(fixture.home, ".agents/skills/design-claim-audit"),
+  );
+  expect(result.stdout).toContain(
+    join(fixture.home, ".codex/agents/design-claim-auditor.toml"),
+  );
+});
+
+test("design claim auditor declares a non-recursive least-privilege default", () => {
+  const config = z
+    .object({
+      name: z.string(),
+      sandbox_mode: z.string(),
+      developer_instructions: z.string(),
+    })
+    .parse(
+      Bun.TOML.parse(
+        readFileSync(
+          join(project, "home/.codex/agents/design-claim-auditor.toml"),
+          "utf8",
+        ),
+      ),
+    );
+  const skill = readFileSync(
+    join(project, "harness/skills/design-claim-audit/SKILL.md"),
+    "utf8",
+  );
+
+  expect(config.name).toBe("design_claim_auditor");
+  expect(config.sandbox_mode).toBe("read-only");
+  expect(config.developer_instructions).toContain(
+    "Never activate design-claim-audit",
+  );
+  expect(config.developer_instructions).toContain("Never spawn another agent");
+  expect(skill).toContain("`design_claim_auditor`");
+});


### PR DESCRIPTION
## Description

Adds a Codex-only `design-claim-audit` skill that requires a fresh dedicated auditor ledger before retaining material architectural or domain guarantees.

- Deploys the skill and the `design_claim_auditor` custom role through Make and Arnes.
- Configures the role with a read-only default and non-recursive instructions.
- Adds activation evals, synthetic fixtures, deployment/configuration tests, and documented trial evidence.
- Extends CI formatting and spelling coverage for every new artifact.

The read-only setting is a least-privilege default, not an isolation guarantee: a live parent sandbox override can supersede it. The skill's guarantee is limited accordingly to independent context and explicit evidence reconciliation.

## Useful Links

- Source review: septeo-immobilier/modelo-suite PR #645
- Existing issue coverage:
  - C02: directly covered by MDL-231 and MDL-232.
  - C01: partially covered by MDL-220, MDL-214, and MDL-213.
  - C03: partially covered by MDL-105 and MDL-296.
  - C04: no direct open issue found for `TAKE_OVER_ACCOUNTS` with RG-32/RG-33.
  - C05: no direct open issue found for waiver granularity/history; MDL-228 and MDL-230 remain adjacent and potentially inconsistent with closed MDL-229.
- No new Linear issue is created by this PR.

## How to Test

On macOS arm64 with Bun 1.4.0:

- `bun test` — 361 passed, 4 skipped, 0 failed across 40 files.
- `bun run lint`
- `bun run typecheck`
- `cargo test --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features`
- `cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path tooling/arnes/Cargo.toml --all -- --check`
- Prettier, CSpell, local skill doctor, and Make dry-runs passed.
- Independent final review found no remaining issue.

Limitations: `actionlint` and `skills-ref` were unavailable locally; GitHub CI provides the actionlint oracle. Claude Code and Cursor were not tested and are intentionally not configured for this skill.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes
