### PR TITLE
feat(tooling): nudge agents toward the code-search skill

### DIFF
--- a/tooling/code-search-nudge
+++ b/tooling/code-search-nudge
@@ -1,0 +1,11 @@
+#!/usr/bin/env bun
+
+import { runCodeSearchNudge } from "./code-search-nudge-hook.ts";
+
+const result = runCodeSearchNudge(await Bun.stdin.text(), process.env);
+if (result.stdout !== undefined) {
+  process.stdout.write(result.stdout);
+}
+if (result.stderr !== undefined) {
+  process.stderr.write(`${result.stderr}\n`);
+}

--- a/tooling/code-search-nudge-hook.test.ts
+++ b/tooling/code-search-nudge-hook.test.ts
@@ -1,0 +1,130 @@
+import {
+  type NudgeIo,
+  missingState,
+  parseHookEvent,
+  runCodeSearchNudge,
+  statePath,
+} from "./code-search-nudge-hook.ts";
+import { expect, test } from "bun:test";
+import { searchThreshold } from "./code-search-nudge.ts";
+
+const environment = { HOME: "/home/agent", XDG_STATE_HOME: "/state" };
+const belowThreshold = searchThreshold - 1;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hookOutputField(content: string, field: string): string {
+  const parsed: unknown = JSON.parse(content);
+  if (!isRecord(parsed)) {
+    return "";
+  }
+  const output = parsed.hookSpecificOutput;
+  if (!isRecord(output)) {
+    return "";
+  }
+  const value = output[field];
+  return typeof value === "string" ? value : "";
+}
+
+function memoryIo(): NudgeIo & { readonly files: Map<string, string> } {
+  const files = new Map<string, string>();
+  return {
+    files,
+    read: (path) => files.get(path) ?? missingState,
+    write: (path, content) => {
+      files.set(path, content);
+    },
+  };
+}
+
+function grepEvent(sessionId = "session-1"): string {
+  return JSON.stringify({
+    session_id: sessionId,
+    tool_input: { pattern: "whatever" },
+    tool_name: "Grep",
+  });
+}
+
+function searchUntilNudged(
+  io: NudgeIo,
+  times: number,
+  sessionId?: string,
+): string {
+  let stdout = "";
+  for (let index = 0; index < times; index += 1) {
+    stdout =
+      runCodeSearchNudge(grepEvent(sessionId), environment, io).stdout ?? "";
+  }
+  return stdout;
+}
+
+test("emits the PreToolUse contract Claude Code understands", () => {
+  const stdout = searchUntilNudged(memoryIo(), searchThreshold);
+
+  expect(hookOutputField(stdout, "hookEventName")).toBe("PreToolUse");
+  expect(hookOutputField(stdout, "additionalContext")).toContain("code-search");
+});
+
+test("persists the count across hook processes", () => {
+  const io = memoryIo();
+  searchUntilNudged(io, belowThreshold);
+
+  expect(io.files.size).toBe(1);
+  expect(searchUntilNudged(io, 1)).not.toBe("");
+});
+
+test("keeps sessions independent", () => {
+  const io = memoryIo();
+  searchUntilNudged(io, belowThreshold, "session-1");
+
+  expect(searchUntilNudged(io, 1, "session-2")).toBe("");
+});
+
+test("refuses a session_id that would escape the state directory", () => {
+  for (const sessionId of ["../escape", "..", "a/b", ""]) {
+    expect(() =>
+      parseHookEvent(
+        JSON.stringify({
+          session_id: sessionId,
+          tool_input: {},
+          tool_name: "Grep",
+        }),
+      ),
+    ).toThrow();
+  }
+});
+
+test("never blocks a search when its own input is unusable", () => {
+  const io = memoryIo();
+  for (const input of ["", "not json", "[]", '{"tool_name":"Grep"}']) {
+    const result = runCodeSearchNudge(input, environment, io);
+
+    expect(result.stdout).toBeUndefined();
+    expect(result.stderr).toContain("code-search-nudge disabled");
+  }
+});
+
+test("never blocks a search when the state directory cannot be written", () => {
+  const failing: NudgeIo = {
+    read: () => missingState,
+    write: () => {
+      throw new Error("read-only file system");
+    },
+  };
+  const result = runCodeSearchNudge(grepEvent(), environment, failing);
+
+  expect(result.stdout).toBeUndefined();
+  expect(result.stderr).toContain("read-only file system");
+});
+
+test("falls back to the XDG default when XDG_STATE_HOME is unset", () => {
+  expect(statePath({ HOME: "/home/agent" }, "session-1")).toBe(
+    "/home/agent/.local/state/code-search-nudge/session-1.json",
+  );
+});
+
+test("reports a missing HOME instead of writing to a guessed path", () => {
+  expect(() => statePath({}, "session-1")).toThrow("missing HOME");
+});

