### PR TITLE
feat(skills): require behavior evidence in PR verdicts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -154,6 +154,9 @@ jobs:
           harness/skills/obsidian-retrieval/evals/trigger-queries.json
           harness/skills/pr-feedback/SKILL.md
           harness/skills/pr-feedback/evals/trigger-queries.json
+          harness/skills/pr-verdict/SKILL.md
+          harness/skills/pr-verdict/assets/verdict-template.md
+          harness/skills/pr-verdict/references/cases.md
           harness/skills/requirements-clarification/SKILL.md
           harness/skills/requirements-clarification/evals/trigger-queries.json
           docs/requirements-clarification-validation.md
@@ -205,6 +208,9 @@ jobs:
             harness/skills/obsidian-retrieval/evals/trigger-queries.json \
             harness/skills/pr-feedback/SKILL.md \
             harness/skills/pr-feedback/evals/trigger-queries.json \
+            harness/skills/pr-verdict/SKILL.md \
+            harness/skills/pr-verdict/assets/verdict-template.md \
+            harness/skills/pr-verdict/references/cases.md \
             harness/skills/requirements-clarification/SKILL.md \
             harness/skills/requirements-clarification/evals/trigger-queries.json \
             docs/requirements-clarification-validation.md \

--- a/harness/skills/pr-verdict/SKILL.md
+++ b/harness/skills/pr-verdict/SKILL.md
@@ -18,10 +18,10 @@ metadata:
 
 The output is a verdict that commits to a merge decision, not a list of remarks. Three properties
 separate it from a default agent review: every blocking finding names a failure mechanism that
-breaks an invariant the code claims to hold, the evidence is measured on the exact head SHA under
-review, and the limits of that evidence are declared inside the verdict. A green barrier whose gaps
-stay implicit is the failure this skill exists to prevent — a verdict is only as strong as what it
-admits it did not test.
+breaks an invariant the code claims to hold, every changed observable behavior has explicit
+behavior-level evidence, and the limits of that evidence are declared inside the verdict. A green
+barrier whose gaps stay implicit is the failure this skill exists to prevent — a verdict is only as
+strong as what it admits it did not test.
 
 Not for re-reading your own diff before committing: perform that review and verification directly.
 This skill judges an open pull request and engages a decision the team will act on. That the PR is
@@ -66,12 +66,23 @@ says to post directly.
    finding before the flow is traced end to end is forbidden: the mechanism is what makes a finding
    blocking, and you cannot name a mechanism you have not followed.
 
+   Inventory every externally observable behavior added, removed or changed by the diff. Start a
+   changed-behavior ledger with one row per behavior: the behavior, positive evidence on the exact
+   head, a negative witness, and the result. A negative witness is an executed test-first RED or a
+   controlled faulty variant derived from the exact head, shown to fail when the behavior is removed,
+   reversed or broken. Restore and verify the exact head before running its positive barrier. A
+   passing regression test without an observed failing counterpart is positive evidence only; a
+   green aggregate barrier is evidence for no individual row by itself. Record missing evidence as
+   `absent`, never as an inference.
+
 3. **Sweep the failure classes.** Put all ten questions in `references/failure-classes.md` to the
    diff. Record, per class, one of: not applicable, holds because `<evidence>`, or broken by
    `<mechanism>`. Only the third form can become a blocker. When the head under review was written
    in this session, delegate this sweep to a fresh context, read-only and scoped to the diff: the
    context that produced the diff shares the blind spot that produced the defect, and records
-   `holds` for the class it has just broken.
+   `holds` for the class it has just broken. Reconcile the sweep with the changed-behavior ledger:
+   the sweep can add findings, but cannot replace a row or turn absent behavior-level evidence into
+   `holds`.
 
 4. **Run the barrier, then declare its holes.** Run lint, typecheck and tests the way the project
    runs them — including inside a container when the project requires it, since numbers from the
@@ -86,13 +97,21 @@ says to post directly.
    interchangeable — "not observed" written over evidence sitting in the description is a false
    statement about the author's work, and a lift criterion asking for a run the PR already shows
    asks them to repeat themselves. What is missing in that case is a control in the repository:
