### PR TITLE
feat: orchestrate Arnes check with Moon

### DIFF
--- a/.agents/skills/scripts/SKILL.md
+++ b/.agents/skills/scripts/SKILL.md
@@ -13,9 +13,9 @@ metadata:
 ## Overview
 
 Keep Bash at the process boundary: bootstrap a machine, set environment, and invoke fixed commands
-in a short linear sequence. Use Just for named development recipes, Bun and TypeScript for small
-testable utilities, and Rust for substantial or system-oriented CLIs. Existing complex shell is
-legacy to reduce, not a pattern for new work.
+in a short linear sequence. Use Moon for named development tasks, project graphs, and affected
+selection, Bun and TypeScript for small testable utilities, and Rust for substantial or
+system-oriented CLIs. Existing complex shell is legacy to reduce, not a pattern for new work.
 
 ## Usage
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -142,11 +142,12 @@ jobs:
       - name: Check text syntax and formatting
         run: >-
           prettier --check .github/ISSUE_TEMPLATE/change.yml .github/dependabot.yml
-          .github/workflows/lint.yml
+          .github/workflows/lint.yml .github/workflows/test-moon-arnes.yml
+          .moon/workspace.yml tooling/arnes/moon.yml
           package.json tsconfig.json
           docs/AGENTS.md docs/ARCHITECTURE.md
           harness/AGENTS.md
-          docs/adr/039-code-search.md
+          docs/adr/039-code-search.md docs/adr/041-frontiere-automatisation-typescript-rust.md
           docs/adr/README.md docs/code-search.md
           docs/superpowers/plans/2026-08-29-code-search-replacement.md
           docs/superpowers/specs/2026-08-29-code-search-design.md

