### PR TITLE
feat(arnes): report observable silence

### DIFF
--- a/docs/arnes-mesure.md
+++ b/docs/arnes-mesure.md
@@ -1,0 +1,22 @@
+# Mesure locale des exécutions Arnes
+
+`arnes measure list --without-result` limite la restitution aux exécutions dont l’historique ne
+contient aucun résultat structuré. `--format json` fournit la même observation sous forme
+structurée.
+
+Le rapport indique une unique référence `reported_at_ms`. Pour chaque exécution, il expose
+`run_id`, `agent`, `started_at_ms`, `last_event`, `last_event_at_ms`,
+`start_to_last_event_ms` et `silence_ms`. Les durées sont exprimées en millisecondes. La sortie
+humaine emploie `unavailable` et la sortie JSON `null` lorsqu’un événement ou une durée ne peut pas
+être jugé. Ces valeurs restent distinctes de zéro.
+
+Les exécutions sont ordonnées par `silence_ms` décroissant ; celles dont la durée est indisponible
+apparaissent ensuite. Un journal d’événements absent ou vide produit des valeurs indisponibles. Un
+enregistrement présent mais invalide reste un échec de mesure visible.
+
+Le silence mesure uniquement l’intervalle observable entre le dernier événement collecté et
+l’heure du rapport. Il ne prouve ni un blocage, ni une progression, ni un temps actif, ni que le
+processus est encore vivant ou arrêté. La commande n’applique aucun seuil et ne modifie,
+n’interrompt ou ne relance aucune exécution.
+
+Cette vue ciblée n’affiche ni prompt, ni contenu utilisateur, ni dépôt, ni secret, ni chemin local.

--- a/tooling/arnes/src/measure/result.rs
+++ b/tooling/arnes/src/measure/result.rs
@@ -22,6 +22,11 @@ pub(super) use records::{ResultRecord, validate_result_record};
 pub struct ListArgs {
     #[arg(long, value_enum)]
     pub agent: Option<HookAgent>,
+    #[arg(
+        long,
+        help = "Report only runs without structured result history; silence does not prove blockage, active time, or process state"
+    )]
+    pub without_result: bool,
     #[arg(long, value_enum, default_value_t)]
     pub format: ListFormat,
 }

--- a/tooling/arnes/src/measure/result/list.rs
+++ b/tooling/arnes/src/measure/result/list.rs
@@ -1,8 +1,11 @@
 use super::super::MeasureError;
 use super::super::model::{PromptRecord, RunRecord};
 use super::io::read_optional_json;
-use super::records::{ResultState, read_events_with, read_first_prompt, result_state};
+use super::records::{
+    ResultState, read_events_for_list_with, read_events_with, read_first_prompt, result_state,
+};
 use super::{ListArgs, ListFormat, ResultRecord, open_run, open_store, validate_result_record};
