### PR TITLE
fix(fish): keep runtime state out of repository

### DIFF
--- a/.github/workflows/test-fish.yml
+++ b/.github/workflows/test-fish.yml
@@ -52,3 +52,6 @@ jobs:
 
       - name: Test PATH idempotency
         run: fish --no-config home/.config/fish/tests/path_test.fish
+
+      - name: Test runtime state isolation
+        run: fish --no-config home/.config/fish/tests/runtime_state_test.fish

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ home/.config/nvim/pack/
 home/.config/fish/fish_plugins
 home/.config/fish/functions
 home/.config/fish/completions
+home/.config/fish/fish_variables
 .DS_Store
 
 # Temporary working files

--- a/home/.config/fish/conf.d/editor.fish
+++ b/home/.config/fish/conf.d/editor.fish
@@ -1,1 +1,1 @@
-set -Ux EDITOR nvim
+set -gx EDITOR nvim

--- a/home/.config/fish/config.fish
+++ b/home/.config/fish/config.fish
@@ -19,6 +19,7 @@ end
 set --export BUN_INSTALL "$HOME/.bun"
 fish_add_path --global --move --path $BUN_INSTALL/bin
 fish_add_path --global --move --path "$HOME/.moon/bin"
+fish_add_path --move --path "$HOME/.local/bin" "$HOME/.fzf/bin"
 
 # zoxide - smarter cd command
 if type -q zoxide

--- a/home/.config/fish/fish_variables
+++ b/home/.config/fish/fish_variables
@@ -1,9 +1,0 @@
-# This file contains fish universal variable definitions.
-# VERSION: 3.0
-SETUVAR --export EDITOR:nvim
-SETUVAR __fish_initialized:4300
-SETUVAR _fisher_patrickf1_2F_fzf_2E_fish_files:\x7e/\x2econfig/fish/functions/_fzf_configure_bindings_help\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_extract_var_info\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_preview_changed_file\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_preview_file\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_report_diff_type\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_report_file_type\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_search_directory\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_search_git_log\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_search_git_status\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_search_history\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_search_processes\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_search_variables\x2efish\x1e\x7e/\x2econfig/fish/functions/_fzf_wrapper\x2efish\x1e\x7e/\x2econfig/fish/functions/fzf_configure_bindings\x2efish\x1e\x7e/\x2econfig/fish/conf\x2ed/fzf\x2efish\x1e\x7e/\x2econfig/fish/completions/fzf_configure_bindings\x2efish
-SETUVAR _fisher_plugins:patrickf1/fzf\x2efish
-SETUVAR _fisher_upgraded_to_4_4:\x1d
-SETUVAR fish_greeting:\x1d
-SETUVAR fish_user_paths:/Users/sebastien/\x2elocal/bin\x1e/Users/sebastien/\x2efzf/bin

--- a/home/.config/fish/tests/path_test.fish
+++ b/home/.config/fish/tests/path_test.fish
@@ -14,7 +14,8 @@ end
 
 set -l config_root (path resolve (path dirname (status filename))/..)
 set -gx HOME "$path_test_root"
-/bin/mkdir -p "$HOME/.cargo/bin" "$HOME/.volta/bin" "$HOME/.bun/bin" "$HOME/.moon/bin" \
+/bin/mkdir -p "$HOME/.local/bin" "$HOME/.fzf/bin" "$HOME/.cargo/bin" "$HOME/.volta/bin" \
+    "$HOME/.bun/bin" "$HOME/.moon/bin" \
     "$HOME/homebrew/opt/postgresql@16/bin" "$HOME/homebrew/opt/ruby/bin"
 or fail "could not create test directories"
 set -gx PATH (path dirname (status fish-path))
@@ -51,7 +52,8 @@ for entry in $PATH
     set -a seen_path "$entry"
 end
 
-for expected in "$HOME/.cargo/bin" "$HOME/.volta/bin" "$HOME/.bun/bin" "$HOME/.moon/bin" \
+for expected in "$HOME/.local/bin" "$HOME/.fzf/bin" "$HOME/.cargo/bin" "$HOME/.volta/bin" \
+    "$HOME/.bun/bin" "$HOME/.moon/bin" \
     "$HOME/homebrew/opt/postgresql@16/bin" "$HOME/homebrew/opt/ruby/bin"
     contains -- "$expected" $PATH; or fail "missing PATH entry: $expected"
 end