--- a/.github/workflows/test-moon-arnes.yml
+++ b/.github/workflows/test-moon-arnes.yml
@@ -1,0 +1,26 @@
+name: Moon affected Arnes check
+
+on:
+  pull_request:
+    paths:
+      - .moon/**
+      - .cargo/**
+      - tooling/arnes/**
+
+jobs:
+  moon:
+    name: Moon affected Arnes check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      MOON_BASE: ${{ github.event.pull_request.base.sha }}
+      MOON_HEAD: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - uses: moonrepo/setup-toolchain@v0
+      - run: moon task tooling/arnes:check
+      - run: moon query affected | jq -e '.tasks | has("tooling/arnes:check")'
+      - run: moon run tooling/arnes:check --cache write --summary detailed

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ home/.config/fish/completions
 # Temporary working files
 PRODUCTIVITY_REVIEW.md
 tooling/arnes/target/
+.moon/cache/
 node_modules/
 .harness-export/
 

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,0 +1,2 @@
+projects:
+  tooling/arnes: tooling/arnes

--- a/Makefile
+++ b/Makefile
@@ -411,6 +411,10 @@ ${VOLTA_BIN}/pnpm: ${VOLTA_BIN}/node
 	${BREW_BIN}/volta install pnpm
 	touch $@
 
+.PHONY: moon
+moon:
+	curl -fsSL https://moonrepo.dev/install/moon.sh | bash
+
 .PHONY: clean
 clean:
 	rm -rf ~/.config/nvim

--- a/docs/adr/041-frontiere-automatisation-typescript-rust.md
+++ b/docs/adr/041-frontiere-automatisation-typescript-rust.md
@@ -1,4 +1,4 @@
-# ADR-041 — Frontière d'automatisation entre Shell, Just, TypeScript et Rust
+# ADR-041 — Frontière d'automatisation entre Shell, Moon, TypeScript et Rust
 
 - **Statut** : accepté
 - **Date** : 2026-08
@@ -22,7 +22,8 @@ plutôt que comme infrastructure vide.
 
 - Le `Makefile` reste l'installateur idempotent défini par l'ADR-001.
 - Bash se limite à l'amorçage, à l'environnement et à une courte séquence linéaire de commandes.
-- Just porte les recettes de développement nommées et délègue tout comportement à un outil testable.
+- Moon porte les tâches de développement nommées progressivement migrées, leur graphe de dépendances
+  et leur sélection affectée; chaque migration conserve une frontière de projet précise.
 - Bun et TypeScript sont le choix par défaut pour un petit utilitaire cohésif qui dépasse la frontière
   Shell, y compris l'analyse et la validation de données ou une politique bornée.
 - Rust est retenu pour une CLI substantielle, un état durable, une concurrence complexe, une
@@ -39,6 +40,8 @@ plutôt que comme infrastructure vide.
 - Bun et `tsc` constituent deux oracles distincts : tests d'exécution et vérification statique.
 - Une migration de Bash reste locale au comportement modifié ; les scripts historiques ne sont pas
   réécrits sans besoin.
+- La migration vers Moon est progressive : les commandes non migrées conservent leur point d’entrée
+  actuel.
 - La frontière Rust repose sur les garanties requises, pas sur un seuil arbitraire de lignes.
 
 ## Alternatives écartées

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -74,4 +74,4 @@ ici sont les dates d'auteur.
 | [038](038-frontieres-home-harness-tooling.md)          | Frontières `home/`, `harness/` et `tooling/`                     | 2026-08 |
 | [039](039-code-search.md)                              | Recherche exacte et conceptuelle dans les checkouts Git          | 2026-08 |
 | [040](040-skills-user-dans-harness.md)                 | Skills user dans `harness/`                                      | 2026-08 |
-| [041](041-frontiere-automatisation-typescript-rust.md) | Frontière d'automatisation entre Shell, Just, TypeScript et Rust | 2026-08 |
+| [041](041-frontiere-automatisation-typescript-rust.md) | Frontière d'automatisation entre Shell, Moon, TypeScript et Rust | 2026-08 |

--- a/docs/software-source-exceptions.md
+++ b/docs/software-source-exceptions.md
@@ -9,6 +9,7 @@ référencé par [ADR-002](adr/002-homebrew-source-unique.md).
 | Paquets Node via Volta ou npm | Coordonnée de la cible             | Vérification du registre par le gestionnaire | `tooling/upgrade`                      | Sentinelle du shim ou du binaire                    |
 | Plugins Fisher et TPM         | Révision distante à l'installation | Objets GitHub en HTTPS                       | Commande explicite du gestionnaire     | Configuration Fisher ou checkout TPM                |
 | Claude Code                   | Canal éditeur `latest`             | HTTPS éditeur                                | `claude update`                        | Sentinelle du binaire                               |
+| Moon                          | Canal éditeur `latest`             | HTTPS éditeur                                | `tooling/upgrade` → `moon upgrade`     | Sentinelle du binaire                               |
 | Images Docker des MCP         | Image et tag déclarés              | Manifeste et couches du registre             | `docker pull` ou `docker compose pull` | Image locale réutilisée                             |
 | Thèmes Bat                    | Branche Catppuccin par défaut      | HTTPS GitHub                                 | Changement explicite de source         | Fichier de thème existant                           |
 | Dictionnaires Hunspell        | Commit LibreOffice déclaré         | SHA-256 déclaré                              | Changement du commit et du checksum    | Destination identique conservée, divergence refusée |

--- a/harness/skills/workflow-automation/SKILL.md
+++ b/harness/skills/workflow-automation/SKILL.md
@@ -33,10 +33,13 @@ $workflow-automation review these repeated agent runs for an automation candidat
 2. Name the stable outcome, inputs, outputs, effects, authority, failure modes, and variable choices.
    Remove discovery, debugging, and recovery commands that are incidental to one run.
 3. Search for an existing supported command, connector, configuration, task, or workflow that already
-   provides the outcome. Standardize that primitive before creating another one.
-4. Choose the narrowest durable implementation. Use Just for fixed command orchestration, Bun and
-   TypeScript for small testable utilities, Rust for substantial or system-oriented CLIs, and CI or
-   a supported scheduler for event-driven or timed execution.
+   provides the outcome. Standardize that primitive before creating another one. When a supported
+   CLI query and a direct `jq` projection express the complete outcome, keep them in the workflow
+   instead of wrapping them in a new program.
+4. Choose the narrowest durable implementation. Use Moon for named development tasks, project
+   graphs, and affected selection, Bun and TypeScript for small testable utilities, Rust for
+   substantial or system-oriented CLIs, and CI or a supported scheduler for event-driven or timed
+   execution.
 5. Automate every safe deterministic step. Keep an explicit human checkpoint only for unresolved
    judgment, missing authority, or an irreversible external effect.
 6. Make effects explicit and design for idempotence, inspection or dry-run, bounded retries,
@@ -67,7 +70,8 @@ $workflow-automation review these repeated agent runs for an automation candidat
 - Never automate irreversible or externally visible effects without established authority and an
   explicit checkpoint when that authority cannot be delegated safely.
 - Reuse an existing supported primitive before introducing a new tool.
-- Follow the applicable `scripts` boundary: Just orchestrates fixed commands, Bun and TypeScript own
-  small utilities, and Rust owns substantial or system-oriented CLIs.
+- Follow the applicable `scripts` boundary: Moon owns named tasks, project graphs, and affected
+  selection, Bun and TypeScript own small utilities, and Rust owns substantial or system-oriented
+  CLIs.
 - Never store secrets or raw private prompts in automation evidence, fixtures, or logs.
 - Test the shipped entry point rather than a duplicate implementation in the test harness.

--- a/home/.config/fish/config.fish
+++ b/home/.config/fish/config.fish
@@ -18,6 +18,7 @@ end
 # bun
 set --export BUN_INSTALL "$HOME/.bun"
 fish_add_path --global --move --path $BUN_INSTALL/bin
+fish_add_path --global --move --path "$HOME/.moon/bin"
 
 # zoxide - smarter cd command
 if type -q zoxide

--- a/home/.config/fish/tests/path_test.fish
+++ b/home/.config/fish/tests/path_test.fish
@@ -14,7 +14,7 @@ end
 
 set -l config_root (path resolve (path dirname (status filename))/..)
 set -gx HOME "$path_test_root"
-/bin/mkdir -p "$HOME/.cargo/bin" "$HOME/.volta/bin" "$HOME/.bun/bin" \
+/bin/mkdir -p "$HOME/.cargo/bin" "$HOME/.volta/bin" "$HOME/.bun/bin" "$HOME/.moon/bin" \
     "$HOME/homebrew/opt/postgresql@16/bin" "$HOME/homebrew/opt/ruby/bin"
 or fail "could not create test directories"
 set -gx PATH (path dirname (status fish-path))
@@ -51,7 +51,7 @@ for entry in $PATH
     set -a seen_path "$entry"
 end
 
-for expected in "$HOME/.cargo/bin" "$HOME/.volta/bin" "$HOME/.bun/bin" \
+for expected in "$HOME/.cargo/bin" "$HOME/.volta/bin" "$HOME/.bun/bin" "$HOME/.moon/bin" \
     "$HOME/homebrew/opt/postgresql@16/bin" "$HOME/homebrew/opt/ruby/bin"
     contains -- "$expected" $PATH; or fail "missing PATH entry: $expected"
 end

--- a/tooling/arnes/moon.yml
+++ b/tooling/arnes/moon.yml
@@ -1,0 +1,12 @@
+tasks:
+  check:
+    command: cargo check --all-targets --locked
+    inputs:
+      - Cargo.toml
+      - Cargo.lock
+      - build.rs
+      - src/**/*
+      - tests/**/*
+      - examples/**/*
+      - benches/**/*
+      - /.cargo/**/*

