### PR TITLE
chore(arnes): declare codex bundled plugins

### DIFF
--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -125,6 +125,8 @@ external:
   plugins:
     - { agent: claude, scope: user, id: superpowers@claude-plugins-official }
     - { agent: cursor, scope: user, id: superpowers }
+    - { agent: codex, scope: user, id: codex-app-tools@openai-bundled }
+    - { agent: codex, scope: user, id: github@openai-curated }
     - { agent: codex, scope: user, id: superpowers@openai-curated }
   skills:
     - agent: codex


### PR DESCRIPTION
## Contexte

`arnes doctor` signalait deux plugins Codex installés mais non déclarés :

```
codex user plugin codex-app-tools@openai-bundled@0.1.3
  DRIFT plugin · enabled · healthy · unexpected · artifact=0.1.3
codex user plugin github@openai-curated@0.1.11
  DRIFT plugin · enabled · healthy · unexpected · artifact=1e285826
```

## Changement

Déclaration de leurs identifiants stables dans `external.plugins` de `home/.arnes.yaml`. L'id comparé par arnes exclut la version (`plugin_group` la concatène uniquement pour l'affichage), d'où `codex-app-tools@openai-bundled` et `github@openai-curated`. Ces deux plugins n'exposent aucun skill : aucune entrée `external.skills` n'est nécessaire.

## Vérification

`arnes doctor` (macOS 25.6, fish) : Codex passe de 5 issues / 57 healthy à 3 issues / 59 healthy.

Reste hors périmètre : `sites@openai-bundled@0.1.46` et ses skills `sites-building` / `sites-hosting`, toujours en drift — à déclarer ou à désinstaller selon la décision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBvucvNXQUyRio2PvJvXfr