--- a/home/.config/fish/tests/runtime_state_test.fish
+++ b/home/.config/fish/tests/runtime_state_test.fish
@@ -1,0 +1,60 @@
+function fail
+    echo "not ok - $argv" >&2
+    exit 1
+end
+
+set -g runtime_state_test_root (mktemp -d)
+test -n "$runtime_state_test_root"; and test -d "$runtime_state_test_root"
+or fail "mktemp did not create the test directory"
+
+function cleanup --on-event fish_exit
+    /bin/rm -rf -- "$runtime_state_test_root"
+    or echo "not ok - failed to remove $runtime_state_test_root" >&2
+end
+
+set -l config_root (path resolve (path dirname (status filename))/..)
+set -l source_root (path resolve "$config_root/../../..")
+set -l repository_root "$runtime_state_test_root/repository"
+set -l test_home "$runtime_state_test_root/home"
+set -l deployed_config "$repository_root/home/.config/fish"
+set -l fish_bin_dir (path dirname (status fish-path))
+set -l test_path "$fish_bin_dir:/usr/bin:/bin"
+
+/bin/mkdir -p "$deployed_config/conf.d" "$test_home/.local/bin" "$test_home/.fzf/bin" \
+    "$test_home/.bun/bin" "$test_home/.moon/bin"
+or fail "could not create the fresh deployment"
+/bin/cp "$config_root/config.fish" "$deployed_config/config.fish"
+or fail "could not copy config.fish"
+/bin/cp "$config_root/conf.d/editor.fish" "$deployed_config/conf.d/editor.fish"
+or fail "could not copy editor.fish"
+/bin/cp "$source_root/.gitignore" "$repository_root/.gitignore"
+or fail "could not copy .gitignore"
+
+git -C "$repository_root" init --quiet
+or fail "could not initialize the fixture repository"
+git -C "$repository_root" add .
+or fail "could not stage the fresh deployment"
+git -C "$repository_root" -c user.name=Test -c user.email=test@example.com commit --quiet -m snapshot
+or fail "could not commit the fresh deployment"
+
+env -u EDITOR HOME="$test_home" XDG_CONFIG_HOME="$repository_root/home/.config" PATH="$test_path" \
+    fish -c '
+        test "$EDITOR" = nvim; or exit 12
+        set -q -g EDITOR; or exit 13
+        not set -q -U EDITOR; or exit 14
+        test -z "$fish_greeting"; or exit 15
+        contains -- "$HOME/.local/bin" $PATH; or exit 16
+        contains -- "$HOME/.fzf/bin" $PATH; or exit 17
+        not set -q -U fish_user_paths; or exit 18
+        set -U issue_68_runtime_value persisted; or exit 19
+    ' >/dev/null 2>/dev/null
+or fail "fresh Fish configuration contract failed with status $status"
+
+env -u EDITOR HOME="$test_home" XDG_CONFIG_HOME="$repository_root/home/.config" PATH="$test_path" fish -c \
+    'test "$issue_68_runtime_value" = persisted' >/dev/null 2>/dev/null
+or fail "universal variable did not persist for the next Fish session"
+
+test -z "$(git -C "$repository_root" status --porcelain)"
+or fail "Fish runtime state changed tracked repository content"
+
+echo "ok - Fish runtime state stays local to a fresh deployment"


### PR DESCRIPTION
## Description

- Stop tracking Fish's generated `fish_variables` state and ignore future copies.
- Keep `EDITOR`, `~/.local/bin`, and `~/.fzf/bin` declarative and session-local.
- Add regression coverage for fresh Fish deployments, universal-variable persistence, PATH idempotency, and repository cleanliness.

## Useful Links

- Closes #68

## How to Test

- `fish --no-config home/.config/fish/tests/runtime_state_test.fish`
- `fish --no-config home/.config/fish/tests/path_test.fish`
- `bun test tooling/deployment-fish.test.ts`
- `bun test`
- `actionlint .github/workflows/test-fish.yml`
- `make -n fish`

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