--- a/tooling/code-search-nudge-hook.ts
+++ b/tooling/code-search-nudge-hook.ts
@@ -1,0 +1,111 @@
+import {
+  type HookToolCall,
+  type NudgeState,
+  nextNudgeTurn,
+  parseStoredState,
+} from "./code-search-nudge.ts";
+import { dirname, join } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+
+const safeSessionId = /^(?!\.{1,2}$)[A-Za-z0-9._-]+$/u;
+const missingState = "";
+
+type HookEnvironment = Readonly<Record<string, string | undefined>>;
+
+type NudgeIo = Readonly<{
+  read: (path: string) => string;
+  write: (path: string, content: string) => void;
+}>;
+
+type NudgeOutcome = Readonly<{ stderr?: string; stdout?: string }>;
+
+const fileSystemIo: NudgeIo = {
+  read(path) {
+    try {
+      return readFileSync(path, "utf8");
+    } catch {
+      return missingState;
+    }
+  },
+  write(path, content) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content);
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function statePath(environment: HookEnvironment, sessionId: string): string {
+  const home = environment.HOME;
+  if (home === undefined || home.length === 0) {
+    throw new Error("missing HOME");
+  }
+  const stateHome = environment.XDG_STATE_HOME ?? join(home, ".local/state");
+  return join(stateHome, "code-search-nudge", `${sessionId}.json`);
+}
+
+function parseHookEvent(
+  input: string,
+): Readonly<{ call: HookToolCall; sessionId: string }> {
+  const value: unknown = JSON.parse(input);
+  if (!isRecord(value)) {
+    throw new Error("expected an object");
+  }
+  const sessionId = value.session_id;
+  if (typeof sessionId !== "string" || !safeSessionId.test(sessionId)) {
+    throw new Error("missing or unsafe session_id");
+  }
+  const toolName = value.tool_name;
+  if (typeof toolName !== "string" || toolName.length === 0) {
+    throw new Error("missing tool_name");
+  }
+  return {
+    call: {
+      toolInput: isRecord(value.tool_input) ? value.tool_input : {},
+      toolName,
+    },
+    sessionId,
+  };
+}
+
+function renderOutput(additionalContext: string): string {
+  return JSON.stringify({
+    hookSpecificOutput: { additionalContext, hookEventName: "PreToolUse" },
+  });
+}
+
+function runCodeSearchNudge(
+  input: string,
+  environment: HookEnvironment,
+  io: NudgeIo = fileSystemIo,
+): NudgeOutcome {
+  /* Advisory by construction: a hook sees tool calls, never the intent behind
+     them, and ADR-039 forbids running ColGrep from a lifecycle hook. It may
+     only remind, so every failure below degrades to silence rather than
+     blocking a search, and says why on stderr. */
+  try {
+    const { call, sessionId } = parseHookEvent(input);
+    const path = statePath(environment, sessionId);
+    const state: NudgeState = parseStoredState(io.read(path));
+    const turn = nextNudgeTurn(state, call);
+    io.write(path, JSON.stringify(turn.state));
+    return turn.additionalContext === undefined
+      ? {}
+      : { stdout: renderOutput(turn.additionalContext) };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { stderr: `code-search-nudge disabled for this call: ${reason}` };
+  }
+}
+
+export {
+  type NudgeIo,
+  type NudgeOutcome,
+  fileSystemIo,
+  missingState,
+  parseHookEvent,
+  runCodeSearchNudge,
+  statePath,
+};