-   name the control, not the re-run.
+   name the control, not the re-run. Complete the ledger from evidence actually reproduced during
+   this review; evidence supplied by the author but not reproduced stays attributed and does not
+   satisfy an approval row until reproduced.
 
 5. **Return a verdict.** Exactly one of _changes required_, _approved with reservations_,
-   _approved_. Each blocking finding carries its named mechanism and its lift criterion — what must
-   become true for the block to go away. Reservations are for mechanisms whose consequence is
-   bounded; a mechanism that can lose or corrupt data blocks even when the author disagrees. A
-   style, naming or structure preference never blocks: label it non-blocking, or drop it.
+   _approved_. Write the phase-5 verdict in the order defined by `assets/verdict-template.md`, with
+   the complete changed-behavior ledger before the blocking paragraph. Keep one row per inventoried
+   behavior; a prose summary does not replace the rows. Both approval verdicts require every ledger
+   row to contain reproduced positive evidence on the exact head and a reproduced negative witness
+   traceable to its controlled faulty variant, with no contradictory result. Otherwise the verdict
+   is _changes required_, and the missing evidence is the lift criterion. Each other blocking
+   finding carries its named mechanism and its lift criterion — what must become true for the block
+   to go away. Reservations are for mechanisms whose consequence is bounded; a mechanism that can
+   lose or corrupt data blocks even when the author disagrees. A style, naming or structure
+   preference never blocks: label it non-blocking, or drop it.
 
 6. **Trace and publish.** When running inside the pre-repair pass of `pr-fix`, return the phase 5
    verdict without a ticket or publication and let that workflow continue. Otherwise, open or reuse
@@ -103,7 +122,8 @@ says to post directly.
    `<!-- pr-verdict:<pr>:<head-sha-12> -->` — not a rain of inline comments. Search the existing
    comments for that marker first: a verdict carrying the same `<pr>:<sha>` is updated in place,
    never duplicated. Re-read before publishing — past about thirty lines, non-blocking remarks are
-   posing as blockers. On GitHub, _changes required_ is published with
+   posing as blockers; never truncate the required behavior ledger to meet that heuristic. On
+   GitHub, _changes required_ is published with
    `gh pr review --request-changes`, the native state, unless you authored the PR: GitHub refuses it
    there, and Bitbucket has no reliable equivalent at all. Whenever that native state is
    unavailable, the comment _is_ the verdict and its closing sentence carries the whole enforcement
@@ -136,7 +156,7 @@ says to post directly.
   as an `<img>` tag inside the body, and a text pass slides over it. The verdict then announces that
   nothing was observed and makes the merge conditional on steps the author has already run and
   attached, which reads as not having read the PR. Open every attachment in phase 2, and label
-  supplied-but-unreproduced evidence as theirs.
+  supplied evidence not reproduced here as theirs.
 - **Numbers copied from the PR's own pipeline** — a green pipeline is context for phase 1, never the
   barrier of phase 4. The barrier is what you ran, authenticated, on the head you checked out.
 - **The package script mistaken for the CI gate** — the repository's `lint` script may walk the whole
@@ -152,6 +172,11 @@ says to post directly.
 - Never publish a blocking finding without a named failure mechanism and a lift criterion.
 - Never block on style, naming or structure preference; label it non-blocking.
 - Never open a review that is not anchored on a head SHA.
+- Never issue either approval verdict unless every changed observable behavior has reproduced
+  positive evidence on the exact head and a reproduced negative witness.
+- Never infer behavior-level evidence from an aggregate green barrier.
+- Never call a passing test a negative witness without an observed failure when the claimed behavior
+  is broken.
 - Never leave a limit of the evidence implicit; the barrier's gaps belong in the verdict text.
 - Never report as absent, or demand in a lift criterion, evidence the PR already supplies.
 - Never publish two verdicts for the same `<pr>:<sha>`; update the existing comment instead.
@@ -168,5 +193,5 @@ says to post directly.
   questions to put to the diff. Read in phase 3.
 - [assets/verdict-template.md](assets/verdict-template.md) — the verdict skeleton with its required
   slots. Filled in phase 6.