--- a/tooling/node-version-installation-test-support.ts
+++ b/tooling/node-version-installation-test-support.ts
@@ -126,7 +126,9 @@ async function createUpgradeFakes(
   scenario: UpgradeScenario,
 ): Promise<string> {
   const bin = join(root, "bin");
+  const moonBin = join(root, "home", ".moon/bin");
   await mkdir(bin, { recursive: true });
+  await mkdir(moonBin, { recursive: true });
   for (const command of ["brew", "mas", "npm"]) {
     await writeExecutable(join(bin, command), "exit 0");
   }
@@ -134,6 +136,7 @@ async function createUpgradeFakes(
     join(bin, "date"),
     String.raw`printf '%s\n' 2026-08-23T00:00:00Z`,
   );
+  await writeExecutable(join(moonBin, "moon"), "exit 0");
   if (scenario.includeVolta !== false) {
     await writeExecutable(
       join(bin, "volta"),

--- a/tooling/upgrade
+++ b/tooling/upgrade
@@ -46,6 +46,15 @@ echo "ℹ️  Mas upgrade"
 mas outdated
 mas upgrade
 
+echo "ℹ️  Moon upgrade"
+if [[ ! -x $HOME/.moon/bin/moon ]]; then
+  echo "  Warning: Moon not found, unable to upgrade Moon"
+  upgrade_status=1
+elif ! "$HOME/.moon/bin/moon" upgrade; then
+  echo "  Warning: unable to upgrade Moon"
+  upgrade_status=1
+fi
+
 echo "ℹ️  Volta Node.js upgrade"
 node_pin_stage=
 if ! command -v volta &> /dev/null; then

--- a/tooling/upgrade-test
+++ b/tooling/upgrade-test
@@ -31,7 +31,9 @@ remote=$test_root/remote.git
 mock_bin=$test_root/bin
 git_log=$test_root/git.log
 command_log=$test_root/command.log
-mkdir -p "$repository/tooling" "$repository/home/.config/nvim" "$mock_bin"
+moon_bin=$test_home/.moon/bin
+moon=$moon_bin/moon
+mkdir -p "$repository/tooling" "$repository/home/.config/nvim" "$mock_bin" "$moon_bin"
 cp "$upgrade" "$main_branch_helper" "$main_branch_cli" "$main_branch_core" "$repository/tooling/"
 cp "$node_version_contract" "$repository/tooling/"
 cp "$package_json" "$repository/"
@@ -76,6 +78,10 @@ printf '%s\n' \
   'exec "$REAL_GIT" "$@"' >"$mock_bin/git"
 chmod +x "$mock_bin"/*
 ln -s "$real_bun" "$mock_bin/bun"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'exit 0' >"$moon"
+chmod +x "$moon"
 
 run_upgrade() {
   output=$test_root/$1.out
@@ -159,5 +165,21 @@ assert_equal "$("$real_git" -C "$repository" rev-parse HEAD)" "$probe_tip" "fail
 [[ ! -s $git_log ]] || fail "failed repository probe allowed a push"
 grep -Fq "fatal: simulated rev-parse failure" "$test_root/probe-rev-parse.out" || fail "rev-parse error was suppressed"
 grep -Fq "unable to determine the main dotfiles branch" "$test_root/probe-rev-parse.out" || fail "rev-parse failure was not reported"
+
+rm "$moon"
+run_upgrade moon-missing moon-update 1
+grep -Fq "Moon not found, unable to upgrade Moon" "$test_root/moon-missing.out" ||
+  fail "missing Moon was not reported"
+grep -Fxq 'brew update' "$command_log" || fail "Moon absence stopped the remaining upgrade sequence"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s\\n" "simulated Moon upgrade failure" >&2' \
+  'exit 42' >"$moon"
+chmod +x "$moon"
+run_upgrade moon-failure moon-update 1
+grep -Fq "simulated Moon upgrade failure" "$test_root/moon-failure.out" ||
+  fail "Moon upgrade failure was not preserved"
+grep -Fxq 'brew update' "$command_log" || fail "Moon failure stopped the remaining upgrade sequence"
 
 echo "upgrade tests passed"


### PR DESCRIPTION
## Résultat

- expose `tooling/arnes:check` avec la commande directe `cargo check --all-targets --locked`
- décrit précisément ses entrées Moon et vérifie le graphe `affected` par cas positifs et négatif
- ajoute une CI pull request dédiée qui prouve la sélection affected puis exécute la tâche
- conserve Make comme installateur de Moon et aligne ADR-041 sur la migration progressive de l’orchestration

## Vérifications locales (macOS)

- `bun test --timeout 15000 tooling/moon-installation.test.ts tooling/assert-moon-task-affected.test.ts tooling/moon-arnes-graph.test.ts tooling/moon-ci-contract.test.ts tooling/node-version-installation.test.ts tooling/lint-typescript-contract.test.ts` — 51 pass, 0 fail
- `cargo fmt --check`
- `cargo check --all-targets --locked`
- `cargo test --locked`
- `git diff --check`

La preuve Ubuntu et `actionlint` sont fournies par GitHub Actions sur cette PR.