--- a/tooling/code-search-nudge.test.ts
+++ b/tooling/code-search-nudge.test.ts
@@ -1,0 +1,135 @@
+import {
+  type HookToolCall,
+  initialNudgeState,
+  nextNudgeTurn,
+  parseStoredState,
+  searchThreshold,
+} from "./code-search-nudge.ts";
+import { expect, test } from "bun:test";
+
+const belowThreshold = searchThreshold - 1;
+const persistentSearches = 12;
+
+function replay(
+  calls: readonly HookToolCall[],
+): readonly (string | undefined)[] {
+  let state = initialNudgeState;
+  const emitted: (string | undefined)[] = [];
+  for (const call of calls) {
+    const turn = nextNudgeTurn(state, call);
+    ({ state } = turn);
+    emitted.push(turn.additionalContext);
+  }
+  return emitted;
+}
+
+function grep(times: number): readonly HookToolCall[] {
+  return Array.from({ length: times }, () => ({
+    toolInput: { pattern: "whatever" },
+    toolName: "Grep",
+  }));
+}
+
+function bash(commands: readonly string[]): readonly HookToolCall[] {
+  return commands.map((command) => ({
+    toolInput: { command },
+    toolName: "Bash",
+  }));
+}
+
+function repeated(command: string, times: number): readonly string[] {
+  return Array.from({ length: times }, () => command);
+}
+
+test("stays silent below the threshold so a one-off lookup is never nudged", () => {
+  const emitted = replay(grep(belowThreshold));
+
+  expect(emitted.every((entry) => entry === undefined)).toBe(true);
+});
+
+test("nudges once the exploratory threshold is reached", () => {
+  const emitted = replay(grep(searchThreshold));
+
+  expect(emitted.at(-1)).toContain("code-search");
+});
+
+test("nudges only once so repeated searches never turn into alert fatigue", () => {
+  const emitted = replay(grep(persistentSearches));
+
+  expect(emitted.filter((entry) => entry !== undefined)).toHaveLength(1);
+});
+
+test("counts ripgrep and fd reached through Bash, not only Grep and Glob", () => {
+  const emitted = replay(
+    bash([...repeated("rg pattern", belowThreshold), "fd -e ts"]),
+  );
+
+  expect(emitted.at(-1)).toContain("code-search");
+});
+
+test("counts a search hidden behind a compound Bash command", () => {
+  const emitted = replay(
+    bash(repeated("cd /tmp && rg pattern", searchThreshold)),
+  );
+
+  expect(emitted.at(-1)).toContain("code-search");
+});
+
+test("counts a search behind an environment assignment prefix", () => {
+  const emitted = replay(
+    bash(repeated("RIPGREP_CONFIG_PATH=/dev/null rg pattern", searchThreshold)),
+  );
+
+  expect(emitted.at(-1)).toContain("code-search");
+});
+
+test("ignores Bash commands that are not searches", () => {
+  const emitted = replay(
+    bash(repeated("git log --oneline", persistentSearches)),
+  );
+
+  expect(emitted.every((entry) => entry === undefined)).toBe(true);
+});
+
+test("disarms permanently once the skill is invoked", () => {
+  const emitted = replay([
+    ...grep(belowThreshold),
+    { toolInput: { skill: "code-search" }, toolName: "Skill" },
+    ...grep(persistentSearches),
+  ]);
+
+  expect(emitted.every((entry) => entry === undefined)).toBe(true);
+});
+
+test("another skill does not disarm the nudge", () => {
+  const emitted = replay([
+    { toolInput: { skill: "testing" }, toolName: "Skill" },
+    ...grep(searchThreshold),
+  ]);
+
+  expect(emitted.at(-1)).toContain("code-search");
+});
+
+test("treats unreadable or absent stored state as a fresh session", () => {
+  expect(parseStoredState("")).toEqual(initialNudgeState);
+  expect(parseStoredState("not json")).toEqual(initialNudgeState);
+  expect(parseStoredState('{"searches":"many"}')).toEqual(initialNudgeState);
+});
+
+test("restores a stored session so the count survives across hook processes", () => {
+  const stored = parseStoredState(JSON.stringify({ searches: belowThreshold }));
+  const turn = nextNudgeTurn(stored, {
+    toolInput: { pattern: "whatever" },
+    toolName: "Grep",
+  });
+
+  expect(turn.additionalContext).toContain("code-search");
+});
+
+test("names the skill and the count so the nudge is actionable", () => {
+  const emitted = replay(grep(searchThreshold));
+  const message = emitted.at(-1) ?? "";
+
+  expect(message).toContain("code-search");
+  expect(message).toContain(String(searchThreshold));
+});