-- [references/cases.md](references/cases.md) — two end-to-end cases with their expected verdicts,
-  one per forge path, and the record of what they have never validated.
+- [references/cases.md](references/cases.md) — three behavioral cases with their expected verdicts,
+  forge coverage, and the record of what they have never validated.

--- a/harness/skills/pr-verdict/assets/verdict-template.md
+++ b/harness/skills/pr-verdict/assets/verdict-template.md
@@ -15,6 +15,14 @@ the PR.
 naming the parent PR when the branch is stacked. Then the CI state, open tasks and conflicts,
 or "none observed".>
 
+<Changed-behavior ledger — REQUIRED. One row per externally observable behavior added, removed or
+changed by the diff:
+| Observable behavior | Positive evidence on the exact head | Negative witness | Result |
+The positive evidence was reproduced on the reviewed head. The negative witness identifies the
+executed test-first RED or controlled faulty variant derived from that head and the failure it
+observed; "test passes" alone is not a negative witness. Use `absent` for missing evidence. Either
+approval verdict is invalid while a row is incomplete or contradicted.>
+
 <Blocking paragraph — one clause per blocker: the mechanism, then the invariant it breaks. Close
 with one sentence stating what must become true to lift them. Omit this paragraph entirely when
 the verdict is "approved".>
@@ -54,6 +62,11 @@ gives numbers, then immediately spends a sentence dismantling its own green.
 Review of PR #1042 on a1b2c3d4e5f6, stacked base feat/ledger-read-side@9f8e7d6c5b4a.
 Pipeline #318 green, no task and no conflict observed.
 
+| Observable behavior | Positive evidence on the exact head | Negative witness | Result |
+| --- | --- | --- | --- |
+| A closing transaction retains concurrent writes | absent | absent | blocked |
+| Concurrent closes produce one successor | absent | absent | blocked |
+
 Blockers: the snapshot and the controls both run before the closing transaction, so a concurrent
 write can vanish from the successor; two simultaneous closes can create two successors, because the
 retry never re-reads the winning result and the uniqueness constraints that would refuse the second
@@ -76,6 +89,8 @@ Do not approve or merge this head.
 ## Self-check before publishing
 
 - The marker is the first line, and its SHA is the head you actually checked out.
+- Every changed observable behavior has one ledger row with reproduced positive evidence and an
+  observed negative witness; an aggregate green barrier is not repeated as row-level evidence.
 - Every clause in the blocking paragraph names a sequence of steps, not a quality judgement.
 - The barrier paragraph contains digits, and a sentence saying what those digits do not prove.
 - The closing sentence tells the reader what to do, not how the reviewer feels.
@@ -85,4 +100,5 @@ Do not approve or merge this head.
 - No lift criterion asks for a run the PR already shows; it names the control the repository lacks.
 - At most three non-blocking lines; a fourth means the section is competing with the verdict.
 - No re-review ticket or `Re-review:` slot; the head-specific verdict is the re-review record.
-- Total under about thirty lines. Past that, preferences have leaked into the blocking section.
+- Outside the required ledger, total under about thirty lines. Past that, preferences have leaked
+  into the blocking section.

--- a/harness/skills/pr-verdict/references/cases.md
+++ b/harness/skills/pr-verdict/references/cases.md
@@ -1,12 +1,13 @@
 # Verdict cases
 
-Two end-to-end cases. Each names the PR to point the skill at, the verdict it must reach, and the
-criteria that decide pass or fail. They are assigned to different forges so that both command sets in
-`references/forges.md` get exercised.
+Three behavioral cases. Each names the PR or evidence package to review, the verdict it must reach,
+and the criteria that decide pass or fail. Cases A and B are assigned to different forges so that
+both command sets in `references/forges.md` get exercised.
 
-Run them against real pull requests — a case that never touched a forge proves nothing about a skill
-whose first phase is anchoring. Use a scratch repository if no suitable PR exists; the domain does not
-matter, the shape of the diff does.
+Run cases A and B against real pull requests — a case that never touched a forge proves nothing about
+a skill whose first phase is anchoring. Use a scratch repository if no suitable PR exists; the domain
+does not matter, the shape of the diff does. Case C deliberately isolates phase-5 ledger retention
+with an evidence package and makes no claim about forge behavior.
 
 ## Case A — changes required (Bitbucket)
 
@@ -40,15 +41,18 @@ index backs the uniqueness the service checks in code. Unit tests exist and pass
 ## Case B — approved with reservations (GitHub)
 
 **Diff under review.** A small, correct bug fix: a null-handling defect repaired at its cause, with
-one regression test covering the reported input. A second input path reaches the same function and is
-not covered, and the error code the endpoint now returns is not documented.
+one regression test covering the reported input and a controlled faulty variant that reproduces its
+test-first RED. A second, unchanged input path reaches the same function and is not covered, and the
+pre-existing error code is not documented.
 
 **Expected verdict:** _approved with reservations_.
 
 **Pass criteria**
 
-- The verdict names the reservation as a bounded consequence: the uncovered second path and the
-  undocumented code (failure class 6), with what would lift each.
+- The changed-behavior ledger records the repaired null input, its passing regression test on the
+  exact head, and the reproduced test-first RED as its negative witness.
+- The verdict names the reservation as a bounded consequence: the unchanged uncovered second path
+  and the pre-existing undocumented code (failure class 6), with what would lift each.
 - The barrier paragraph gives counts and states that coverage is limited to the reported input path.
 - No blocker is raised. Neither an uncovered path nor an undocumented code is a mechanism that loses
   data, so promoting either to a block fails the case.
@@ -61,9 +65,33 @@ not covered, and the error code the endpoint now returns is not documented.
 - "Everything is green" with no counts.
 - A barrier paragraph with no statement of what the single test does not cover.
 
+## Case C — changed behavior without negative witnesses
+
+**Evidence package under review.** A rolling-deployment change claims four observable contracts:
+historical cursors preserve their original ordering, create replay returns the original resource
+without a second allocation, a schema migration publishes atomically, and the public contract
+declares the conflict returned for an identical in-progress request. The exact head passes a large
+aggregate barrier, but the review record contains no test-first RED or controlled faulty variant for
+any of the four contracts.
+
+**Expected verdict:** _changes required_.
+
+**Pass criteria**
+
+- The changed-behavior ledger retains all four contracts as separate rows.
+- Aggregate barrier results are not substituted for behavior-level evidence.
+- Every missing negative witness is recorded as `absent`.
+- The verdict is _changes required_, with the four witnesses as lift criteria.
+
+**Fail signals**
+
+- Either approval verdict because the aggregate barrier is green.
+- A summary paragraph that drops one or more ledger rows.
+- A passing regression test described as a negative witness without an observed failing counterpart.
+
 ## Execution record
 
-Both cases were run once, on 2026-08-11, phases 1 to 5 only — publication was deliberately not
+Cases A and B were run once, on 2026-08-11, phases 1 to 5 only — publication was deliberately not
 reached. A third run, on 2026-08-12, was a real review rather than a case, and went through phase 6.
 
 - **Case A**, on a Bitbucket PR (`bkt`), reached _changes required_ as expected, on the three
@@ -75,7 +103,7 @@ reached. A third run, on 2026-08-12, was a real review rather than a case, and w
 - **Case B**, on a GitHub PR (`gh`), ran end to end but produced _changes required_ rather than the
   expected reservations: the target held a measured mechanism that destroys an unversioned file and
   still reports success. The expectation was wrong about the target, not about the skill — the
-  _approved with reservations_ path therefore remains unexercised.
+  original target therefore did not exercise the _approved with reservations_ path.
 - **Third run**, on GitHub, phases 1 to 6, first publication the skill has ever performed: a general
   comment written through a body file, plus a fix ticket and the re-review ticket the procedure then
   required. Verdict _changes required_, on classes 4 and 5 only. Five gaps came back into the skill.