+use crate::measure::hook::now_ms;
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -12,9 +15,32 @@ struct ListedRun {
     repository: Option<String>,
     first_prompt_excerpt: Option<String>,
     last_event: Option<String>,
+    #[serde(skip)]
+    first_event_at_ms: Option<u64>,
+    #[serde(skip)]
+    last_event_at_ms: Option<u64>,
+    #[serde(skip)]
+    event_timestamps_consistent: bool,
     has_result: bool,
     result_state: ResultState,
     started_at_ms: u64,
+}
+
+#[derive(Serialize)]
+struct SilenceReport {
+    reported_at_ms: u64,
+    runs: Vec<SilentRun>,
+}
+
+#[derive(Serialize)]
+struct SilentRun {
+    run_id: String,
+    agent: String,
+    started_at_ms: u64,
+    last_event: Option<String>,
+    last_event_at_ms: Option<u64>,
+    start_to_last_event_ms: Option<u64>,
+    silence_ms: Option<u64>,
 }
 
 pub fn render(args: ListArgs) -> Result<String, MeasureError> {
@@ -22,12 +48,15 @@ pub fn render(args: ListArgs) -> Result<String, MeasureError> {
     let runs_path = store.runs_path();
     let mut runs = if runs_path.exists()? {
         runs_path.open_directory()?;
-        collect(&store)?
+        collect(&store, args.without_result)?
     } else {
         Vec::new()
     };
     if let Some(agent) = args.agent {
         runs.retain(|run| run.agent == agent.as_str());
+    }
+    if args.without_result {
+        return render_silence(runs, args.format, now_ms());
     }
     runs.sort_by(|left, right| {
         left.started_at_ms
@@ -40,7 +69,10 @@ pub fn render(args: ListArgs) -> Result<String, MeasureError> {
     }
 }
 
-fn collect(store: &super::super::store::Store) -> Result<Vec<ListedRun>, MeasureError> {
+fn collect(
+    store: &super::super::store::Store,
+    allow_empty_events: bool,
+) -> Result<Vec<ListedRun>, MeasureError> {
     let mut runs = Vec::new();
     for name in store.runs_path().read_dir_names()? {
         let run_id = name
@@ -49,10 +81,12 @@ fn collect(store: &super::super::store::Store) -> Result<Vec<ListedRun>, Measure
         let run_dir = open_run(store, &run_id)?;
         let run: RunRecord = super::super::store::validation::read_run(&run_dir.join("run.json"))?;
         let first_prompt = read_first_prompt(&run_dir.join("prompts.jsonl"), &run)?;
-        let (events, result): (_, Option<ResultRecord>) =
-            read_events_with(&run_dir.join("events.jsonl"), &run_id, || {
-                read_optional_json(&run_dir.join("result.json"), "result.json")
-            })?;
+        let read_result = || read_optional_json(&run_dir.join("result.json"), "result.json");
+        let (events, result): (_, Option<ResultRecord>) = if allow_empty_events {
+            read_events_for_list_with(&run_dir.join("events.jsonl"), &run_id, read_result)?
+        } else {
+            read_events_with(&run_dir.join("events.jsonl"), &run_id, read_result)?
+        };
         if let Some(result) = &result {
             validate_result_record(result, &run_id)?;
         }
@@ -63,12 +97,94 @@ fn collect(store: &super::super::store::Store) -> Result<Vec<ListedRun>, Measure
             repository: run.repository,
             first_prompt_excerpt: first_prompt.as_ref().map(first_prompt_excerpt),
             last_event: events.last_event().map(str::to_owned),
+            first_event_at_ms: events.first_event_at_ms(),
+            last_event_at_ms: events.last_event_at_ms(),
+            event_timestamps_consistent: events.timestamps_consistent(),
             has_result: result.is_some(),
             result_state,
             started_at_ms: run.started_at_ms,
         });
     }
     Ok(runs)
+}
+
+fn render_silence(
+    runs: Vec<ListedRun>,
+    format: ListFormat,
+    reported_at_ms: u64,
+) -> Result<String, MeasureError> {
+    let mut runs = runs
+        .into_iter()
+        .filter(|run| run.result_state == ResultState::Pending)
+        .map(|run| SilentRun::new(run, reported_at_ms))
+        .collect::<Vec<_>>();
+    runs.sort_by(|left, right| {
+        right
+            .silence_ms
+            .cmp(&left.silence_ms)
+            .then_with(|| left.run_id.cmp(&right.run_id))
+    });
+    let report = SilenceReport {
+        reported_at_ms,
+        runs,
+    };
+    match format {
+        ListFormat::Json => serde_json::to_string_pretty(&report).map_err(Into::into),
+        ListFormat::Human => Ok(render_human_silence(&report)),
+    }
+}
+
+impl SilentRun {
+    fn new(run: ListedRun, reported_at_ms: u64) -> Self {
+        let durations = run
+            .last_event_at_ms
+            .filter(|last| {
+                run.event_timestamps_consistent
+                    && run
+                        .first_event_at_ms
+                        .is_some_and(|first| run.started_at_ms <= first)
+                    && *last <= reported_at_ms
+            })
+            .map(|last| (last - run.started_at_ms, reported_at_ms - last));
+        Self {
+            run_id: run.run_id,
+            agent: run.agent,
+            started_at_ms: run.started_at_ms,
+            last_event: run.last_event,
+            last_event_at_ms: run.last_event_at_ms,
+            start_to_last_event_ms: durations.map(|value| value.0),
+            silence_ms: durations.map(|value| value.1),
+        }
+    }
+}
+
+fn render_human_silence(report: &SilenceReport) -> String {
+    std::iter::once(format!("reported_at_ms={}", report.reported_at_ms))
+        .chain(report.runs.iter().map(|run| {
+            format!(
+                "{} agent={} started_at_ms={} last_event={} last_event_at_ms={} start_to_last_event_ms={} silence_ms={}",
+                run.run_id,
+                run.agent,
+                run.started_at_ms,
+                optional_text(run.last_event.as_deref()),
+                optional_u64(run.last_event_at_ms),
+                optional_u64(run.start_to_last_event_ms),
+                optional_u64(run.silence_ms)
+            )
+        }))
+        .map(|line| escape_terminal_controls(&line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn optional_text(value: Option<&str>) -> &str {
+    value.unwrap_or("unavailable")
+}
+
+fn optional_u64(value: Option<u64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unavailable".to_owned())
 }
 
 fn first_prompt_excerpt(record: &PromptRecord) -> String {

--- a/tooling/arnes/src/measure/result/records.rs
+++ b/tooling/arnes/src/measure/result/records.rs
@@ -8,7 +8,8 @@ use serde_json::{Map, Value};
 
 mod history;
 pub use history::{
-    EventHistory, ResultState, latest_result, read_events_file, read_events_with, result_state,
+    EventHistory, ResultState, latest_result, read_events_file, read_events_for_list_with,
+    read_events_with, result_state,
 };
 
 #[derive(Clone, Deserialize, PartialEq, Serialize)]

--- a/tooling/arnes/src/measure/result/records/history.rs
+++ b/tooling/arnes/src/measure/result/records/history.rs
@@ -7,11 +7,14 @@ use std::fs::File;
 
 pub struct EventHistory {
     last_event: Option<String>,
+    first_event_at_ms: Option<u64>,
+    last_event_at_ms: Option<u64>,
+    timestamps_consistent: bool,
     latest_result: Option<ResultRecord>,
     previous_result: Option<ResultRecord>,
 }
 
-#[derive(Clone, Copy, Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ResultState {
     Pending,
@@ -46,12 +49,34 @@ pub fn read_events_with<T>(
     Ok((history, result))
 }
 
+pub fn read_events_for_list_with<T>(
+    path: &ManagedPath,
+    run_id: &str,
+    read_result: impl FnOnce() -> Result<T, MeasureError>,
+) -> Result<(EventHistory, T), MeasureError> {
+    match open_locked_jsonl(path)? {
+        Some(mut file) => {
+            let history = read_events_file_allow_empty(&mut file, run_id)?;
+            let result = read_result()?;
+            Ok((history, result))
+        }
+        None => Ok((EventHistory::new(), read_result()?)),
+    }
+}
+
 pub fn read_events_file(file: &mut File, run_id: &str) -> Result<EventHistory, MeasureError> {
+    read_events_file_allow_empty(file, run_id)?.finish()
+}
+
+fn read_events_file_allow_empty(
+    file: &mut File,
+    run_id: &str,
+) -> Result<EventHistory, MeasureError> {
     let mut history = EventHistory::new();
     visit_jsonl_typed_file::<StoredEvent>(file, "events.jsonl", |event| {
         history.push(event, run_id)
     })?;
-    history.finish()
+    Ok(history)
 }
 
 pub fn latest_result(history: &EventHistory) -> Option<&ResultRecord> {
@@ -83,6 +108,9 @@ impl EventHistory {
     fn new() -> Self {
         Self {
             last_event: None,
+            first_event_at_ms: None,
+            last_event_at_ms: None,
+            timestamps_consistent: true,
             latest_result: None,
             previous_result: None,
         }
@@ -97,6 +125,11 @@ impl EventHistory {
         if let Some(result) = event.result {
             self.push_result(result)?;
         }
+        self.first_event_at_ms.get_or_insert(event.timestamp_ms);
+        self.timestamps_consistent &= self
+            .last_event_at_ms
+            .is_none_or(|previous| previous <= event.timestamp_ms);
+        self.last_event_at_ms = Some(event.timestamp_ms);
         self.last_event = Some(event.event);
         Ok(())
     }
@@ -126,6 +159,18 @@ impl EventHistory {
     pub fn last_event(&self) -> Option<&str> {
         self.last_event.as_deref()
     }
+
+    pub fn first_event_at_ms(&self) -> Option<u64> {
+        self.first_event_at_ms
+    }
+
+    pub fn last_event_at_ms(&self) -> Option<u64> {
+        self.last_event_at_ms
+    }
+
+    pub fn timestamps_consistent(&self) -> bool {
+        self.timestamps_consistent
+    }
 }
 
 fn revision_error() -> MeasureError {
@@ -134,7 +179,7 @@ fn revision_error() -> MeasureError {
 
 #[cfg(test)]
 mod tests {
-    use super::read_events_with;
+    use super::{read_events_for_list_with, read_events_with};
     use crate::measure::store::ManagedPath;
     use serde_json::json;
     use std::fs::OpenOptions;
@@ -168,5 +213,35 @@ mod tests {
         .unwrap();
 
         assert_eq!(result, 7);
+    }
+
+    #[test]
+    fn list_keeps_the_event_lock_while_reading_the_result_snapshot() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("events.jsonl");
+        let event_id = "a".repeat(64);
+        let mut file = std::fs::File::create(&path).unwrap();
+        writeln!(
+            file,
+            "{}",
+            json!({
+                "timestamp_ms": 1,
+                "event_id": event_id,
+                "event": "prompt.submit",
+                "native_event": "UserPromptSubmit",
+                "artifact": "artifacts/hooks/event.json",
+                "native_ids": {}
+            })
+        )
+        .unwrap();
+
+        let result =
+            read_events_for_list_with(&ManagedPath::test_path(&path), &"b".repeat(64), || {
+                let other = OpenOptions::new().read(true).write(true).open(&path)?;
+                assert!(other.try_lock().is_err());
+                Ok(7)
+            });
+
+        assert_eq!(result.unwrap().1, 7);
     }
 }

--- a/tooling/arnes/tests/measure_result.rs
+++ b/tooling/arnes/tests/measure_result.rs
@@ -10,3 +10,5 @@ mod list;
 mod measure_support;
 #[path = "measure_result/recovery.rs"]
 mod recovery;
+#[path = "measure_result/silence.rs"]
+mod silence;

--- a/tooling/arnes/tests/measure_result/silence.rs
+++ b/tooling/arnes/tests/measure_result/silence.rs
@@ -1,0 +1,208 @@
+use super::measure_support::*;
+use serde_json::{Value, json};
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const DAY_MS: u64 = 24 * 60 * 60 * 1_000;
+
+#[test]
+fn without_result_orders_oldest_observable_silence_first() {
+    let harness = Harness::new();
+    let now_ms = current_time_ms();
+    let recent = harness.capture("codex", "session_id", "recent", "recent secret prompt");
+    let old = harness.capture("claude-code", "session_id", "old", "old secret prompt");
+    set_observed_times(&harness, &recent, now_ms - 2_000, now_ms - 1_000);
+    set_observed_times(&harness, &old, now_ms - 4 * DAY_MS, now_ms - 3 * DAY_MS);
+
+    let output = harness.run(&["measure", "list", "--without-result", "--format", "json"]);
+
+    assert_success(&output);
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let reported_at_ms = report["reported_at_ms"].as_u64().unwrap();
+    let runs = report["runs"].as_array().unwrap();
+    assert_eq!(runs.len(), 2);
+    assert_eq!(runs[0]["run_id"], old);
+    assert_eq!(runs[0]["agent"], "claude-code");
+    assert_eq!(runs[0]["started_at_ms"], now_ms - 4 * DAY_MS);
+    assert_eq!(runs[0]["last_event"], "prompt.submit");
+    assert_eq!(runs[0]["last_event_at_ms"], now_ms - 3 * DAY_MS);
+    assert_eq!(runs[0]["start_to_last_event_ms"], DAY_MS);
+    assert_eq!(
+        runs[0]["silence_ms"],
+        reported_at_ms - (now_ms - 3 * DAY_MS)
+    );
+    assert_eq!(runs[1]["run_id"], recent);
+    assert_eq!(runs[1]["start_to_last_event_ms"], 1_000);
+    assert_eq!(runs[1]["silence_ms"], reported_at_ms - (now_ms - 1_000));
+    assert!(runs[0]["silence_ms"].as_u64() > runs[1]["silence_ms"].as_u64());
+}
+
+#[test]
+fn without_result_marks_missing_and_incoherent_durations_unavailable() {
+    let harness = Harness::new();
+    let no_event = harness.capture("codex", "session_id", "no-event", "private prompt");
+    fs::write(harness.run_path(&no_event).join("events.jsonl"), b"").unwrap();
+    let future = harness.capture("codex", "session_id", "future", "private prompt");
+    set_observed_times(&harness, &future, u64::MAX - 1, u64::MAX);
+    let reversed = harness.capture("codex", "session_id", "reversed", "private prompt");
+    set_observed_times(&harness, &reversed, 1_000, 2_000);
+    append_event_at(&harness, &reversed, 1_500);
+
+    let output = harness.run(&["measure", "list", "--without-result", "--format", "json"]);
+
+    assert_success(&output);
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(report["reported_at_ms"].as_u64().unwrap() > 0);
+    for run_id in [&no_event, &future, &reversed] {
+        let run = find_run(&report, run_id);
+        assert_eq!(run["start_to_last_event_ms"], Value::Null);
+        assert_eq!(run["silence_ms"], Value::Null);
+    }
+    let no_event_run = find_run(&report, &no_event);
+    assert_eq!(no_event_run["last_event"], Value::Null);
+    assert_eq!(no_event_run["last_event_at_ms"], Value::Null);
+    let human =
+        String::from_utf8(harness.run(&["measure", "list", "--without-result"]).stdout).unwrap();
+    assert!(human.contains(&format!("{no_event} agent=codex started_at_ms=")));
+    assert!(human.contains(
+        "last_event=unavailable last_event_at_ms=unavailable start_to_last_event_ms=unavailable silence_ms=unavailable"
+    ));
+}
+
+#[test]
+fn without_result_excludes_every_run_with_structured_result_history() {
+    let harness = Harness::new();
+    let pending = harness.capture("codex", "session_id", "pending", "prompt");
+    let recorded = harness.capture("codex", "session_id", "recorded", "prompt");
+    let missing_snapshot = harness.capture("codex", "session_id", "missing", "prompt");
+    finish(&harness, &recorded);
+    finish(&harness, &missing_snapshot);
+    fs::remove_file(harness.run_path(&missing_snapshot).join("result.json")).unwrap();
+
+    let output = harness.run(&["measure", "list", "--without-result", "--format", "json"]);
+
+    assert_success(&output);
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let runs = report["runs"].as_array().unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0]["run_id"], pending);
+}
+
+#[test]
+fn without_result_human_and_json_outputs_exclude_sensitive_fields() {
+    let harness = Harness::new();
+    let prompt = "secret user content";
+    let run_id = harness.capture("codex", "session_id", "session", prompt);
+    let local_path = harness.repository.to_str().unwrap();
+
+    let json_output = harness.run(&["measure", "list", "--without-result", "--format", "json"]);
+    let human_output = harness.run(&["measure", "list", "--without-result"]);
+
+    assert_success(&json_output);
+    assert_success(&human_output);
+    let json = String::from_utf8(json_output.stdout).unwrap();
+    let human = String::from_utf8(human_output.stdout).unwrap();
+    for output in [&json, &human] {
+        assert!(output.contains(&run_id));
+        assert!(output.contains("reported_at_ms"));
+        assert!(output.contains("started_at_ms"));
+        assert!(output.contains("last_event"));
+        assert!(output.contains("last_event_at_ms"));
+        assert!(output.contains("start_to_last_event_ms"));
+        assert!(output.contains("silence_ms"));
+        assert!(!output.contains(prompt));
+        assert!(!output.contains(local_path));
+        assert!(!output.contains("repository"));
+    }
+}
+
+#[test]
+fn without_result_keeps_invalid_event_records_visible_as_measurement_failures() {
+    let harness = Harness::new();
+    let run_id = harness.capture("codex", "session_id", "invalid", "private prompt");
+    fs::write(
+        harness.run_path(&run_id).join("events.jsonl"),
+        b"{\"event\":\"prompt.submit\",\"timestamp_ms\":\"invalid\"}\n",
+    )
+    .unwrap();
+
+    assert_failure(
+        &harness.run(&["measure", "list", "--without-result"]),
+        "events.jsonl has an invalid record",
+    );
+}
+
+#[test]
+fn without_result_help_limits_the_interpretation_of_silence() {
+    let harness = Harness::new();
+
+    let output = harness.run(&["measure", "list", "--help"]);
+
+    assert_success(&output);
+    let help = String::from_utf8(output.stdout).unwrap();
+    assert!(help.contains("silence does not prove blockage, active time, or process state"));
+}
+
+fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .try_into()
+        .unwrap()
+}
+
+fn set_observed_times(harness: &Harness, run_id: &str, started_at_ms: u64, event_at_ms: u64) {
+    let run_path = harness.run_path(run_id);
+    let run_json = run_path.join("run.json");
+    let mut run = read_json(&run_json);
+    run["started_at_ms"] = json!(started_at_ms);
+    fs::write(run_json, serde_json::to_vec(&run).unwrap()).unwrap();
+    let events_path = run_path.join("events.jsonl");
+    let mut events = read_jsonl(&events_path);
+    events[0]["timestamp_ms"] = json!(event_at_ms);
+    let content = events
+        .into_iter()
+        .map(|event| serde_json::to_string(&event).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    fs::write(events_path, content).unwrap();
+}
+
+fn find_run<'a>(report: &'a Value, run_id: &str) -> &'a Value {
+    report["runs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|run| run["run_id"] == run_id)
+        .unwrap()
+}
+
+fn append_event_at(harness: &Harness, run_id: &str, timestamp_ms: u64) {
+    let path = harness.run_path(run_id).join("events.jsonl");
+    let mut events = read_jsonl(&path);
+    let mut event = events[0].clone();
+    event["timestamp_ms"] = json!(timestamp_ms);
+    event["event_id"] = json!("b".repeat(64));
+    events.push(event);
+    let content = events
+        .iter()
+        .map(|event| serde_json::to_string(event).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    fs::write(path, content).unwrap();
+}
+
+fn finish(harness: &Harness, run_id: &str) {
+    assert_success(&harness.run(&[
+        "measure",
+        "finish",
+        run_id,
+        "--merge-ready",
+        "pass",
+        "--human-minutes",
+        "1",
+    ]));
+}


### PR DESCRIPTION
## Description

Les exécutions sans résultat structuré étaient visibles dans `arnes measure list`, mais leur silence observable ne pouvait pas être inspecté sans exposer aussi le dépôt et un extrait du prompt.

Cette PR ajoute `arnes measure list --without-result`. Les sorties humaine et JSON indiquent l'heure du rapport, le début observé, le dernier événement et ses durées, classent les silences les plus longs en premier, et conservent `null`/`unavailable` pour les valeurs non jugeables. La vue exclut les historiques déjà qualifiés, les données sensibles et toute interprétation de blocage, progression ou état du processus.

La lecture tolérante des journaux absents ou vides reste limitée à cette vue. Les enregistrements invalides échouent toujours visiblement et le verrou des événements couvre la lecture du snapshot de résultat.

## Useful Links

- Closes #264
- Parent: #255

## How to Test

Sur macOS 26.6.2 arm64 avec Rust 1.98.0 :

```sh
cargo fmt --manifest-path tooling/arnes/Cargo.toml --check
RUSTFLAGS=-Funsafe-code cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings
RUSTFLAGS=-Funsafe-code cargo test --manifest-path tooling/arnes/Cargo.toml
prettier --check docs/arnes-mesure.md
```

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes
