### PR TITLE
fix(harness): stage new files before validation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -145,6 +145,7 @@ jobs:
           .github/workflows/lint.yml
           package.json tsconfig.json
           docs/AGENTS.md docs/ARCHITECTURE.md
+          harness/AGENTS.md
           docs/adr/039-code-search.md
           docs/adr/README.md docs/code-search.md
           docs/superpowers/plans/2026-08-29-code-search-replacement.md
@@ -194,6 +195,7 @@ jobs:
           HOME="$test_home" cspell lint --config "$test_home/cspell.json" \
             home/cspell.json \
             home/.config/cspell/user.txt \
+            harness/AGENTS.md \
             .agents/skills/scripts/SKILL.md \
             harness/skills/agent-instructions/SKILL.md \
             harness/skills/agent-instructions/references/maintenance.md \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VOLTA_BIN:=$(HOME)/.volta/bin
 PNPM_BIN:=$(HOME)/Library/pnpm
 LOCAL_BIN:=$(HOME)/.local/bin
 APP_BIN:=/Applications
-MINIMAL_SNAPSHOT_PATHS:=.agents/skills .arnes.yaml .claude .claude.json .codex/AGENTS.md .codex/agents .codex/config.toml .config/bat .config/cspell .config/fish .config/git/config.delta .config/git/ignore .config/nvim .config/starship.toml .config/tmux .config/wezterm .gitconfig .local/bin/agent-handoff .local/bin/arnes .local/bin/claude .local/bin/colgrep-search .tmux/plugins/tpm .volta/bin/codex .volta/bin/node .volta/bin/pnpm Library/Spelling cspell.json
+MINIMAL_SNAPSHOT_PATHS:=.agents/skills .arnes.yaml .claude .claude.json .codex/AGENTS.md .codex/agents .config/bat .config/cspell .config/fish .config/git/config.delta .config/git/ignore .config/nvim .config/starship.toml .config/tmux .config/wezterm .gitconfig .local/bin/agent-handoff .local/bin/arnes .local/bin/claude .local/bin/colgrep-search .tmux/plugins/tpm .volta/bin/codex .volta/bin/node .volta/bin/pnpm Library/Spelling cspell.json
 SCRAPLING_IMAGE?=pyd4vinci/scrapling
 CLOAKBROWSER_IMAGE?=cloakhq/cloakbrowser:0.5.3
 DOCKER_UNAVAILABLE_POLICY?=require-docker
@@ -355,7 +355,7 @@ nvim: ~/.config/nvim ~/cspell.json ~/.config/cspell/user.txt
 	@${CREATE_SYMLINK}
 
 .PHONY: git-delta
-git-delta: ~/.config/git/config.delta
+git-delta: ~/.config/git/config.delta ~/.config/git/ignore
 	@includes=$$(git config --global --get-all include.path || test $$? -eq 1) || exit; \
 	if ! printf '%s\n' "$$includes" | grep -Fxq '~/.config/git/config.delta'; then \
 		git config --global --add include.path '~/.config/git/config.delta' || exit; \
@@ -367,6 +367,8 @@ git-delta: ~/.config/git/config.delta
 ~/.config/git:
 	mkdir -p $@
 ~/.config/git/config.delta: ${DOTFILES_PATH}/home/.config/git/config.delta FORCE | ~/.config/git
+	@${CREATE_SYMLINK}
+~/.config/git/ignore: ${DOTFILES_PATH}/home/.config/git/ignore FORCE | ~/.config/git
 	@${CREATE_SYMLINK}
 
 .PHONY: starship

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 ~/.codex/agents:
 	mkdir -p $@
 ~/.codex/agents/design-claim-auditor.toml: ${DOTFILES_PATH}/home/.codex/agents/design-claim-auditor.toml FORCE | ~/.codex/agents
-	cp "$<" "$@"
+	@if [ -f "$@" ] && cmp -s "$<" "$@"; then exit 0; fi; cp "$<" "$@"
 ~/.agents/skills:
 	mkdir -p $@
 ~/.agents/skills/agent-instructions: ${DOTFILES_PATH}/harness/skills/agent-instructions FORCE | ~/.agents/skills

--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -56,9 +56,15 @@ Escalate only when the previous tier fails; never start above the first tier:
 
 ## Verification Claims
 
+- **Index new files before validation.** Before format, lint or typecheck, add every new file in
+  the intended change to Git's index with explicit pathspecs and stop if staging fails. Do not use
+  a broad untracked-file scan to compensate: these gates may deliberately discover inputs from the
+  index, so a pre-staging run is not evidence for the eventual commit.
 - **Check that the barrier covers what changed.** Before saying "green", confirm a linter
   and a test actually run on the extensions you touched. If nothing covers them, that gap
   is the first thing to fix — not a reason to claim green.
+- **Treat hooks as advisory.** A hook that can be bypassed is not the final barrier; verify the
+  indexed change with the repository checks and require the remote CI before merge.
 - **Name the environment.** Every piece of evidence states where it was produced and is
   valid only there. Green on one platform, one shell or one image says nothing about the
   others the project supports: list the supported targets, say which you exercised.

--- a/home/.config/cspell/user.txt
+++ b/home/.config/cspell/user.txt
@@ -2,6 +2,9 @@ AppleScript
 backlink
 backlinks
 backticked
+cloakbrowser
+cloakhq
+cloakserve
 colgrep
 cstring
 diffstat
@@ -15,9 +18,11 @@ libc
 mkfifo
 osascript
 pagelen
+pathspecs
 pullrequests
 renameat
 renamex
+scrapling
 wezterm
 wikilinks
 worktree

--- a/tooling/agent-instructions-lint-gate.test.ts
+++ b/tooling/agent-instructions-lint-gate.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+const workflowPath = resolve(import.meta.dir, "../.github/workflows/lint.yml");
+
+const stepBody = (workflow: string, name: string): string => {
+  const start = workflow.indexOf(`      - name: ${name}\n`);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const nextStep = workflow.indexOf("\n      - ", start + 1);
+  return workflow.slice(start, nextStep === -1 ? undefined : nextStep);
+};
+
+test("text CI formats and spellchecks the canonical agent instructions", async () => {
+  const workflow = await Bun.file(workflowPath).text();
+  const formatStep = stepBody(workflow, "Check text syntax and formatting");
+  const spellStep = stepBody(
+    workflow,
+    "Check configuration and user dictionary",
+  );
+
+  expect(formatStep).toContain("harness/AGENTS.md");
+  expect(spellStep).toContain("harness/AGENTS.md");
+});

--- a/tooling/deployment-xdg.test.ts
+++ b/tooling/deployment-xdg.test.ts
@@ -37,6 +37,7 @@ test("deploys XDG links while preserving obsolete user links", () => {
     join(project, "home", ".config", "wezterm", "wezterm.lua"),
     join(project, "home", ".config", "tmux", "tmux.conf"),
     join(project, "home", ".config", "git", "config.delta"),
+    join(project, "home", ".config", "git", "ignore"),
   ]);
   expect(legacy.map((name) => linkTarget(join(fixture.home, name)))).toEqual(
     legacy.map((name) => join(project, "home", name)),
@@ -47,16 +48,18 @@ test("public targets wire their XDG destinations", () => {
   const fixture = createDeploymentFixture("xdg-wiring");
   const targets = xdgTargets(fixture.home);
   for (const [name, expected] of [
-    ["wezterm", targets[0]],
-    ["tmux", targets[1]],
-    ["git-delta", targets[2]],
+    ["wezterm", [targets[0]]],
+    ["tmux", [targets[1]]],
+    ["git-delta", [targets[2], targets[3]]],
   ] as const) {
     const result = runMake(fixture, [name], {
       dryRun: true,
       repository: project,
     });
     expectSuccess(result);
-    expect(result.stdout).toContain(expected);
+    for (const target of expected) {
+      expect(result.stdout).toContain(target);
+    }
   }
 });
 
@@ -219,10 +222,11 @@ function git(fixture: Fixture, arguments_: readonly string[]): void {
   }
 }
 