@@ -87,6 +115,20 @@ reached. A third run, on 2026-08-12, was a real review rather than a case, and w
   different commands over different file sets, and only the second measures the head. And the
   non-blocking section grew until it rivalled the blocking one, which is where the three-line cap
   comes from. Last, the request anticipated a PR that was not open yet, a case phase 1 assumed away.
+
+Case C was run on 2026-08-28 in fresh Codex subagent contexts using GPT-5.4 at high reasoning effort.
+The candidate guidance retained all four rows in 3/3 runs. The first integrated wording returned the
+right block in 3/3 runs but retained the ledger rows in 0/3, so it was rejected; after phase 5 gained
+the template-ordered output contract, 3/3 new runs retained all four rows, marked every negative
+witness absent and returned _changes required_, with no contradictory result. The scenario supplied
+an already-run barrier and stopped at phase 5, so it validates verdict reasoning and ledger
+retention, not forge anchoring, command execution or publication.
+
+The revised Case B evidence package was run on 2026-08-28 in three fresh contexts with the same model
+and effort. All three retained the completed ledger row and returned _approved with reservations_;
+no contradictory result was observed. This isolates the approval decision after exact-head positive
+evidence and a controlled negative witness were supplied; it does not replace the original GitHub
+forge run.
 
 Nothing has yet validated: the marker's idempotent update, the duplicate-verdict guard, or Bitbucket
 comment publication.
@@ -102,9 +144,9 @@ since the blocking case is assigned to Bitbucket. The third run attempted it and
 the account being the PR's author; that measures the refusal, not the success path. Run case A a
 second time on GitHub, on a PR the account did not write, or the enforcement path stays unverified.
 
-_Approved with reservations_ has never been produced: both cases that reached a verdict landed on
-_changes required_. The state that requires stating a bound rather than forbidding a merge is
-therefore the least exercised part of the skill.
+Flat _approved_ has never been produced. The revised Case B evidence package exercises _approved with
+reservations_, but no recorded run yet proves that a clean review with complete ledger rows ends in
+an unconditional approval.
 
 Do not let the runs that went green imply either gap is covered: that is the same substitution of a
 green for a guarantee that phase 4 exists to prevent.

--- a/tooling/pr-verdict-lint-gate.test.ts
+++ b/tooling/pr-verdict-lint-gate.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+const repositoryRoot = resolve(import.meta.dir, "..");
+const workflowPath = resolve(repositoryRoot, ".github/workflows/lint.yml");
+const prVerdictPaths = [
+  "harness/skills/pr-verdict/SKILL.md",
+  "harness/skills/pr-verdict/assets/verdict-template.md",
+  "harness/skills/pr-verdict/references/cases.md",
+] as const;
+
+const stepBody = (workflow: string, name: string): string => {
+  const start = workflow.indexOf(`      - name: ${name}\n`);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const nextStep = workflow.indexOf("\n      - ", start + 1);
+  return workflow.slice(start, nextStep === -1 ? undefined : nextStep);
+};
+
+test("the text lint gates cover every pr-verdict source file", async () => {
+  const workflow = await Bun.file(workflowPath).text();
+  const formatStep = stepBody(workflow, "Check text syntax and formatting");
+  const spellStep = stepBody(
+    workflow,
+    "Check configuration and user dictionary",
+  );
+
+  for (const path of prVerdictPaths) {
+    expect(formatStep).toContain(path);
+    expect(spellStep).toContain(path);
+  }
+});


### PR DESCRIPTION
## Description

- require a complete changed-behavior ledger before either approval verdict
- require reproduced positive evidence on the exact head and an observed negative witness per row
- retain the ledger in the verdict template and record negative and positive behavioral sessions
- add the `pr-verdict` Markdown sources to the repository formatting and spelling gates

## Useful Links

- Issue: none

## How to Test

- `bun run lint`
- `bun run typecheck`
- `bun run format:typescript:check`
- `prettier --check` and `cspell lint` on the changed skill sources
- `bun test tooling` — 362 passed, 4 explicit real-integration skips, 0 failed
- behavioral sessions recorded in `references/cases.md`: rejection 3/3 and approval with reservations 3/3

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