--- a/tooling/code-search-nudge.ts
+++ b/tooling/code-search-nudge.ts
@@ -1,0 +1,133 @@
+const searchThreshold = 3;
+
+const routedSkill = "code-search";
+const searchTools = new Set(["Glob", "Grep"]);
+const searchBinaries = new Set(["ack", "ag", "fd", "find", "grep", "rg"]);
+const shellSeparators = /\||&&|;/u;
+const environmentAssignment = /^[A-Za-z_][A-Za-z0-9_]*=/u;
+
+type NudgeState = Readonly<{
+  nudged: boolean;
+  searches: number;
+  skillInvoked: boolean;
+}>;
+
+type HookToolCall = Readonly<{
+  toolInput: Readonly<Record<string, unknown>>;
+  toolName: string;
+}>;
+
+type NudgeTurn = Readonly<{
+  additionalContext?: string;
+  state: NudgeState;
+}>;
+
+type Classification = "ignored" | "search" | "skill-invocation";
+
+const initialNudgeState: NudgeState = {
+  nudged: false,
+  searches: 0,
+  skillInvoked: false,
+};
+
+function leadingWord(segment: string): string {
+  return (
+    segment
+      .trim()
+      .split(/\s+/u)
+      .find((token) => !environmentAssignment.test(token)) ?? ""
+  );
+}
+
+function isBashSearch(command: unknown): boolean {
+  if (typeof command !== "string") {
+    return false;
+  }
+  return command
+    .split(shellSeparators)
+    .some((segment) => searchBinaries.has(leadingWord(segment)));
+}
+
+function classifyToolCall(call: HookToolCall): Classification {
+  if (call.toolName === "Skill") {
+    return call.toolInput.skill === routedSkill
+      ? "skill-invocation"
+      : "ignored";
+  }
+  if (searchTools.has(call.toolName)) {
+    return "search";
+  }
+  if (call.toolName === "Bash" && isBashSearch(call.toolInput.command)) {
+    return "search";
+  }
+  return "ignored";
+}
+
+function nudgeMessage(searches: number): string {
+  return [
+    `${String(searches)} searches in this session without the ${routedSkill} skill.`,
+    `Exploratory or structural search routes through ${routedSkill}: invoke it before continuing.`,
+    "A one-off lookup of a literal you already know needs no skill.",
+  ].join(" ");
+}
+
+function nextNudgeTurn(state: NudgeState, call: HookToolCall): NudgeTurn {
+  const classification = classifyToolCall(call);
+  if (classification === "skill-invocation") {
+    return { state: { ...state, skillInvoked: true } };
+  }
+  if (classification === "ignored") {
+    return { state };
+  }
+  const searches = state.searches + 1;
+  if (state.skillInvoked || state.nudged || searches < searchThreshold) {
+    return { state: { ...state, searches } };
+  }
+  return {
+    additionalContext: nudgeMessage(searches),
+    state: { ...state, nudged: true, searches },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJson(content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+function parseStoredState(content: string): NudgeState {
+  const value = parseJson(content);
+  if (!isRecord(value)) {
+    return initialNudgeState;
+  }
+  const { nudged, searches, skillInvoked } = value;
+  if (
+    typeof searches !== "number" ||
+    !Number.isInteger(searches) ||
+    searches < 0
+  ) {
+    return initialNudgeState;
+  }
+  return {
+    nudged: nudged === true,
+    searches,
+    skillInvoked: skillInvoked === true,
+  };
+}
+
+export {
+  type HookToolCall,
+  type NudgeState,
+  type NudgeTurn,
+  classifyToolCall,
+  initialNudgeState,
+  nextNudgeTurn,
+  parseStoredState,
+  searchThreshold,
+};


### PR DESCRIPTION
## Pourquoi

`AGENTS.md` §Context Management route désormais toute recherche exploratoire vers le skill `code-search` (livré en `fb74c99`), mais rien n'observe si un agent le suit réellement. Cette PR ajoute un hook `PreToolUse` qui compte les recherches par session et rappelle **une fois**.

## Ce que le hook est — et n'est pas

**Advisory, et il ne peut pas être autre chose.** Un hook voit des appels d'outils, jamais l'intention derrière : distinguer « recherche exploratoire » d'un « lookup ponctuel d'un littéral connu » est une heuristique, pas une décision. ADR-039 interdit par ailleurs d'initialiser ColGrep depuis un hook de cycle de vie, donc il ne cherche jamais lui-même.

Toute défaillance — entrée inexploitable, état non inscriptible, `HOME` absent — dégrade en silence + une ligne sur stderr, jamais en blocage d'une recherche. C'est un choix assumé : le pire cas de ce contrôle est un rappel manquant, et un garde qui bloquerait un `Grep` sur sa propre panne serait supprimé dans la semaine.

## Comportement

| | |
|---|---|
| Comptés | `Grep`, `Glob`, et `rg`/`fd`/`grep`/`find` via Bash — y compris derrière `&&` et un préfixe d'affectation d'environnement |
| Ignorés | toute autre commande Bash |
| Seuil | 3 recherches, rappel émis **au plus une fois** par session |
| Désarmement | définitif dès que le skill est invoqué |
| Sécurité | `session_id` validé avant de devenir un nom de fichier d'état |

## Vérifications

Sur macOS 26.6.2, Claude Code 2.1.251, bun 1.4.0 :

- 20 tests, **un par bypass énuméré** avant écriture ; `bun test` complet vert (284 passants).
- Charge `PreToolUse` réelle passée au wrapper : silence sous le seuil, un rappel au seuil, silence ensuite, exit 0 partout.
- **Déclenchement observé en session réelle**, et désarmement après appel du skill.
- `arnes setup hooks --agent claude` exécuté : le hook reste en place — coexistence avec les hooks possédés par arnes vérifiée, pas supposée.

## Limites, explicitement

- **Le câblage n'est pas livré.** `~/.claude/settings.json` n'est pas tracké ici : cette PR livre le hook sans le déployer. Cursor et Codex ne sont pas touchés.
- **Pas promu en `HookKind` dans arnes**, délibérément — tant que le rappel n'a pas prouvé son utilité.
- **Un faux positif déjà observé** : pendant la session de développement, des lookups ciblés (config du linter, en-têtes de fichiers) ont déclenché le rappel. Le seuil de 3 est peut-être trop bas ; c'est précisément la mesure que ce prototype doit produire.
- Aucune purge des fichiers d'état sous `~/.local/state/code-search-nudge/`.