-function xdgTargets(home: string): [string, string, string] {
+function xdgTargets(home: string): [string, string, string, string] {
   return [
     join(home, ".config", "wezterm", "wezterm.lua"),
     join(home, ".config", "tmux", "tmux.conf"),
     join(home, ".config", "git", "config.delta"),
+    join(home, ".config", "git", "ignore"),
   ];
 }

--- a/tooling/validation-sequencing.test.ts
+++ b/tooling/validation-sequencing.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, expect, test } from "bun:test";
+import { join, resolve } from "node:path";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { lintTrackedTypeScript } from "./lint-typescript.ts";
+import { tmpdir } from "node:os";
+
+const repositoryRoot = resolve(import.meta.dir, "..");
+const oxlint = resolve(repositoryRoot, "node_modules/.bin/oxlint");
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+const run = async (
+  command: readonly string[],
+  cwd: string,
+): Promise<Readonly<{ status: number; stderr: string; stdout: string }>> => {
+  const child = Bun.spawn([...command], {
+    cwd,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [status, stderr, stdout] = await Promise.all([
+    child.exited,
+    new Response(child.stderr).text(),
+    new Response(child.stdout).text(),
+  ]);
+  return { status, stderr, stdout };
+};
+
+const assertCommandSuccess = (
+  result: Readonly<{ status: number; stderr: string; stdout: string }>,
+): void => {
+  if (result.status !== 0) {
+    throw new Error(`${result.stdout}\n${result.stderr}`);
+  }
+};
+
+test("keeps a staging failure visible", async () => {
+  const repository = await mkdtemp(join(tmpdir(), "validation-sequencing-"));
+  temporaryDirectories.push(repository);
+  assertCommandSuccess(await run(["git", "init", "-q"], repository));
+
+  const failedAddition = await run(["git", "add", "missing.ts"], repository);
+  expect(() => {
+    assertCommandSuccess(failedAddition);
+  }).toThrow("pathspec");
+});
+
+test("lint only validates a new TypeScript file after it enters the index", async () => {
+  const repository = await mkdtemp(join(tmpdir(), "validation-sequencing-"));
+  temporaryDirectories.push(repository);
+  const initialization = await run(["git", "init", "-q"], repository);
+  assertCommandSuccess(initialization);
+  await Promise.all([
+    symlink(
+      join(repositoryRoot, "node_modules"),
+      join(repository, "node_modules"),
+      "dir",
+    ),
+    Bun.write(
+      join(repository, ".oxlintrc.json"),
+      Bun.file(join(repositoryRoot, ".oxlintrc.json")),
+    ),
+    writeFile(
+      join(repository, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { strict: true } }),
+    ),
+    writeFile(
+      join(repository, "tracked.ts"),
+      'export const value = "valid";\n',
+    ),
+    writeFile(join(repository, "new.ts"), "Promise.resolve();\n"),
+  ]);
+  const trackedAddition = await run(["git", "add", "tracked.ts"], repository);
+  assertCommandSuccess(trackedAddition);
+
+  const beforeStaging = await lintTrackedTypeScript(repository, oxlint);
+  expect(beforeStaging.status).toBe(0);
+
+  const newAddition = await run(["git", "add", "new.ts"], repository);
+  assertCommandSuccess(newAddition);
+  const afterStaging = await lintTrackedTypeScript(repository, oxlint);
+  expect(afterStaging.status).toBe(1);
+  expect(`${afterStaging.stdout}\n${afterStaging.stderr}`).toContain(
+    "typescript(no-floating-promises)",
+  );
+});


### PR DESCRIPTION
## Description

Require explicit staging of intended new files before format, lint, and typecheck. Keep untracked discovery bounded, treat hooks as advisory, and add behavioral coverage for the pre-staging lint omission and staging failures. Add the canonical instruction source to Prettier and cspell CI coverage.

## Useful Links

- Issue: none

## How to Test

- bun run format:typescript:check
- bun run lint
- bun run typecheck
- bun test
- prettier --check harness/AGENTS.md .github/workflows/lint.yml
- cspell lint harness/AGENTS.md home/.config/cspell/user.txt using the repository configuration

Local macOS with Bun 1.4.0: 267 tests passed, 2 integration tests skipped, 0 failed. actionlint was unavailable locally; GitHub CI is the final workflow oracle.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)