### PR TITLE
refactor(arnes): drop unconditional unsupported diagnostics

### DIFF
--- a/docs/arnes-capacites-externes.md
+++ b/docs/arnes-capacites-externes.md
@@ -15,6 +15,12 @@ Le manifest `.arnes.yaml` sépare trois déclarations :
 L'origine `managed` désigne un skill standalone géré hors d'Arnes mais déjà exposé dans une racine
 de projection. Cette autorisation ne l'adopte pas et ne déclenche aucun contrôle qualitatif.
 
+Un diagnostic `unsupported` rapporte une observation qui a échoué : version de registre inconnue,
+résolveur illisible, exposition indéterminable. Une capacité dont aucun inventaire n'est observable
+n'en produit aucun : elle est documentée ici et reste silencieuse à l'exécution. Une racine non
+déclarée est donc absente du rapport plutôt que signalée, le manifeste restant la source unique de
+ce qui est audité.
+
 Une autorisation permet une capacité, elle ne la rend pas obligatoire. Son absence ne crée donc
 aucun drift. La propriété reste `external`, même pour une capacité autorisée. Les diagnostics
 conservent le schéma partagé `resource/state/message` et exposent dans le message l'origine, le
@@ -38,7 +44,9 @@ sans chemin physique public pour ces derniers. Elle définit aussi `[[skills.con
 Le chemin `~/.codex/skills/.system` utilisé dans le manifest de ce dépôt est un contrat
 d'implémentation local explicite, pas une convention Codex universelle. Arnes peut donc auditer
 `openai-docs` sous cette racine sans transformer une observation de HOME en table Rust. Une autre
-installation doit déclarer sa propre racine stable ou accepter un diagnostic `unsupported`.
+installation déclare sa propre racine stable ; sans déclaration, aucun skill système n'est audité.
+L'activation des plugins de projet n'a aucun registre filesystem : le scope project ne rapporte donc
+aucun plugin Codex.
 
 Codex CLI 0.147.0 expose `codex plugin marketplace list --json` et `codex plugin list --json`. La
 première commande fournit les marketplaces considérées ; la seconde fournit la sélection installée,
@@ -68,8 +76,13 @@ sont lus depuis leurs fichiers documentés ; le réglage le plus proche du proje
 périmètre observable par un doctor lancé dans ce projet. Les réglages managed, serveur ou MDM ne
 sont pas déduits depuis HOME.
 
-L'interface officiellement supportée pour l'inventaire est `claude plugin list --json`. Le schéma
-statique de `~/.claude/plugins/installed_plugins.json` n'est pas publié. Arnes reconnaît seulement la
+Les *bundled skills* sont embarqués dans le binaire natif, sans répertoire ni sous-commande
+d'énumération ; `disableBundledSkills` et `skillOverrides` documentent leur exposition, pas leur
+inventaire. Les reconstituer exigerait une table de noms en Rust liée à une version du binaire :
+Arnes n'audite donc aucun skill système Claude.
+
+L'interface officiellement supportée pour l'inventaire des plugins est `claude plugin list --json`.
+Le schéma statique de `~/.claude/plugins/installed_plugins.json` n'est pas publié. Arnes reconnaît seulement la
 version 2 observée par l'installation couverte par cette slice ; toute autre version devient
 `unsupported`. Le registre sélectionne l'unique `installPath` effectif. Les anciennes versions du
 cache et les market places connues ne sont jamais prises pour des plugins actifs.
@@ -90,9 +103,15 @@ filesystem stable pour les builtins. Il documente le chargement de plugins de d�
 `~/.cursor/plugins/local/<plugin>` ; Arnes audite uniquement cette racine explicite.
 
 Customize reste l'interface officielle des plugins marketplace installés. Aucun registre
-filesystem stable ne publie leur activation, et `workspaceOpen` peut produire des chemins
-dynamiquement. Les plugins marketplace, extensions, builtins et capacités dynamiques sont donc
-`unsupported` plutôt que déduits depuis un cache ou exécutés par le doctor.
+filesystem stable ne publie leur activation, `cursor-agent plugin marketplace list` n'énumère que
+les marketplaces, et `workspaceOpen` peut produire des chemins dynamiquement.
+`~/.cursor/extensions/extensions.json` liste les extensions installées mais pas leur activation,
+qui réside dans le stockage global non documenté de l'éditeur ; aucune extension n'expose de skill.
+Le répertoire `~/.cursor/skills-cursor` contient bien les builtins synchronisés, mais il est non
+documenté, décrit par deux manifestes internes divergents, et Cursor ne documente aucun moyen de
+désactiver un builtin : un inventaire y serait donc un drift permanent sans remède. Les plugins
+marketplace, extensions, builtins et capacités dynamiques ne sont donc ni audités, ni déduits depuis
+un cache, ni obtenus en exécutant l'agent.
 
 Sources : [Skills](https://cursor.com/docs/skills),
 [Plugins](https://cursor.com/docs/plugins),

--- a/tooling/arnes/src/skills/external/codex.rs
+++ b/tooling/arnes/src/skills/external/codex.rs
@@ -39,11 +39,7 @@ struct SkillConfig {
 
 pub(super) fn diagnose(roots: &Roots, policy: &Manifest, scope: Scope) -> Vec<Diagnostic> {
     if scope == Scope::Project {
-        return vec![Diagnostic::new(
-            "skills",
-            State::Unsupported,
-            "external codex project plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=project plugin activation has no documented filesystem registry",
-        )];
+        return Vec::new();
     }
     let path = roots.home().join(".codex/config.toml");
     let config = match load(&path, roots.home()) {

--- a/tooling/arnes/src/skills/external/cursor.rs
+++ b/tooling/arnes/src/skills/external/cursor.rs
@@ -10,35 +10,21 @@ use std::io::ErrorKind;
 use std::path::Path;
 
 pub(super) fn diagnose(roots: &Roots, policy: &Manifest, scope: Scope) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-    if scope == Scope::User {
-        let root = roots.home().join(".cursor/plugins/local");
-        match local_plugins(&root, roots.home()) {
-            Ok(plugins) => diagnostics.extend(plugin_diagnostics(
-                policy,
-                Agent::Cursor,
-                scope,
-                plugins,
-            )),
-            Err(detail) => diagnostics.push(Diagnostic::new(
-                "skills",
-                State::Error,
-                format!(
-                    "external cursor user local plugin root origin=plugin ownership=external exposure=unknown topology=unreadable policy=unknown activation=unknown path={} detail={detail}",
-                    root.display(),
-                ),
-            )),
-        }
+    if scope == Scope::Project {
+        return Vec::new();
     }
-    diagnostics.push(unsupported(
-        scope,
-        "marketplace plugin activation has no documented filesystem registry",
-    ));
-    diagnostics.push(unsupported(
-        scope,
-        "extension activation and skill exposure have no documented filesystem registry",
-    ));
-    diagnostics
+    let root = roots.home().join(".cursor/plugins/local");
+    match local_plugins(&root, roots.home()) {
+        Ok(plugins) => plugin_diagnostics(policy, Agent::Cursor, scope, plugins),
+        Err(detail) => vec![Diagnostic::new(
+            "skills",
+            State::Error,
+            format!(
+                "external cursor user local plugin root origin=plugin ownership=external exposure=unknown topology=unreadable policy=unknown activation=unknown path={} detail={detail}",
+                root.display(),
+            ),
+        )],
+    }
 }
 
 fn local_plugins(root: &Path, home: &Path) -> Result<Vec<Plugin>, &'static str> {
@@ -122,14 +108,4 @@ fn inspect_plugin(root: &Path, entry: DirEntry) -> Option<Plugin> {
         detail,
         skills: inspected.skills,
     })
-}
-
-fn unsupported(scope: Scope, detail: &str) -> Diagnostic {
-    Diagnostic::new(
-        "skills",
-        State::Unsupported,
-        format!(
-            "external cursor {scope} plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail={detail}"
-        ),
-    )
 }

--- a/tooling/arnes/src/skills/external/mod.rs
+++ b/tooling/arnes/src/skills/external/mod.rs
@@ -1,5 +1,5 @@
 use crate::Roots;
-use crate::diagnostic::{Diagnostic, State};
+use crate::diagnostic::Diagnostic;
 use crate::manifest::{Agent, Manifest, Scope};
 
 mod claude;
@@ -22,20 +22,6 @@ pub(super) fn diagnose(
         Agent::Codex => codex::diagnose(roots, manifest, scope),
     });
     diagnostics
-}
-
-pub(super) fn unsupported(agent: Agent, scope: Scope, subject: &str) -> Diagnostic {
-    Diagnostic::new(
-        "skills",
-        State::Unsupported,
-        format!(
-            "external {agent} {scope} {subject} origin=system ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown"
-        ),
-    )
-    .with_human(
-        format!("{agent} {scope} unsupported capabilities"),
-        subject,
-    )
 }
 
 pub(super) fn is_claude_skills_plugin(agent: Agent, path: &std::path::Path) -> bool {

--- a/tooling/arnes/src/skills/external/system.rs
+++ b/tooling/arnes/src/skills/external/system.rs
@@ -1,6 +1,5 @@
 use super::codex;
 use super::model::{Exposure, SystemSkill, Topology, external_skill_diagnostic};
-use super::unsupported;
 use crate::Roots;
 use crate::diagnostic::{Diagnostic, State};
 use crate::files::paths::{ancestor_within, canonical_within, label};
@@ -21,11 +20,7 @@ pub(super) fn diagnose(
         .filter(|root| root.agent == agent && root.scope == scope)
         .collect::<Vec<_>>();
     if declared.is_empty() {
-        return vec![unsupported(
-            agent,
-            scope,
-            "system skills inventory is unsupported",
-        )];
+        return Vec::new();
     }
     let base = match scope {
         Scope::User => roots.home(),

--- a/tooling/arnes/tests/cli.rs
+++ b/tooling/arnes/tests/cli.rs
@@ -76,7 +76,7 @@ fn doctor_accepts_shared_options_without_reading_the_environment() {
     assert_eq!(output.status.code(), Some(0));
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
-        "Skills · project scope · codex agent\n✓ 0 healthy\n! 3 unsupported (non-blocking)\n\nCODEX\n  3 unsupported · 0 healthy\n\n  UNSUPPORTED codex project skill projection is not declared or supported\n  codex project unsupported capabilities\n    UNSUPPORTED system skills inventory is unsupported\n  UNSUPPORTED external codex project plugin inventory origin=plugin ownership=external exposure=unknown topology=unknown policy=unknown activation=unknown detail=project plugin activation has no documented filesystem registry\n"
+        "Skills · project scope · codex agent\n✓ 0 healthy\n! 1 unsupported (non-blocking)\n\nCODEX\n  1 unsupported · 0 healthy\n\n  UNSUPPORTED codex project skill projection is not declared or supported\n"
     );
     assert!(output.stderr.is_empty());
 }

--- a/tooling/arnes/tests/external_system_skills.rs
+++ b/tooling/arnes/tests/external_system_skills.rs
@@ -87,7 +87,7 @@ fn absent_roots_and_allowed_skills_do_not_drift() {
 }
 
 #[test]
-fn undeclared_system_mechanism_is_explicitly_unsupported() {
+fn undeclared_system_root_is_silent_rather_than_unsupported() {
     let fixture = configured_fixture();
 
     let (code, stdout, _) = run(
@@ -98,8 +98,8 @@ fn undeclared_system_mechanism_is_explicitly_unsupported() {
     );
 
     assert_eq!(code, 0, "{stdout}");
-    assert!(stdout.contains("codex user unsupported capabilities"));
-    assert!(stdout.contains("system skills inventory is unsupported"));
+    assert!(!stdout.contains("system skills"), "{stdout}");
+    assert!(!stdout.contains("unsupported capabilities"), "{stdout}");
 }
 
 #[test]

--- a/tooling/arnes/tests/fixtures/skills/report-verbose.txt
+++ b/tooling/arnes/tests/fixtures/skills/report-verbose.txt
@@ -15,7 +15,7 @@ CURSOR
 CLAUDE
   1 unsupported · 1 healthy
 
-  UNSUPPORTED system skills inventory
+  UNSUPPORTED plugin registry version
   HEALTHY handoff
 
 CODEX

--- a/tooling/arnes/tests/fixtures/skills/report.txt
+++ b/tooling/arnes/tests/fixtures/skills/report.txt
@@ -14,7 +14,7 @@ CURSOR
 CLAUDE
   1 unsupported · 1 healthy
 
-  UNSUPPORTED system skills inventory
+  UNSUPPORTED plugin registry version
 
 CODEX
   1 unsupported · 0 healthy

--- a/tooling/arnes/tests/human_skills.rs
+++ b/tooling/arnes/tests/human_skills.rs
@@ -26,8 +26,8 @@ fn report() -> Report {
         diagnostic(
             claude,
             State::Unsupported,
-            "system skills inventory is unsupported",
-            "system skills inventory",
+            "unsupported registry version 3",
+            "plugin registry version",
         ),
         diagnostic(
             cursor.clone(),
@@ -94,7 +94,8 @@ fn skills_doctor_attaches_agent_sections_without_reading_real_home() {
     let (_, verbose, verbose_stderr) = run(&fixture, &["doctor", "skills", "-v"]);
 
     assert_eq!(code, 1, "{normal}");
-    assert!(normal.find("CURSOR").unwrap() < normal.find("CLAUDE").unwrap());
+    assert!(normal.contains("CURSOR"), "{normal}");
+    assert!(verbose.find("CURSOR").unwrap() < verbose.find("CLAUDE").unwrap());
     assert!(!normal.contains("HEALTHY"));
     assert!(verbose.contains("HEALTHY"));
     assert!(stderr.is_empty());


### PR DESCRIPTION
## Contexte

`arnes doctor skills` émettait dix lignes `UNSUPPORTED` constantes qui ne rapportaient aucune observation :

- `system skills inventory is unsupported`, une par couple (agent, scope) sans racine déclarée — soit 5 : `claude user`, `claude project`, `cursor user`, `cursor project`, `codex project` ;
- deux constantes Cursor : `marketplace plugin activation has no documented filesystem registry` et `extension activation and skill exposure have no documented filesystem registry`, en user et en project ;
- une constante Codex : `project plugin activation has no documented filesystem registry`.

Aucune ne variait, aucune n'était actionnable. La première était même tautologique : elle se déclenchait uniquement parce que le manifeste ne déclare pas de racine pour ce couple.

## Règle retenue

Un diagnostic `unsupported` rapporte désormais une **observation qui a échoué** : version de registre inconnue, résolveur illisible, exposition indéterminable. Une capacité dont aucun inventaire n'est observable est documentée dans `docs/arnes-capacites-externes.md` et reste silencieuse à l'exécution. Une racine non déclarée est absente du rapport plutôt que signalée, le manifeste restant la source unique de ce qui est audité.

Les `unsupported` conditionnels sont intacts : version de registre Claude inconnue, échec du résolveur Codex, `exposure=unknown`, projection ou combinaison non déclarée demandée en CLI.

## Vérification amont

Constats établis sur macOS 25.6 arm64, Claude Code 2.1.251, `cursor-agent` (Homebrew), Codex 0.147 :

| Capacité | Inventaire observable ? |
|---|---|
| Claude system skills | **Non.** Bundled skills embarqués dans le binaire natif (`~/.local/share/claude/versions/2.1.251`, Mach-O). Aucun répertoire, aucune sous-commande. `disableBundledSkills` et `skillOverrides` documentent l'exposition, pas l'inventaire ; les reconstituer exigerait une table de noms en Rust liée à une version du binaire. |
| Cursor system skills | **Techniquement oui, inexploitable.** `~/.cursor/skills-cursor/<slug>/SKILL.md` contient 24 skills, mais le chemin est non documenté (doc Cursor : builtins « not stored in a separate filesystem directory »), décrit par deux manifestes internes divergents (`.cursor-managed-skills-manifest.json`, 6+3 slugs, avril ; `.sync-manifest.json`, 24 slugs, août), et Cursor ne documente aucun moyen de désactiver un builtin. Comme `state()` classe `enabled + non autorisé` en `Drift`, on obtiendrait 24 drifts irréparables autrement qu'en allowlistant 24 slugs resynchronisés à chaque release. |
| Cursor marketplace plugin activation | **Non.** Les artefacts sont sous `~/.cursor/plugins/cache/<marketplace>/<plugin>/<sha>/`, mais aucun état on/off n'existe sur disque et `cursor-agent plugin marketplace list` n'énumère que les marketplaces. |
| Cursor extension activation | **Non.** `~/.cursor/extensions/extensions.json` liste les extensions installées (version, source) mais pas leur activation, qui réside dans le stockage global non documenté de l'éditeur. Aucune des extensions installées n'expose de skill : le diagnostic mélangeait deux sujets dont aucun n'est observable. |

## Changements

- `system.rs` : aucune racine déclarée ⇒ vecteur vide.
- `cursor.rs` : suppression des deux constantes et du constructeur `unsupported` ; `diagnose` devient un early return symétrique de Codex.
- `codex.rs` : scope project ⇒ vecteur vide, sans lire `~/.codex/config.toml`.
- `mod.rs` : `unsupported`, devenu mort, supprimé.
- `docs/arnes-capacites-externes.md` : la règle et les trois constats vérifiés.

## Résultat observé

Binaire release, lancé depuis `/Users/sebastien/.dotfiles` :

| | avant | après |
|---|---|---|
| `doctor skills` (user) | `✓ 122 healthy` · `! 4 unsupported` | `✓ 122 healthy` |
| `doctor skills --scope project` | `✓ 18 healthy` · `! 6 unsupported` | `✓ 18 healthy` |

## Oracles

- `undeclared_system_root_is_silent_rather_than_unsupported` : assertion inversée, ni `system skills` ni `unsupported capabilities` dans la sortie.
- `tests/cli.rs` conserve son oracle par égalité exacte de la sortie complète, désormais `! 1 unsupported` — la combinaison non déclarée demandée en CLI, signal conditionnel conservé.
- `tests/human_skills.rs` et les fixtures : le message synthétique du test de rendu passe d'un cas supprimé à un cas encore réel (`unsupported registry version`).

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` et `cargo test` (49 suites, 0 échec) avec `RUSTFLAGS=-Funsafe-code`, exactement les commandes de `test-arnes.yml`, sur macOS 25.6 arm64 ; la CI les rejoue sur `ubuntu-latest`.

**Lacune de barrière :** `docs/arnes-capacites-externes.md` n'est ni dans la liste `prettier --check` ni dans celle de `cspell lint` de `lint.yml`. Aucun oracle ne couvre cette prose ; je ne l'ai pas ajouté, le contenu préexistant échouerait probablement.

**Hors périmètre :** `arnes doctor skills --scope project` rapporte, avant comme après, `DRIFT broken managed <agent> project skill do-nothing-script` sur les trois agents — `SKILL.md` manquant sous `.claude/skills/`, `.cursor/skills/` et `.codex/skills/`. Constat préexistant, non traité ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146sXEJZNT9N6iupQHSP1Qo
