### PR TITLE
feat(arnes): validate MCP configuration in doctor

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -150,7 +150,9 @@ jobs:
           docs/adr/039-code-search.md docs/adr/041-frontiere-automatisation-typescript-rust.md
           docs/adr/README.md docs/code-search.md
           docs/superpowers/plans/2026-08-29-code-search-replacement.md
+          docs/superpowers/plans/2026-09-01-arnes-mcp-doctor.md
           docs/superpowers/specs/2026-08-29-code-search-design.md
+          docs/superpowers/specs/2026-09-01-arnes-mcp-doctor-design.md
           docs/design-claim-audit-validation.md
           docs/issue-257-installation-macos-audit.md
           docs/issue-257-installation-macos-design.md

--- a/docs/superpowers/plans/2026-09-01-arnes-mcp-doctor.md
+++ b/docs/superpowers/plans/2026-09-01-arnes-mcp-doctor.md
@@ -1,0 +1,359 @@
+# Arnes MCP Doctor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Diagnose manifest-declared MCP registrations through both `arnes doctor mcp` and the aggregate `arnes doctor` command without executing a server or exposing secrets.
+
+**Architecture:** Add an explicit WET manifest projection for each `(agent, scope, name)`, parse each agent's native MCP configuration into one internal observed-registration type, then compare fields and resolve local commands through filesystem inspection only. Keep parsing, comparison, command resolution, and Doctor orchestration in focused Rust modules.
+
+**Tech Stack:** Rust 2024, Serde, `serde_json`, `toml`, Clap, Cargo integration tests
+
+**Spec:** `docs/superpowers/specs/2026-09-01-arnes-mcp-doctor-design.md`
+
+## Global Constraints
+
+- Diagnosis is read-only: no agent CLI, server, wrapper, subprocess, container, image, network, or configuration mutation.
+- A manifest entry contains only environment-variable names; observed secret values are never rendered.
+- Command availability follows the actual resolved file: scope root for relative paths and ordered `PATH` lookup for bare names.
+- ADR-031 wrappers are checked as executable files only; their Docker topology is never inspected.
+- Unknown types, missing inputs, duplicate keys, and parser failures fail closed with an actionable diagnostic.
+- Production files stay under the 250-line review trigger and production functions under 50 logical lines.
+- No new dependency and no production comment.
+
+---
+
+### Task 1: Canonical MCP Manifest Model
+
+**Files:**
+
+- Create: `tooling/arnes/src/manifest/mcp.rs`
+- Create: `tooling/arnes/src/manifest/validation/mcp.rs`
+- Modify: `tooling/arnes/src/manifest.rs`
+- Modify: `tooling/arnes/src/manifest/validation.rs`
+- Test: `tooling/arnes/tests/manifest_mcp.rs`
+
+**Interfaces:**
+
+- Produces: `Manifest::mcp_registrations() -> impl Iterator<Item = McpRegistration<'_>>`
+- Produces: `McpRegistration { name, agent, scope, command, args, environment, enabled }`
+
+- [ ] **Step 1: Write failing manifest tests**
+
+```rust
+#[test]
+fn parses_one_explicit_mcp_projection() {
+    let manifest = manifest::parse(MANIFEST).unwrap();
+    let registration = manifest.mcp_registrations().next().unwrap();
+    assert_eq!(registration.name, "apple-notes");
+    assert_eq!(registration.args, ["--stdio"]);
+    assert_eq!(registration.environment, ["NOTES_PROFILE"]);
+}
+
+#[test]
+fn rejects_duplicate_projection_and_environment_names() {
+    assert_eq!(error(DUPLICATE), "mcp[1]: duplicates mcp[0] projection");
+    assert_eq!(error(DUPLICATE_ENV), "mcp[0].environment[1]: duplicate environment reference");
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `cargo test --locked --test manifest_mcp`
+Expected: compilation fails because `mcp_registrations` does not exist.
+
+- [ ] **Step 3: Add the minimal schema and validation**
+
+```rust
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct McpDeclaration {
+    pub(super) name: String,
+    pub(super) agent: Agent,
+    pub(super) scope: Scope,
+    pub(super) command: String,
+    #[serde(default)] pub(super) args: Vec<String>,
+    #[serde(default)] pub(super) environment: Vec<String>,
+    pub(super) enabled: Option<bool>,
+}
+```
+
+Validate non-empty portable names, non-empty commands, shell environment-name syntax, declared agent/scope targets, duplicate environment names, duplicate `(agent, scope, name)` projections, and reject `enabled` for Cursor.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+Run: `cargo test --locked --test manifest_mcp`
+Expected: PASS.
+
+```bash
+git add tooling/arnes/src/manifest.rs tooling/arnes/src/manifest/mcp.rs tooling/arnes/src/manifest/validation.rs tooling/arnes/src/manifest/validation/mcp.rs tooling/arnes/tests/manifest_mcp.rs
+git commit -m "feat(arnes): declare managed MCP registrations"
+```
+
+### Task 2: Fail-Closed Native Configuration Readers
+
+**Files:**
+
+- Create: `tooling/arnes/src/mcp/configuration.rs`
+- Create: `tooling/arnes/src/mcp/json.rs`
+- Create: `tooling/arnes/src/mcp/observed.rs`
+- Create: `tooling/arnes/src/mcp.rs`
+- Modify: `tooling/arnes/src/lib.rs`
+- Test: `tooling/arnes/src/mcp/configuration/tests.rs`
+
+**Interfaces:**
+
+- Produces: `configuration::load(roots, agent, scope) -> Result<Option<ObservedConfiguration>, ConfigurationError>`
+- Produces: `ObservedRegistration { command, args, environment, enabled }` with environment values reduced to reference names or redacted mismatch markers.
+
+- [ ] **Step 1: Write failing reader tests**
+
+```rust
+#[test]
+fn reads_claude_cursor_and_codex_native_entries() {
+    for case in configured_cases() {
+        let observed = case.load().unwrap().unwrap();
+        assert_eq!(observed.registration("managed").unwrap().command, case.command);
+    }
+}
+
+#[test]
+fn duplicate_json_names_and_wrong_field_types_are_errors() {
+    assert_error(DUPLICATE_JSON, "duplicate MCP name managed");
+    assert_error(WRONG_ARGS, "managed.args must be an array of strings");
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `cargo test --locked mcp::configuration::tests`
+Expected: compilation fails because `arnes::mcp` is absent.
+
+- [ ] **Step 3: Implement native paths and duplicate-preserving parsing**
+
+```rust
+pub(super) struct ObservedRegistration {
+    pub command: String,
+    pub args: Vec<String>,
+    pub environment: BTreeMap<String, EnvironmentValue>,
+    pub enabled: Option<bool>,
+}
+
+pub(super) enum EnvironmentValue {
+    Reference(String),
+    RedactedLiteral,
+}
+```
+
+Use a recursive Serde visitor in `json.rs` that rejects a repeated object key before building a
+`serde_json::Value`; use `toml::Value` for TOML duplicate rejection. Extract only `mcpServers` or
+`mcp_servers`, preserve ordered arguments, map Claude/Cursor `${NAME}` values and Codex `env_vars`
+to references, and never retain literal environment values. For Claude, combine the selected
+registration file with the current repository's `disabledMcpServers` state from `~/.claude.json`;
+for Codex, read `enabled` with its documented default of `true`; leave Cursor state absent.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+Run: `cargo test --locked mcp::configuration::tests`
+Expected: PASS for user/project JSON and TOML fixtures; malformed, duplicate, unreadable, and wrong-root cases return the asserted errors.
+
+```bash
+git add tooling/arnes/src/lib.rs tooling/arnes/src/mcp.rs tooling/arnes/src/mcp
+git commit -m "feat(arnes): read native MCP configurations"
+```
+
+### Task 3: Registration Comparison and Local Command Oracle
+
+**Files:**
+
+- Create: `tooling/arnes/src/mcp/command.rs`
+- Create: `tooling/arnes/src/mcp/comparison.rs`
+- Test: `tooling/arnes/src/mcp/command/tests.rs`
+- Test: `tooling/arnes/src/mcp/comparison/tests.rs`
+
+**Interfaces:**
+
+- Produces: `command::diagnose(roots, scope, command, path) -> Option<Diagnostic>`
+- Produces: `comparison::diagnose(expected, observed) -> Vec<Diagnostic>`
+
+- [ ] **Step 1: Write failing comparison and command tests**
+
+```rust
+#[test]
+fn detects_each_contract_field_without_rendering_literals() {
+    let diagnostics = diagnose_fixture(DIVERGENT);
+    assert_messages(&diagnostics, ["command differs", "ordered arguments differ", "environment references differ", "enabled state differs"]);
+    assert!(!render(&diagnostics).contains("actual-secret"));
+}
+
+#[test]
+fn resolves_absolute_relative_and_path_commands_without_running_them() {
+    let fixture = executable_cases();
+    assert_eq!(fixture.doctor_code(), 0);
+    assert!(!fixture.home().join("executed-sentinel").exists());
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `cargo test --locked mcp::`
+Expected: compilation fails because comparison and command modules are absent.
+
+- [ ] **Step 3: Implement exact comparisons and filesystem-only resolution**
+
+```rust
+fn candidate(command: &str, roots: &Roots, scope: Scope) -> Result<PathBuf, CommandError> {
+    if command.contains(std::path::MAIN_SEPARATOR) {
+        let path = PathBuf::from(command);
+        return Ok(if path.is_absolute() { path } else { scope_root(roots, scope).join(path) });
+    }
+    resolve_in_path(command)
+}
+```
+
+Use `metadata`, `is_file`, and Unix execute bits only. Missing commands are drift; unreadable,
+non-file, non-executable, missing `PATH`, and non-UTF-8 paths are errors. Compare exact command,
+ordered args, environment names/references, and represented enabled state.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+Run: `cargo test --locked mcp::`
+Expected: PASS, including missing/non-executable cases and the execution sentinel.
+
+```bash
+git add tooling/arnes/src/mcp/command.rs tooling/arnes/src/mcp/command tooling/arnes/src/mcp/comparison.rs tooling/arnes/src/mcp/comparison
+git commit -m "feat(arnes): compare MCP registrations"
+```
+
+### Task 4: `doctor mcp` Orchestration and Collision Diagnostics
+
+**Files:**
+
+- Modify: `tooling/arnes/src/mcp.rs`
+- Modify: `tooling/arnes/src/doctor.rs`
+- Test: `tooling/arnes/tests/mcp.rs`
+- Test: `tooling/arnes/tests/mcp_failures.rs`
+- Create: `tooling/arnes/tests/support/mcp.rs`
+
+**Interfaces:**
+
+- Produces: `mcp::diagnose(&Roots, &Manifest, Option<Agent>, Option<Scope>) -> Vec<Diagnostic>`
+- Consumes: manifest projections, native readers, comparison, and command oracle from Tasks 1-3.
+
+- [ ] **Step 1: Write failing CLI tests**
+
+```rust
+#[test]
+fn matching_managed_registrations_are_healthy_for_all_agents() {
+    for agent in ["claude", "cursor", "codex"] {
+        let output = fixture(agent).command(["doctor", "mcp", "--agent", agent, "-v"]);
+        assert_eq!(output.status.code(), Some(0));
+        assert!(stdout(output).contains("healthy mcp:"));
+    }
+}
+
+#[test]
+fn explicit_undeclared_combinations_are_unsupported() {
+    assert_contains(run(["doctor", "mcp", "--agent", "cursor", "--scope", "project"]), "unsupported mcp:");
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `cargo test --locked --test mcp --test mcp_failures`
+Expected: tests fail because `Resource::Mcp` still dispatches no diagnostics.
+
+- [ ] **Step 3: Implement bounded selection and collisions**
+
+Load only combinations selected from manifest declarations. Return `unsupported` only for an
+explicitly requested empty combination. Diagnose missing entries, same-agent same-name scope
+collisions, and a managed name occupied by an undeclared projection; ignore every unrelated and
+plugin-owned name. Prefix every result with resource `mcp` and preserve deterministic manifest order.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+Run: `cargo test --locked --test mcp --test mcp_failures`
+Expected: PASS for healthy, missing, collision, unsupported, redaction, read-only snapshot, and no-execution cases.
+
+```bash
+git add tooling/arnes/src/doctor.rs tooling/arnes/src/mcp.rs tooling/arnes/tests/mcp.rs tooling/arnes/tests/mcp_failures.rs tooling/arnes/tests/support/mcp.rs
+git commit -m "feat(arnes): diagnose MCP registrations"
+```
+
+### Task 5: Aggregate Doctor and Repository Declaration
+
+**Files:**
+
+- Modify: `tooling/arnes/src/cli.rs`
+- Modify: `tooling/arnes/src/doctor.rs`
+- Modify: `tooling/arnes/src/doctor/render.rs`
+- Modify: `tooling/arnes/tests/cli.rs`
+- Modify: `tooling/arnes/tests/mcp.rs`
+- Modify: `home/.arnes.yaml`
+- Modify: `.github/workflows/lint.yml`
+
+**Interfaces:**
+
+- Produces: aggregate `arnes doctor` sections `Manifest`, `Skills`, `Hooks`, `MCP`.
+- Preserves: resource-specific commands default to user scope; unfiltered aggregate MCP scans every declared scope.
+
+- [ ] **Step 1: Write the failing aggregate test**
+
+```rust
+#[test]
+fn default_doctor_checks_project_mcp_without_changing_other_scope_defaults() {
+    let output = configured_fixture().command(["doctor", "-v"]);
+    let stdout = stdout(output);
+    assert!(stdout.contains("MCP"));
+    assert!(stdout.contains("healthy mcp: claude project apple-notes"));
+    assert!(stdout.contains("Skills · user scope"));
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `cargo test --locked --test mcp default_doctor_checks_project_mcp_without_changing_other_scope_defaults`
+Expected: FAIL because the default Doctor omits MCP.
+
+- [ ] **Step 3: Add aggregate scope semantics and the managed Apple Notes declaration**
+
+Remove Clap's implicit scope value so explicitness is observable. Apply user scope inside each
+resource-specific Doctor and to existing aggregate resources; pass no scope to aggregate MCP unless
+the user supplied one. Add `Resource::Mcp` to default rendering and declare the existing
+`apple-notes` Claude project entry in `home/.arnes.yaml` with its absolute executable command.
+Add this plan and its spec to the Prettier file list in `.github/workflows/lint.yml`.
+
+```yaml
+mcp:
+  - name: apple-notes
+    agent: claude
+    scope: project
+    command: /Applications/Apple Notes Exporter.app/Contents/SharedSupport/notes-export-mcp
+```
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run from `tooling/arnes`:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --locked
+```
+
+Run from the repository root:
+
+```bash
+prettier --check docs/superpowers/specs/2026-09-01-arnes-mcp-doctor-design.md docs/superpowers/plans/2026-09-01-arnes-mcp-doctor.md .github/workflows/lint.yml home/.arnes.yaml
+moon run tooling/arnes:check --cache write --summary detailed
+git diff --check
+```
+
+Expected: every command passes on the local macOS environment. Confirm every changed production
+function is at most 50 logical lines and every changed hand-written production file at most 250.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tooling/arnes/src/cli.rs tooling/arnes/src/doctor.rs tooling/arnes/src/doctor/render.rs tooling/arnes/tests/cli.rs tooling/arnes/tests/mcp.rs home/.arnes.yaml .github/workflows/lint.yml docs/superpowers
+git commit -m "feat(arnes): include MCP in default doctor"
+```

--- a/docs/superpowers/specs/2026-09-01-arnes-mcp-doctor-design.md
+++ b/docs/superpowers/specs/2026-09-01-arnes-mcp-doctor-design.md
@@ -37,11 +37,11 @@ la validation existante du manifeste.
 
 Le diagnostic lit directement les fichiers natifs sans appeler les agents :
 
-| Agent | Scope utilisateur | Scope projet |
-| --- | --- | --- |
-| Claude Code | `~/.claude.json` | `.mcp.json` |
-| Cursor | `~/.cursor/mcp.json` | `.cursor/mcp.json` |
-| Codex | `~/.codex/config.toml` | `.codex/config.toml` |
+| Agent       | Scope utilisateur      | Scope projet         |
+| ----------- | ---------------------- | -------------------- |
+| Claude Code | `~/.claude.json`       | `.mcp.json`          |
+| Cursor      | `~/.cursor/mcp.json`   | `.cursor/mcp.json`   |
+| Codex       | `~/.codex/config.toml` | `.codex/config.toml` |
 
 Les formats JSON et TOML sont validés avant toute comparaison. Une racine, une table ou une entrée
 de type inattendu produit une erreur explicite ; une valeur inconnue ne devient jamais une valeur

--- a/docs/superpowers/specs/2026-09-01-arnes-mcp-doctor-design.md
+++ b/docs/superpowers/specs/2026-09-01-arnes-mcp-doctor-design.md
@@ -1,0 +1,131 @@
+# Diagnostic MCP dans Arnes Doctor
+
+## Intention
+
+Arnes doit considérer les inscriptions MCP gérées par le dépôt comme une ressource de diagnostic à
+part entière. `arnes doctor mcp` contrôle une sélection explicite, tandis que `arnes doctor` inclut
+les MCP déclarés dans son diagnostic courant afin qu'une dérive ne reste pas invisible tant que
+l'utilisateur ne connaît pas la sous-commande spécialisée.
+
+Le diagnostic reste strictement en lecture seule. Il ne lance aucun serveur MCP, n'appelle aucun
+CLI d'agent, n'inspecte ni ne démarre aucun conteneur, ne tire aucune image, ne contacte aucun réseau
+et ne modifie aucune configuration.
+
+## Source canonique
+
+Le manifeste Arnes porte une collection normalisée d'inscriptions MCP. Chaque inscription déclare
+explicitement :
+
+- le nom MCP visible par l'agent ;
+- l'agent et le scope ciblés ;
+- la commande locale attendue ;
+- les arguments attendus dans leur ordre exact ;
+- les noms des variables d'environnement référencées ;
+- l'état activé attendu lorsque l'agent représente cet état dans sa configuration.
+
+Une inscription représente exactement une projection `(agent, scope, nom)`. Des inscriptions
+séparées expriment les différences réelles entre agents ou scopes ; le manifeste ne déduit pas de
+valeurs communes et n'applique pas d'override implicite. Cette forme volontairement explicite évite
+qu'une abstraction de projection masque une différence de commande ou d'arguments.
+
+Le manifeste ne contient aucune valeur de secret. Une variable d'environnement est représentée par
+son nom et par la référence attendue dans la configuration de l'agent, jamais par sa valeur résolue.
+Une déclaration qui embarque une valeur sous un champ dont le nom indique un secret est refusée par
+la validation existante du manifeste.
+
+## Configurations observées
+
+Le diagnostic lit directement les fichiers natifs sans appeler les agents :
+
+| Agent | Scope utilisateur | Scope projet |
+| --- | --- | --- |
+| Claude Code | `~/.claude.json` | `.mcp.json` |
+| Cursor | `~/.cursor/mcp.json` | `.cursor/mcp.json` |
+| Codex | `~/.codex/config.toml` | `.codex/config.toml` |
+
+Les formats JSON et TOML sont validés avant toute comparaison. Une racine, une table ou une entrée
+de type inattendu produit une erreur explicite ; une valeur inconnue ne devient jamais une valeur
+par défaut plausible. Les clés sans rapport avec MCP et les inscriptions dont le nom n'est pas
+déclaré dans le manifeste sont conservées hors du périmètre du diagnostic.
+
+Pour Claude Code, l'état désactivé enregistré pour le projet courant est pris en compte lorsqu'il
+est observable sans exécution. Pour Codex, le champ `enabled` de l'inscription est comparé. Cursor
+n'expose pas d'état activé portable dans ses fichiers MCP documentés ; aucune santé n'est donc
+affirmée sur cet état.
+
+## Comparaison
+
+Une inscription est saine lorsque son nom, sa commande, ses arguments ordonnés, ses références de
+variables d'environnement et, lorsqu'il existe, son état activé correspondent au manifeste. Chaque
+différence produit un diagnostic actionnable qui nomme le champ et la valeur attendue sans rendre
+une valeur sensible observée.
+
+La disponibilité d'une commande locale est contrôlée sans l'exécuter :
+
+- une commande absolue ou contenant un séparateur de chemin doit désigner un fichier exécutable ;
+- un nom de commande simple doit résoudre vers un fichier exécutable dans le `PATH` injecté ;
+- un chemin relatif est résolu depuis la racine du scope, home pour `user` et dépôt pour `project` ;
+- une référence de chemin non résoluble ou ambiguë est une erreur de diagnostic, jamais un succès ;
+- un wrapper couvert par l'ADR-031 est traité comme toute autre commande locale, sans inspection de
+  son image, de son daemon ou de ses conteneurs.
+
+Le chemin réellement résolu est la valeur contrôlée. Une simple présence textuelle dans le fichier
+de configuration ne suffit pas à prouver la disponibilité du lanceur.
+
+## Doublons et collisions
+
+Le manifeste refuse deux déclarations portant le même triplet `(agent, scope, nom)`. Le parseur
+refuse également les clés MCP dupliquées dans un même objet JSON ou une même table TOML au lieu de
+conserver silencieusement la dernière valeur.
+
+Lorsqu'un même nom géré apparaît dans plusieurs scopes chargés par un agent, le diagnostic signale
+la collision et la priorité susceptible de masquer une inscription. Une inscription non gérée ou
+fournie par un plugin n'est jamais signalée pour sa seule présence. Son contenu ne devient pertinent
+que s'il occupe un nom déclaré et peut donc masquer l'inscription gérée attendue.
+
+## Sélection et rendu
+
+`arnes doctor mcp --agent <agent> --scope <scope>` limite le diagnostic à la combinaison demandée.
+Une combinaison explicitement demandée mais non supportée ou non déclarée produit un état
+`unsupported`, distinct d'une inscription saine et non bloquant conformément au contrat Doctor.
+
+Sans ressource explicite, `arnes doctor` ajoute une section `MCP` aux sections existantes. Sans
+filtre `--scope`, cette section contrôle toutes les projections MCP déclarées, y compris les MCP de
+projet ; les autres ressources conservent leur comportement de sélection actuel. Un `--agent` ou
+un `--scope` fourni explicitement filtre aussi la section MCP.
+
+Le rendu normal masque les détails sains selon les conventions Doctor. Le rendu verbose expose les
+inscriptions saines sans secret. Le JSON conserve un diagnostic par constat et les codes de sortie
+existants : `0` pour sain ou unsupported seul, `1` pour une dérive, `2` pour une erreur
+opérationnelle ou un format invalide.
+
+## Preuves attendues
+
+Les tests emploient des homes, dépôts et `PATH` isolés et exercent le vrai binaire Arnes. Ils
+établissent au minimum :
+
+- une projection saine pour chaque format JSON et TOML supporté ;
+- l'absence, la commande divergente, les arguments désordonnés, les références d'environnement
+  divergentes et l'état désactivé inattendu ;
+- une commande absolue, un wrapper relatif et un nom résolu dans le `PATH`, puis leurs absences et
+  permissions non exécutables ;
+- les doublons et collisions de scopes sans bruit sur les entrées étrangères ou fournies par un
+  plugin ;
+- une combinaison unsupported distincte d'un succès vide ;
+- l'absence de valeur de secret dans les sorties humaine et JSON ;
+- l'inclusion de la section MCP dans `arnes doctor` sans ressource explicite ;
+- l'absence de mutation des fixtures et l'absence d'exécution du lanceur référencé.
+
+Une vérification d'ensemble couvre le formatage, le lint Rust et les tests Arnes sur macOS. Les
+garanties portables restent limitées aux plateformes effectivement exercées par la CI ; la présence
+d'une application macOS optionnelle peut légitimement produire une dérive sur une autre plateforme.
+
+## Limites
+
+La synchronisation des configurations, le démarrage et la santé protocolaire des serveurs, les
+connexions OAuth, les approbations interactives, les conteneurs, les images et le réseau restent hors
+périmètre. Le diagnostic prouve la conformité statique de l'inscription et la disponibilité locale
+du lanceur ; il ne prétend pas prouver qu'un serveur démarrera ni qu'un outil MCP répondra.
+
+Cette conception implémente l'issue #121, sous le contrat en lecture seule de l'issue parente #111,
+et respecte la topologie des wrappers couverts par l'ADR-031 sans l'étendre aux autres MCP.

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -427,6 +427,12 @@ external:
         plugin: superpowers@openai-curated,
         slug: writing-skills,
       }
+mcp:
+  - name: apple-notes
+    agent: claude
+    scope: project
+    command: /Applications/Apple Notes Exporter.app/Contents/SharedSupport/notes-export-mcp
+    enabled: true
 resources:
   - id: claude-user-instructions
     kind: instructions

--- a/tooling/arnes/src/cli.rs
+++ b/tooling/arnes/src/cli.rs
@@ -22,7 +22,7 @@ pub(crate) enum Command {
         resource: Option<Resource>,
         #[arg(long, value_enum)]
         agent: Option<Agent>,
-        #[arg(long, value_enum, default_value = "user")]
+        #[arg(long, value_enum)]
         scope: Option<Scope>,
         #[arg(long, value_enum, default_value_t)]
         format: Format,

--- a/tooling/arnes/src/doctor.rs
+++ b/tooling/arnes/src/doctor.rs
@@ -7,6 +7,7 @@ use arnes::diagnostic::{ColorMode, Diagnostic, HumanOptions, Report, State};
 use arnes::hooks;
 use arnes::instructions;
 use arnes::manifest::{self, Agent, Scope};
+use arnes::mcp;
 use arnes::prompts;
 use arnes::rules;
 use arnes::skills;
@@ -40,7 +41,13 @@ pub(super) fn run(
         std::env::var_os("NO_COLOR").as_deref(),
     );
     let (output, exit_code) = match format {
-        Format::Human => render::human(diagnostics, resource, agent, scope, human_options),
+        Format::Human => render::human(
+            diagnostics,
+            resource,
+            agent,
+            resource.and(scope.or(Some(Scope::User))).or(scope),
+            human_options,
+        ),
         Format::Json => {
             let report = Report::new(diagnostics);
             (
@@ -69,11 +76,11 @@ fn diagnose(
             Err(error) => vec![Diagnostic::new("manifest", State::Error, error.to_string())],
         },
         Some(Resource::Config) => match Roots::from_environment() {
-            Ok(roots) => diagnose_config(&roots, agent, scope),
+            Ok(roots) => diagnose_config(&roots, agent, scope.or(Some(Scope::User))),
             Err(error) => vec![Diagnostic::new("config", State::Error, error.to_string())],
         },
         Some(Resource::Instructions) => match Roots::from_environment() {
-            Ok(roots) => diagnose_instructions(&roots, agent, scope),
+            Ok(roots) => diagnose_instructions(&roots, agent, scope.or(Some(Scope::User))),
             Err(error) => vec![Diagnostic::new(
                 "instructions",
                 State::Error,
@@ -81,24 +88,28 @@ fn diagnose(
             )],
         },
         Some(Resource::Skills) => match Roots::from_environment() {
-            Ok(roots) => diagnose_skills(&roots, agent, scope),
+            Ok(roots) => diagnose_skills(&roots, agent, scope.or(Some(Scope::User))),
             Err(error) => vec![Diagnostic::new("skills", State::Error, error.to_string())],
         },
         Some(Resource::Prompts) => match Roots::from_environment() {
-            Ok(roots) => diagnose_prompts(&roots, agent, scope),
+            Ok(roots) => diagnose_prompts(&roots, agent, scope.or(Some(Scope::User))),
             Err(error) => vec![Diagnostic::new("prompts", State::Error, error.to_string())],
         },
         Some(Resource::Commands) => match Roots::from_environment() {
-            Ok(roots) => diagnose_commands(&roots, agent, scope),
+            Ok(roots) => diagnose_commands(&roots, agent, scope.or(Some(Scope::User))),
             Err(error) => vec![Diagnostic::new("commands", State::Error, error.to_string())],
         },
         Some(Resource::Rules) => match Roots::from_environment() {
-            Ok(roots) => diagnose_rules(&roots, agent, scope),
+            Ok(roots) => diagnose_rules(&roots, agent, scope.or(Some(Scope::User))),
             Err(error) => vec![Diagnostic::new("rules", State::Error, error.to_string())],
         },
         Some(Resource::Hooks) => match Roots::from_environment() {
-            Ok(roots) => diagnose_hooks(&roots, agent, scope),
+            Ok(roots) => diagnose_hooks(&roots, agent, scope.or(Some(Scope::User))),
             Err(error) => vec![Diagnostic::new("hooks", State::Error, error.to_string())],
+        },
+        Some(Resource::Mcp) => match Roots::from_environment() {
+            Ok(roots) => diagnose_mcp(&roots, agent, scope.or(Some(Scope::User))),
+            Err(error) => vec![Diagnostic::new("mcp", State::Error, error.to_string())],
         },
         _ => Vec::new(),
     }
@@ -118,8 +129,10 @@ fn diagnose_default(agent: Option<Agent>, scope: Option<Scope>) -> Vec<Diagnosti
         State::Healthy,
         "manifest is valid",
     )];
-    diagnostics.extend(skills::diagnose(&roots, &manifest, agent, scope));
-    diagnostics.extend(hooks::diagnose(&roots, &manifest, agent, scope));
+    let user_scope = scope.or(Some(Scope::User));
+    diagnostics.extend(skills::diagnose(&roots, &manifest, agent, user_scope));
+    diagnostics.extend(hooks::diagnose(&roots, &manifest, agent, user_scope));
+    diagnostics.extend(mcp::diagnose(&roots, &manifest, agent, scope));
     diagnostics
 }
 
@@ -184,5 +197,12 @@ fn diagnose_hooks(roots: &Roots, agent: Option<Agent>, scope: Option<Scope>) -> 
     match manifest::load(roots.home()) {
         Ok(manifest) => hooks::diagnose(roots, &manifest, agent, scope),
         Err(error) => vec![Diagnostic::new("hooks", State::Error, error.to_string())],
+    }
+}
+
+fn diagnose_mcp(roots: &Roots, agent: Option<Agent>, scope: Option<Scope>) -> Vec<Diagnostic> {
+    match manifest::load(roots.home()) {
+        Ok(manifest) => mcp::diagnose(roots, &manifest, agent, scope),
+        Err(error) => vec![Diagnostic::new("mcp", State::Error, error.to_string())],
     }
 }

--- a/tooling/arnes/src/doctor/render.rs
+++ b/tooling/arnes/src/doctor/render.rs
@@ -2,7 +2,12 @@ use crate::cli::Resource;
 use arnes::diagnostic::{Diagnostic, HumanContext, HumanOptions, Report};
 use arnes::manifest::{Agent, Scope};
 
-const DEFAULT_RESOURCES: [Resource; 3] = [Resource::Manifest, Resource::Skills, Resource::Hooks];
+const DEFAULT_RESOURCES: [Resource; 4] = [
+    Resource::Manifest,
+    Resource::Skills,
+    Resource::Hooks,
+    Resource::Mcp,
+];
 
 pub(super) fn human(
     diagnostics: Vec<Diagnostic>,
@@ -29,8 +34,13 @@ pub(super) fn human(
         if !output.is_empty() {
             output.push_str("\n\n");
         }
+        let section_scope = if section == Resource::Mcp {
+            scope
+        } else {
+            scope.or(Some(Scope::User))
+        };
         output.push_str(
-            &Report::new(diagnostics).human(&context(Some(section), agent, scope), options),
+            &Report::new(diagnostics).human(&context(Some(section), agent, section_scope), options),
         );
     }
     (output, exit_code)

--- a/tooling/arnes/src/lib.rs
+++ b/tooling/arnes/src/lib.rs
@@ -6,6 +6,7 @@ mod files;
 pub mod hooks;
 pub mod instructions;
 pub mod manifest;
+pub mod mcp;
 pub mod measure;
 pub mod prompts;
 pub mod roots;

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -1,10 +1,10 @@
 use clap::ValueEnum;
 use serde::Deserialize;
-use std::fmt::{self, Display};
 use std::path::{Path, PathBuf};
 
 mod commands;
 mod config;
+mod error;
 mod external;
 mod hooks;
 mod mcp;
@@ -15,6 +15,7 @@ mod validation;
 
 pub use commands::{Command, CommandBinding};
 pub use config::UserConfig;
+pub use error::ManifestError;
 pub use external::{ExternalOrigin, ExternalRoot, ExternalSkill};
 pub use hooks::HookKind;
 pub use mcp::McpRegistration;
@@ -24,29 +25,6 @@ pub use rules::RuleResource;
 
 const MANIFEST_FILE: &str = ".arnes.yaml";
 const SCHEMA_VERSION: u64 = 1;
-
-#[derive(Debug)]
-pub struct ManifestError {
-    field: String,
-    reason: String,
-}
-
-impl ManifestError {
-    fn new(field: impl Into<String>, reason: impl Into<String>) -> Self {
-        Self {
-            field: field.into(),
-            reason: reason.into(),
-        }
-    }
-}
-
-impl Display for ManifestError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "{}: {}", self.field, self.reason)
-    }
-}
-
-impl std::error::Error for ManifestError {}
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -7,6 +7,7 @@ mod commands;
 mod config;
 mod external;
 mod hooks;
+mod mcp;
 mod parsing;
 mod prompts;
 mod rules;
@@ -16,6 +17,7 @@ pub use commands::{Command, CommandBinding};
 pub use config::UserConfig;
 pub use external::{ExternalOrigin, ExternalRoot, ExternalSkill};
 pub use hooks::HookKind;
+pub use mcp::McpRegistration;
 pub use parsing::{load, parse};
 pub use prompts::{Prompt, PromptProjection, PromptRepresentation};
 pub use rules::RuleResource;
@@ -62,6 +64,8 @@ pub struct Manifest {
     commands: Vec<commands::CommandDeclaration>,
     #[serde(default)]
     hooks: Vec<hooks::HookDeclaration>,
+    #[serde(default)]
+    mcp: Vec<mcp::McpDeclaration>,
     resources: Vec<ResourceDeclaration>,
 }
 

--- a/tooling/arnes/src/manifest/error.rs
+++ b/tooling/arnes/src/manifest/error.rs
@@ -1,0 +1,24 @@
+use std::fmt::{self, Display};
+
+#[derive(Debug)]
+pub struct ManifestError {
+    field: String,
+    reason: String,
+}
+
+impl ManifestError {
+    pub(super) fn new(field: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            field: field.into(),
+            reason: reason.into(),
+        }
+    }
+}
+
+impl Display for ManifestError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.field, self.reason)
+    }
+}
+
+impl std::error::Error for ManifestError {}

--- a/tooling/arnes/src/manifest/mcp.rs
+++ b/tooling/arnes/src/manifest/mcp.rs
@@ -1,0 +1,41 @@
+use super::{Agent, Manifest, Scope};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct McpDeclaration {
+    pub(super) name: String,
+    pub(super) agent: Agent,
+    pub(super) scope: Scope,
+    pub(super) command: String,
+    #[serde(default)]
+    pub(super) args: Vec<String>,
+    #[serde(default)]
+    pub(super) environment: Vec<String>,
+    pub(super) enabled: Option<bool>,
+}
+
+#[derive(Clone, Copy)]
+pub struct McpRegistration<'a> {
+    pub name: &'a str,
+    pub agent: Agent,
+    pub scope: Scope,
+    pub command: &'a str,
+    pub args: &'a [String],
+    pub environment: &'a [String],
+    pub enabled: Option<bool>,
+}
+
+impl Manifest {
+    pub fn mcp_registrations(&self) -> impl Iterator<Item = McpRegistration<'_>> {
+        self.mcp.iter().map(|declaration| McpRegistration {
+            name: &declaration.name,
+            agent: declaration.agent,
+            scope: declaration.scope,
+            command: &declaration.command,
+            args: &declaration.args,
+            environment: &declaration.environment,
+            enabled: declaration.enabled,
+        })
+    }
+}

--- a/tooling/arnes/src/manifest/validation.rs
+++ b/tooling/arnes/src/manifest/validation.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path};
 mod commands;
 mod external;
 mod hooks;
+mod mcp;
 mod prompts;
 mod rules;
 mod skills;
@@ -84,6 +85,7 @@ pub(super) fn validate(manifest: &Manifest) -> Result<(), ManifestError> {
     prompts::validate(&manifest.prompts, &manifest.resources, &agents)?;
     commands::validate(&manifest.commands, &manifest.prompts, &agents)?;
     hooks::validate(&manifest.hooks, &agents)?;
+    mcp::validate(&manifest.mcp, &agents)?;
     skills::validate(&manifest.skills, &manifest.resources, &agents)?;
     external::validate(&manifest.external, &agents)
 }

--- a/tooling/arnes/src/manifest/validation/mcp.rs
+++ b/tooling/arnes/src/manifest/validation/mcp.rs
@@ -1,6 +1,7 @@
 use super::super::mcp::McpDeclaration;
 use super::super::{Agent, ManifestError, Scope};
 use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path};
 
 pub(super) fn validate(
     declarations: &[McpDeclaration],
@@ -38,6 +39,12 @@ fn validate_declaration(declaration: &McpDeclaration, index: usize) -> Result<()
         return Err(ManifestError::new(
             field("command"),
             "command cannot be blank",
+        ));
+    }
+    if !valid_command(&declaration.command) {
+        return Err(ManifestError::new(
+            field("command"),
+            "relative command must stay within its scope root",
         ));
     }
     if declaration.agent == Agent::Cursor && declaration.enabled.is_some() {
@@ -80,4 +87,13 @@ fn valid_environment_name(name: &str) -> bool {
     let mut bytes = name.bytes();
     matches!(bytes.next(), Some(b'A'..=b'Z' | b'a'..=b'z' | b'_'))
         && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn valid_command(command: &str) -> bool {
+    let path = Path::new(command);
+    path.is_absolute()
+        || !command.contains(std::path::MAIN_SEPARATOR)
+        || path
+            .components()
+            .all(|component| matches!(component, Component::CurDir | Component::Normal(_)))
 }

--- a/tooling/arnes/src/manifest/validation/mcp.rs
+++ b/tooling/arnes/src/manifest/validation/mcp.rs
@@ -1,0 +1,83 @@
+use super::super::mcp::McpDeclaration;
+use super::super::{Agent, ManifestError, Scope};
+use std::collections::{HashMap, HashSet};
+
+pub(super) fn validate(
+    declarations: &[McpDeclaration],
+    agents: &HashMap<Agent, HashSet<Scope>>,
+) -> Result<(), ManifestError> {
+    let mut projections = HashMap::new();
+    for (index, declaration) in declarations.iter().enumerate() {
+        let field = |name: &str| format!("mcp[{index}].{name}");
+        validate_declaration(declaration, index)?;
+        super::validate_target(&field, declaration.agent, declaration.scope, agents)?;
+        let identity = (
+            declaration.agent,
+            declaration.scope,
+            declaration.name.as_str(),
+        );
+        if let Some(previous) = projections.insert(identity, index) {
+            return Err(ManifestError::new(
+                field("name"),
+                format!("duplicates mcp[{previous}] projection"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_declaration(declaration: &McpDeclaration, index: usize) -> Result<(), ManifestError> {
+    let field = |name: &str| format!("mcp[{index}].{name}");
+    if !valid_name(&declaration.name) {
+        return Err(ManifestError::new(
+            field("name"),
+            "must be lowercase ASCII kebab-case",
+        ));
+    }
+    if declaration.command.trim().is_empty() {
+        return Err(ManifestError::new(
+            field("command"),
+            "command cannot be blank",
+        ));
+    }
+    if declaration.agent == Agent::Cursor && declaration.enabled.is_some() {
+        return Err(ManifestError::new(
+            field("enabled"),
+            "cursor does not represent enabled state",
+        ));
+    }
+    validate_environment(declaration, index)
+}
+
+fn validate_environment(declaration: &McpDeclaration, index: usize) -> Result<(), ManifestError> {
+    let mut names = HashSet::new();
+    for (environment_index, name) in declaration.environment.iter().enumerate() {
+        let field = format!("mcp[{index}].environment[{environment_index}]");
+        if !valid_environment_name(name) {
+            return Err(ManifestError::new(
+                field,
+                "must be a shell environment variable name",
+            ));
+        }
+        if !names.insert(name) {
+            return Err(ManifestError::new(field, "duplicate environment reference"));
+        }
+    }
+    Ok(())
+}
+
+fn valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.split('-').all(|part| {
+            !part.is_empty()
+                && part
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        })
+}
+
+fn valid_environment_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    matches!(bytes.next(), Some(b'A'..=b'Z' | b'a'..=b'z' | b'_'))
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}

--- a/tooling/arnes/src/mcp.rs
+++ b/tooling/arnes/src/mcp.rs
@@ -1,0 +1,170 @@
+mod command;
+mod comparison;
+mod configuration;
+mod json;
+mod observed;
+
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Manifest, McpRegistration, Scope};
+
+pub fn diagnose(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    let registrations = manifest
+        .mcp_registrations()
+        .filter(|registration| agent.is_none_or(|agent| registration.agent == agent))
+        .filter(|registration| scope.is_none_or(|scope| registration.scope == scope))
+        .collect::<Vec<_>>();
+    if registrations.is_empty() && (agent.is_some() || scope.is_some()) {
+        return vec![Diagnostic::new(
+            "mcp",
+            State::Unsupported,
+            unsupported(agent, scope),
+        )];
+    }
+    registrations
+        .into_iter()
+        .flat_map(|registration| diagnose_registration(roots, manifest, registration))
+        .collect()
+}
+
+fn diagnose_registration(
+    roots: &Roots,
+    manifest: &Manifest,
+    registration: McpRegistration<'_>,
+) -> Vec<Diagnostic> {
+    let identity = format!(
+        "{} {} {}",
+        registration.agent, registration.scope, registration.name
+    );
+    let configuration = match configuration::load(
+        roots,
+        registration.agent,
+        registration.scope,
+        &[registration.name],
+    ) {
+        Ok(Some(configuration)) => configuration,
+        Ok(None) => {
+            return vec![Diagnostic::new(
+                "mcp",
+                State::Drift,
+                format!("{identity}: configuration is missing"),
+            )];
+        }
+        Err(error) => {
+            return vec![Diagnostic::new(
+                "mcp",
+                State::Error,
+                format!("{identity}: {error}"),
+            )];
+        }
+    };
+    let Some(observed) = configuration.registrations.get(registration.name) else {
+        return missing_registration(roots, manifest, registration);
+    };
+    let mut diagnostics = comparison::diagnose(registration, observed);
+    diagnostics.extend(scope_collision(roots, manifest, registration));
+    diagnostics.extend(command::diagnose(roots, registration));
+    if diagnostics.is_empty() {
+        diagnostics.push(Diagnostic::new(
+            "mcp",
+            State::Healthy,
+            format!("{identity}: registration matches manifest"),
+        ));
+    }
+    diagnostics
+}
+
+fn scope_collision(
+    roots: &Roots,
+    manifest: &Manifest,
+    registration: McpRegistration<'_>,
+) -> Option<Diagnostic> {
+    let other_scope = match registration.scope {
+        Scope::User => Scope::Project,
+        Scope::Project => Scope::User,
+    };
+    if !manifest
+        .combinations()
+        .any(|pair| pair == (registration.agent, other_scope))
+    {
+        return None;
+    }
+    match configuration::load(roots, registration.agent, other_scope, &[registration.name]) {
+        Ok(Some(configuration)) if configuration.registrations.contains_key(registration.name) => {
+            Some(Diagnostic::new(
+                "mcp",
+                State::Drift,
+                format!(
+                    "{} {} {}: registration also exists in {other_scope} scope",
+                    registration.agent, registration.scope, registration.name
+                ),
+            ))
+        }
+        Err(error) => Some(Diagnostic::new(
+            "mcp",
+            State::Error,
+            format!(
+                "{} {} {}: could not inspect {other_scope} scope: {error}",
+                registration.agent, registration.scope, registration.name
+            ),
+        )),
+        Ok(_) => None,
+    }
+}
+
+fn missing_registration(
+    roots: &Roots,
+    manifest: &Manifest,
+    registration: McpRegistration<'_>,
+) -> Vec<Diagnostic> {
+    let identity = format!(
+        "{} {} {}",
+        registration.agent, registration.scope, registration.name
+    );
+    let other_scope = match registration.scope {
+        Scope::User => Scope::Project,
+        Scope::Project => Scope::User,
+    };
+    let other = manifest
+        .combinations()
+        .any(|pair| pair == (registration.agent, other_scope))
+        .then(|| configuration::load(roots, registration.agent, other_scope, &[registration.name]))
+        .transpose();
+    let collision = match other {
+        Ok(Some(Some(configuration))) => {
+            configuration.registrations.contains_key(registration.name)
+        }
+        Ok(_) => false,
+        Err(error) => {
+            return vec![Diagnostic::new(
+                "mcp",
+                State::Error,
+                format!("{identity}: could not inspect {other_scope} scope: {error}"),
+            )];
+        }
+    };
+    let reason = if collision {
+        "registration exists in the wrong scope"
+    } else {
+        "registration is missing"
+    };
+    vec![Diagnostic::new(
+        "mcp",
+        State::Drift,
+        format!("{identity}: {reason}"),
+    )]
+}
+
+fn unsupported(agent: Option<Agent>, scope: Option<Scope>) -> String {
+    match (agent, scope) {
+        (Some(agent), Some(scope)) => format!("{agent} {scope}: no MCP registration is declared"),
+        (Some(agent), None) => format!("{agent}: no MCP registration is declared"),
+        (None, Some(scope)) => format!("{scope}: no MCP registration is declared"),
+        (None, None) => "no MCP registration is declared".to_owned(),
+    }
+}

--- a/tooling/arnes/src/mcp/command.rs
+++ b/tooling/arnes/src/mcp/command.rs
@@ -1,0 +1,113 @@
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::files::paths::canonical_within;
+use crate::manifest::{McpRegistration, Scope};
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+pub(super) fn diagnose(roots: &Roots, registration: McpRegistration<'_>) -> Option<Diagnostic> {
+    let identity = format!(
+        "{} {} {}",
+        registration.agent, registration.scope, registration.name
+    );
+    let candidate = match candidate(roots, registration.scope, registration.command) {
+        Ok(Some(path)) => path,
+        Ok(None) => {
+            return Some(Diagnostic::new(
+                "mcp",
+                State::Drift,
+                format!("{identity}: command is missing"),
+            ));
+        }
+        Err(reason) => {
+            return Some(Diagnostic::new(
+                "mcp",
+                State::Error,
+                format!("{identity}: {reason}"),
+            ));
+        }
+    };
+    if escapes_scope(roots, registration.scope, registration.command, &candidate) {
+        return Some(Diagnostic::new(
+            "mcp",
+            State::Error,
+            format!("{identity}: command escapes its scope root"),
+        ));
+    }
+    match fs::metadata(&candidate) {
+        Ok(metadata) if !metadata.is_file() => Some(Diagnostic::new(
+            "mcp",
+            State::Error,
+            format!("{identity}: command is not a file"),
+        )),
+        Ok(metadata) if metadata.permissions().mode() & 0o111 == 0 => Some(Diagnostic::new(
+            "mcp",
+            State::Error,
+            format!("{identity}: command is not executable"),
+        )),
+        Ok(_) => None,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Some(Diagnostic::new(
+            "mcp",
+            State::Drift,
+            format!("{identity}: command is missing"),
+        )),
+        Err(_) => Some(Diagnostic::new(
+            "mcp",
+            State::Error,
+            format!("{identity}: command metadata is unreadable"),
+        )),
+    }
+}
+
+fn escapes_scope(roots: &Roots, scope: Scope, command: &str, candidate: &Path) -> bool {
+    if Path::new(command).is_absolute()
+        || !command.contains(std::path::MAIN_SEPARATOR)
+        || fs::symlink_metadata(candidate).is_err()
+    {
+        return false;
+    }
+    let root = match scope {
+        Scope::User => roots.home(),
+        Scope::Project => roots.repository(),
+    };
+    canonical_within(candidate, root).is_none()
+}
+
+fn candidate(roots: &Roots, scope: Scope, command: &str) -> Result<Option<PathBuf>, &'static str> {
+    if command.contains(std::path::MAIN_SEPARATOR) {
+        let path = PathBuf::from(command);
+        let root = match scope {
+            Scope::User => roots.home(),
+            Scope::Project => roots.repository(),
+        };
+        return Ok(Some(if path.is_absolute() {
+            path
+        } else {
+            root.join(path)
+        }));
+    }
+    let path = env::var_os("PATH").ok_or("PATH is unavailable")?;
+    let mut invalid = None;
+    for directory in env::split_paths(&path) {
+        let candidate = directory.join(command);
+        match fs::metadata(&candidate) {
+            Ok(metadata) if metadata.is_file() && metadata.permissions().mode() & 0o111 != 0 => {
+                return Ok(Some(candidate));
+            }
+            Ok(metadata) if !metadata.is_file() => {
+                invalid.get_or_insert("command in PATH is not a file");
+            }
+            Ok(_) => {
+                invalid.get_or_insert("command in PATH is not executable");
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Err("PATH entry is unreadable"),
+        }
+    }
+    match invalid {
+        Some(error) => Err(error),
+        None => Ok(None),
+    }
+}

--- a/tooling/arnes/src/mcp/comparison.rs
+++ b/tooling/arnes/src/mcp/comparison.rs
@@ -1,0 +1,35 @@
+use super::observed::{EnvironmentValue, ObservedRegistration};
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::McpRegistration;
+
+pub(super) fn diagnose(
+    expected: McpRegistration<'_>,
+    observed: &ObservedRegistration,
+) -> Vec<Diagnostic> {
+    let identity = format!("{} {} {}", expected.agent, expected.scope, expected.name);
+    let mut diagnostics = Vec::new();
+    if expected.command != observed.command {
+        diagnostics.push(drift(&identity, "command differs"));
+    }
+    if expected.args != observed.args {
+        diagnostics.push(drift(&identity, "ordered arguments differ"));
+    }
+    if !environment_matches(expected.environment, observed) {
+        diagnostics.push(drift(&identity, "environment references differ"));
+    }
+    if expected.enabled.is_some() && expected.enabled != observed.enabled {
+        diagnostics.push(drift(&identity, "enabled state differs"));
+    }
+    diagnostics
+}
+
+fn environment_matches(expected: &[String], observed: &ObservedRegistration) -> bool {
+    expected.len() == observed.environment.len()
+        && expected.iter().all(|name| {
+            observed.environment.get(name) == Some(&EnvironmentValue::Reference(name.clone()))
+        })
+}
+
+fn drift(identity: &str, reason: &str) -> Diagnostic {
+    Diagnostic::new("mcp", State::Drift, format!("{identity}: {reason}"))
+}

--- a/tooling/arnes/src/mcp/configuration.rs
+++ b/tooling/arnes/src/mcp/configuration.rs
@@ -1,0 +1,81 @@
+use super::observed::ObservedConfiguration;
+use crate::Roots;
+use crate::files::paths::canonical_within;
+use crate::manifest::{Agent, Scope};
+use std::fmt::{self, Display};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+mod agent_json;
+mod codex;
+
+#[derive(Debug)]
+pub(super) struct ConfigurationError(String);
+
+impl ConfigurationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl Display for ConfigurationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+pub(super) fn load(
+    roots: &Roots,
+    agent: Agent,
+    scope: Scope,
+    managed_names: &[&str],
+) -> Result<Option<ObservedConfiguration>, ConfigurationError> {
+    let (path, root) = configuration_path(roots, agent, scope);
+    let Some(bytes) = read_optional(&path, root)? else {
+        return Ok(None);
+    };
+    match agent {
+        Agent::Claude => {
+            agent_json::load(roots, &bytes, true, scope == Scope::Project, managed_names)
+        }
+        Agent::Cursor => agent_json::load(roots, &bytes, false, false, managed_names),
+        Agent::Codex => codex::load(&bytes, managed_names),
+    }
+}
+
+fn configuration_path(roots: &Roots, agent: Agent, scope: Scope) -> (PathBuf, &Path) {
+    let root = match scope {
+        Scope::User => roots.home(),
+        Scope::Project => roots.repository(),
+    };
+    let relative = match (agent, scope) {
+        (Agent::Claude, Scope::User) => Path::new(".claude.json"),
+        (Agent::Claude, Scope::Project) => Path::new(".mcp.json"),
+        (Agent::Cursor, _) => Path::new(".cursor/mcp.json"),
+        (Agent::Codex, _) => Path::new(".codex/config.toml"),
+    };
+    (root.join(relative), root)
+}
+
+fn read_optional(path: &Path, root: &Path) -> Result<Option<Vec<u8>>, ConfigurationError> {
+    match fs::symlink_metadata(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Ok(_) if canonical_within(path, root).is_none() => {
+            return Err(ConfigurationError::new(format!(
+                "{} escapes its scope root",
+                path.display()
+            )));
+        }
+        Err(_) | Ok(_) => {}
+    }
+    match fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(_) => Err(ConfigurationError::new(format!(
+            "could not read {}",
+            path.display()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/tooling/arnes/src/mcp/configuration/agent_json.rs
+++ b/tooling/arnes/src/mcp/configuration/agent_json.rs
@@ -1,0 +1,142 @@
+use super::super::json;
+use super::super::observed::{EnvironmentValue, ObservedConfiguration, ObservedRegistration};
+use super::{ConfigurationError, read_optional};
+use crate::Roots;
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+
+pub(super) fn load(
+    roots: &Roots,
+    bytes: &[u8],
+    claude: bool,
+    project_state: bool,
+    managed_names: &[&str],
+) -> Result<Option<ObservedConfiguration>, ConfigurationError> {
+    let value = json::parse(bytes).map_err(|error| {
+        ConfigurationError::new(format!("MCP configuration is malformed: {error}"))
+    })?;
+    let root = object(&value, "MCP configuration")?;
+    let Some(servers) = root.get("mcpServers") else {
+        return Ok(Some(ObservedConfiguration::default()));
+    };
+    let disabled = if project_state {
+        claude_disabled(roots)?
+    } else {
+        Vec::new()
+    };
+    let registrations = object(servers, "mcpServers")?
+        .iter()
+        .filter(|(name, _)| managed_names.contains(&name.as_str()))
+        .map(|(name, value)| {
+            registration(name, value, claude, disabled.contains(name))
+                .map(|registration| (name.clone(), registration))
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(Some(ObservedConfiguration { registrations }))
+}
+
+fn registration(
+    name: &str,
+    value: &Value,
+    claude: bool,
+    disabled: bool,
+) -> Result<ObservedRegistration, ConfigurationError> {
+    let entry = object(value, name)?;
+    let command = string_field(entry, name, "command")?.to_owned();
+    let args = string_array(entry.get("args"), name, "args")?;
+    let environment = environment_map(entry.get("env"), name)?;
+    Ok(ObservedRegistration {
+        command,
+        args,
+        environment,
+        enabled: claude.then_some(!disabled),
+    })
+}
+
+fn object<'a>(value: &'a Value, field: &str) -> Result<&'a Map<String, Value>, ConfigurationError> {
+    value
+        .as_object()
+        .ok_or_else(|| ConfigurationError::new(format!("{field} must be an object")))
+}
+
+fn string_field<'a>(
+    entry: &'a Map<String, Value>,
+    name: &str,
+    field: &str,
+) -> Result<&'a str, ConfigurationError> {
+    entry
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| ConfigurationError::new(format!("{name}.{field} must be a string")))
+}
+
+fn string_array(
+    value: Option<&Value>,
+    name: &str,
+    field: &str,
+) -> Result<Vec<String>, ConfigurationError> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    value
+        .as_array()
+        .ok_or_else(|| {
+            ConfigurationError::new(format!("{name}.{field} must be an array of strings"))
+        })?
+        .iter()
+        .map(|value| {
+            value.as_str().map(str::to_owned).ok_or_else(|| {
+                ConfigurationError::new(format!("{name}.{field} must be an array of strings"))
+            })
+        })
+        .collect()
+}
+
+fn environment_map(
+    value: Option<&Value>,
+    name: &str,
+) -> Result<BTreeMap<String, EnvironmentValue>, ConfigurationError> {
+    let Some(value) = value else {
+        return Ok(BTreeMap::new());
+    };
+    object(value, &format!("{name}.env"))?
+        .iter()
+        .map(|(key, value)| {
+            let value = value.as_str().ok_or_else(|| {
+                ConfigurationError::new(format!("{name}.env.{key} must be a string"))
+            })?;
+            Ok((key.clone(), environment_value(value)))
+        })
+        .collect()
+}
+
+fn environment_value(value: &str) -> EnvironmentValue {
+    value
+        .strip_prefix("${")
+        .and_then(|value| value.strip_suffix('}'))
+        .filter(|value| !value.is_empty())
+        .map(|value| EnvironmentValue::Reference(value.to_owned()))
+        .unwrap_or(EnvironmentValue::RedactedLiteral)
+}
+
+fn claude_disabled(roots: &Roots) -> Result<Vec<String>, ConfigurationError> {
+    let Some(bytes) = read_optional(&roots.home().join(".claude.json"), roots.home())? else {
+        return Ok(Vec::new());
+    };
+    let value = json::parse(&bytes).map_err(|error| {
+        ConfigurationError::new(format!("MCP configuration is malformed: {error}"))
+    })?;
+    let root = object(&value, "MCP configuration")?;
+    let Some(project) = root
+        .get("projects")
+        .and_then(Value::as_object)
+        .and_then(|projects| projects.get(roots.repository().to_string_lossy().as_ref()))
+    else {
+        return Ok(Vec::new());
+    };
+    string_array(
+        project.get("disabledMcpServers"),
+        "project",
+        "disabledMcpServers",
+    )
+}

--- a/tooling/arnes/src/mcp/configuration/codex.rs
+++ b/tooling/arnes/src/mcp/configuration/codex.rs
@@ -1,0 +1,103 @@
+use super::super::observed::{EnvironmentValue, ObservedConfiguration, ObservedRegistration};
+use super::ConfigurationError;
+use std::collections::BTreeMap;
+
+pub(super) fn load(
+    bytes: &[u8],
+    managed_names: &[&str],
+) -> Result<Option<ObservedConfiguration>, ConfigurationError> {
+    let input = std::str::from_utf8(bytes)
+        .map_err(|_| ConfigurationError::new("MCP configuration is not UTF-8"))?;
+    let value = toml::from_str::<toml::Value>(input)
+        .map_err(|_| ConfigurationError::new("MCP configuration is malformed"))?;
+    let Some(servers) = value.get("mcp_servers") else {
+        return Ok(Some(ObservedConfiguration::default()));
+    };
+    let servers = servers
+        .as_table()
+        .ok_or_else(|| ConfigurationError::new("mcp_servers must be a table"))?;
+    let registrations = servers
+        .iter()
+        .filter(|(name, _)| managed_names.contains(&name.as_str()))
+        .map(|(name, value)| {
+            registration(name, value).map(|registration| (name.clone(), registration))
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(Some(ObservedConfiguration { registrations }))
+}
+
+fn registration(
+    name: &str,
+    value: &toml::Value,
+) -> Result<ObservedRegistration, ConfigurationError> {
+    let entry = value
+        .as_table()
+        .ok_or_else(|| ConfigurationError::new(format!("{name} must be a table")))?;
+    let command = entry
+        .get("command")
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| ConfigurationError::new(format!("{name}.command must be a string")))?
+        .to_owned();
+    let args = string_array(entry.get("args"), name, "args")?;
+    let mut environment = environment(entry.get("env"), name)?;
+    for reference in string_array(entry.get("env_vars"), name, "env_vars")? {
+        environment.insert(reference.clone(), EnvironmentValue::Reference(reference));
+    }
+    let enabled = entry
+        .get("enabled")
+        .map(|value| {
+            value
+                .as_bool()
+                .ok_or_else(|| ConfigurationError::new(format!("{name}.enabled must be a boolean")))
+        })
+        .transpose()?
+        .unwrap_or(true);
+    Ok(ObservedRegistration {
+        command,
+        args,
+        environment,
+        enabled: Some(enabled),
+    })
+}
+
+fn string_array(
+    value: Option<&toml::Value>,
+    name: &str,
+    field: &str,
+) -> Result<Vec<String>, ConfigurationError> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    value
+        .as_array()
+        .ok_or_else(|| {
+            ConfigurationError::new(format!("{name}.{field} must be an array of strings"))
+        })?
+        .iter()
+        .map(|value| {
+            value.as_str().map(str::to_owned).ok_or_else(|| {
+                ConfigurationError::new(format!("{name}.{field} must be an array of strings"))
+            })
+        })
+        .collect()
+}
+
+fn environment(
+    value: Option<&toml::Value>,
+    name: &str,
+) -> Result<BTreeMap<String, EnvironmentValue>, ConfigurationError> {
+    let Some(value) = value else {
+        return Ok(BTreeMap::new());
+    };
+    value
+        .as_table()
+        .ok_or_else(|| ConfigurationError::new(format!("{name}.env must be a table")))?
+        .iter()
+        .map(|(key, value)| {
+            value.as_str().ok_or_else(|| {
+                ConfigurationError::new(format!("{name}.env.{key} must be a string"))
+            })?;
+            Ok((key.clone(), EnvironmentValue::RedactedLiteral))
+        })
+        .collect()
+}

--- a/tooling/arnes/src/mcp/configuration/tests.rs
+++ b/tooling/arnes/src/mcp/configuration/tests.rs
@@ -1,0 +1,118 @@
+use super::load;
+use crate::Roots;
+use crate::manifest::{Agent, Scope};
+use std::fs;
+
+fn roots() -> (tempfile::TempDir, Roots) {
+    let root = tempfile::tempdir().unwrap();
+    let home = root.path().join("home");
+    let repository = root.path().join("repository");
+    fs::create_dir(&home).unwrap();
+    fs::create_dir(&repository).unwrap();
+    (root, Roots::new(repository, home))
+}
+
+fn write(path: &std::path::Path, contents: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+#[test]
+fn reads_native_registrations_without_retaining_literals() {
+    let (_root, roots) = roots();
+    write(
+        &roots.home().join(".claude.json"),
+        r#"{"mcpServers":{"managed":{"command":"claude-mcp","args":["--stdio"],"env":{"TOKEN":"actual-secret"}},"foreign":{"url":"https://example.invalid"}}}"#,
+    );
+    write(
+        &roots.repository().join(".cursor/mcp.json"),
+        r#"{"mcpServers":{"managed":{"command":"cursor-mcp","env":{"TOKEN":"${TOKEN}"}}}}"#,
+    );
+    write(
+        &roots.home().join(".codex/config.toml"),
+        "[mcp_servers.managed]\ncommand = \"codex-mcp\"\nenv_vars = [\"TOKEN\"]\n[mcp_servers.foreign]\nurl = \"https://example.invalid\"\n",
+    );
+
+    for (agent, scope, command) in [
+        (Agent::Claude, Scope::User, "claude-mcp"),
+        (Agent::Cursor, Scope::Project, "cursor-mcp"),
+        (Agent::Codex, Scope::User, "codex-mcp"),
+    ] {
+        let observed = load(&roots, agent, scope, &["managed"]).unwrap().unwrap();
+        assert_eq!(observed.registrations["managed"].command, command);
+        assert_eq!(observed.registrations["managed"].environment.len(), 1);
+        assert!(!observed.registrations.contains_key("foreign"));
+    }
+    assert!(
+        !format!(
+            "{:?}",
+            load(&roots, Agent::Claude, Scope::User, &["managed"]).unwrap()
+        )
+        .contains("actual-secret")
+    );
+}
+
+#[test]
+fn malformed_and_wrong_field_types_are_errors() {
+    let (_root, roots) = roots();
+    write(
+        &roots.home().join(".claude.json"),
+        r#"{"mcpServers":{"managed":{},"managed":{}}}"#,
+    );
+    assert!(
+        load(&roots, Agent::Claude, Scope::User, &["managed"])
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate object key managed")
+    );
+
+    write(
+        &roots.home().join(".claude.json"),
+        r#"{"mcpServers":{"managed":{"command":"mcp","args":true}}}"#,
+    );
+    assert_eq!(
+        load(&roots, Agent::Claude, Scope::User, &["managed"])
+            .unwrap_err()
+            .to_string(),
+        "managed.args must be an array of strings"
+    );
+
+    write(
+        &roots.home().join(".codex/config.toml"),
+        "[mcp_servers.managed]\ncommand = \"actual-secret\n",
+    );
+    let error = load(&roots, Agent::Codex, Scope::User, &["managed"])
+        .unwrap_err()
+        .to_string();
+    assert_eq!(error, "MCP configuration is malformed");
+    assert!(!error.contains("actual-secret"));
+
+    write(&roots.home().join(".cursor/mcp.json"), "[]");
+    assert_eq!(
+        load(&roots, Agent::Cursor, Scope::User, &["managed"])
+            .unwrap_err()
+            .to_string(),
+        "MCP configuration must be an object"
+    );
+}
+
+#[test]
+fn reads_claude_project_disabled_state() {
+    let (_root, roots) = roots();
+    write(
+        &roots.repository().join(".mcp.json"),
+        r#"{"mcpServers":{"managed":{"command":"mcp"}}}"#,
+    );
+    write(
+        &roots.home().join(".claude.json"),
+        &format!(
+            r#"{{"projects":{{"{}":{{"disabledMcpServers":["managed"]}}}}}}"#,
+            roots.repository().display()
+        ),
+    );
+
+    let observed = load(&roots, Agent::Claude, Scope::Project, &["managed"])
+        .unwrap()
+        .unwrap();
+    assert_eq!(observed.registrations["managed"].enabled, Some(false));
+}

--- a/tooling/arnes/src/mcp/json.rs
+++ b/tooling/arnes/src/mcp/json.rs
@@ -1,0 +1,91 @@
+use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde_json::{Map, Number, Value};
+use std::collections::HashSet;
+use std::fmt;
+
+pub(super) fn parse(bytes: &[u8]) -> Result<Value, serde_json::Error> {
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    let value = ValueSeed.deserialize(&mut deserializer)?;
+    deserializer.end()?;
+    Ok(value)
+}
+
+struct ValueSeed;
+
+impl<'de> DeserializeSeed<'de> for ValueSeed {
+    type Value = Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+struct ValueVisitor;
+
+impl<'de> Visitor<'de> for ValueVisitor {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("JSON without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Value, E> {
+        Ok(Value::Bool(value))
+    }
+    fn visit_i64<E>(self, value: i64) -> Result<Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+    fn visit_u64<E>(self, value: u64) -> Result<Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+    fn visit_str<E>(self, value: &str) -> Result<Value, E> {
+        Ok(Value::String(value.to_owned()))
+    }
+    fn visit_string<E>(self, value: String) -> Result<Value, E> {
+        Ok(Value::String(value))
+    }
+    fn visit_none<E>(self) -> Result<Value, E> {
+        Ok(Value::Null)
+    }
+    fn visit_unit<E>(self) -> Result<Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Value, E>
+    where
+        E: de::Error,
+    {
+        Number::from_f64(value)
+            .map(Value::Number)
+            .ok_or_else(|| E::custom("invalid JSON number"))
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element_seed(ValueSeed)? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+
+    fn visit_map<A>(self, mut object: A) -> Result<Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut keys = HashSet::new();
+        let mut values = Map::new();
+        while let Some(key) = object.next_key::<String>()? {
+            if !keys.insert(key.clone()) {
+                return Err(de::Error::custom(format!("duplicate object key {key}")));
+            }
+            values.insert(key, object.next_value_seed(ValueSeed)?);
+        }
+        Ok(Value::Object(values))
+    }
+}

--- a/tooling/arnes/src/mcp/observed.rs
+++ b/tooling/arnes/src/mcp/observed.rs
@@ -1,0 +1,20 @@
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum EnvironmentValue {
+    Reference(String),
+    RedactedLiteral,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct ObservedRegistration {
+    pub command: String,
+    pub args: Vec<String>,
+    pub environment: BTreeMap<String, EnvironmentValue>,
+    pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct ObservedConfiguration {
+    pub registrations: BTreeMap<String, ObservedRegistration>,
+}

--- a/tooling/arnes/src/measure/result/io.rs
+++ b/tooling/arnes/src/measure/result/io.rs
@@ -124,7 +124,8 @@ mod tests {
 
     #[test]
     fn visits_a_long_journal_line_by_line() {
-        let mut file = tempfile::NamedTempFile::new().unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let mut file = tempfile::NamedTempFile::new_in(directory.path()).unwrap();
         for sequence in 0..20_000 {
             writeln!(file, "{{\"sequence\":{sequence}}}").unwrap();
         }

--- a/tooling/arnes/tests/manifest_mcp.rs
+++ b/tooling/arnes/tests/manifest_mcp.rs
@@ -1,0 +1,81 @@
+use arnes::manifest::{self, Agent, Scope};
+
+fn input(mcp: &str) -> String {
+    format!(
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user, project]\n  - id: cursor\n    scopes: [project]\nmcp:{mcp}\nresources: []\n"
+    )
+}
+
+fn error(mcp: &str) -> String {
+    manifest::parse(&input(mcp)).err().unwrap().to_string()
+}
+
+#[test]
+fn parses_one_explicit_mcp_projection() {
+    let manifest = manifest::parse(&input(
+        "\n  - name: apple-notes\n    agent: claude\n    scope: project\n    command: notes-mcp\n    args: [--stdio]\n    environment: [NOTES_PROFILE]\n    enabled: true",
+    ))
+    .unwrap();
+    let registration = manifest.mcp_registrations().next().unwrap();
+
+    assert_eq!(registration.name, "apple-notes");
+    assert_eq!(
+        (registration.agent, registration.scope),
+        (Agent::Claude, Scope::Project)
+    );
+    assert_eq!(registration.command, "notes-mcp");
+    assert_eq!(registration.args, ["--stdio"]);
+    assert_eq!(registration.environment, ["NOTES_PROFILE"]);
+    assert_eq!(registration.enabled, Some(true));
+}
+
+#[test]
+fn absent_mcp_declarations_remain_compatible() {
+    assert_eq!(
+        manifest::parse(&input(" []"))
+            .unwrap()
+            .mcp_registrations()
+            .count(),
+        0
+    );
+}
+
+#[test]
+fn rejects_invalid_and_duplicate_declarations() {
+    for (mcp, expected) in [
+        (
+            "\n  - { name: Bad_Name, agent: claude, scope: user, command: mcp }",
+            "mcp[0].name: must be lowercase ASCII kebab-case",
+        ),
+        (
+            "\n  - { name: managed, agent: claude, scope: user, command: '' }",
+            "mcp[0].command: command cannot be blank",
+        ),
+        (
+            "\n  - { name: managed, agent: claude, scope: user, command: mcp, environment: [GOOD, BAD-NAME] }",
+            "mcp[0].environment[1]: must be a shell environment variable name",
+        ),
+        (
+            "\n  - { name: managed, agent: claude, scope: user, command: mcp, environment: [TOKEN, TOKEN] }",
+            "mcp[0].environment[1]: duplicate environment reference",
+        ),
+        (
+            "\n  - { name: managed, agent: claude, scope: user, command: one }\n  - { name: managed, agent: claude, scope: user, command: two }",
+            "mcp[1].name: duplicates mcp[0] projection",
+        ),
+        (
+            "\n  - { name: managed, agent: cursor, scope: project, command: mcp, enabled: true }",
+            "mcp[0].enabled: cursor does not represent enabled state",
+        ),
+    ] {
+        assert_eq!(error(mcp), expected);
+    }
+}
+
+#[test]
+fn targets_must_be_declared() {
+    assert_eq!(
+        error("\n  - { name: managed, agent: cursor, scope: user, command: mcp }"),
+        "mcp[0].scope: scope is not declared for this agent"
+    );
+}

--- a/tooling/arnes/tests/manifest_mcp.rs
+++ b/tooling/arnes/tests/manifest_mcp.rs
@@ -52,6 +52,10 @@ fn rejects_invalid_and_duplicate_declarations() {
             "mcp[0].command: command cannot be blank",
         ),
         (
+            "\n  - { name: managed, agent: claude, scope: user, command: ../mcp }",
+            "mcp[0].command: relative command must stay within its scope root",
+        ),
+        (
             "\n  - { name: managed, agent: claude, scope: user, command: mcp, environment: [GOOD, BAD-NAME] }",
             "mcp[0].environment[1]: must be a shell environment variable name",
         ),

--- a/tooling/arnes/tests/mcp.rs
+++ b/tooling/arnes/tests/mcp.rs
@@ -1,0 +1,125 @@
+mod support;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use support::Fixture;
+
+fn manifest(mcp: &str) -> String {
+    format!(
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user, project]\n  - id: cursor\n    scopes: [user, project]\n  - id: codex\n    scopes: [user, project]\nmcp:{mcp}\nresources: []\n"
+    )
+}
+
+fn executable(fixture: &Fixture, path: &str) {
+    fixture.write_repository(path, "#!/bin/sh\nexit 99\n");
+    let path = fixture.repository().join(path);
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).unwrap()
+}
+
+#[test]
+fn matching_project_registration_is_healthy_without_execution() {
+    let fixture = Fixture::new();
+    executable(&fixture, "bin/mcp");
+    fixture.write_home(
+        ".arnes.yaml",
+        &manifest("\n  - { name: managed, agent: claude, scope: project, command: bin/mcp }"),
+    );
+    fixture.write_repository(
+        ".mcp.json",
+        r#"{"mcpServers":{"managed":{"command":"bin/mcp"}}}"#,
+    );
+
+    let before = fixture.snapshot();
+    let output = fixture.command([
+        "doctor", "mcp", "--agent", "claude", "--scope", "project", "-v",
+    ]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout(&output).contains("healthy mcp: claude project managed"));
+    assert!(!fixture.home().join("executed-sentinel").exists());
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn matching_native_project_registrations_are_healthy_for_all_agents() {
+    let fixture = Fixture::new();
+    executable(&fixture, "bin/mcp");
+    fixture.write_home(
+        ".arnes.yaml",
+        &manifest(
+            "\n  - { name: managed, agent: claude, scope: project, command: bin/mcp }\n  - { name: managed, agent: cursor, scope: project, command: bin/mcp }\n  - { name: managed, agent: codex, scope: project, command: bin/mcp }",
+        ),
+    );
+    fixture.write_repository(
+        ".mcp.json",
+        r#"{"mcpServers":{"managed":{"command":"bin/mcp"}}}"#,
+    );
+    fixture.write_repository(
+        ".cursor/mcp.json",
+        r#"{"mcpServers":{"managed":{"command":"bin/mcp"}}}"#,
+    );
+    fixture.write_repository(
+        ".codex/config.toml",
+        "[mcp_servers.managed]\ncommand = \"bin/mcp\"\n",
+    );
+
+    for agent in ["claude", "cursor", "codex"] {
+        let output = fixture.command([
+            "doctor", "mcp", "--agent", agent, "--scope", "project", "-v",
+        ]);
+        assert_eq!(output.status.code(), Some(0), "{agent}");
+        assert!(stdout(&output).contains(&format!("healthy mcp: {agent} project managed")));
+    }
+}
+
+#[test]
+fn default_doctor_checks_project_mcp_without_changing_other_scope_defaults() {
+    let fixture = Fixture::new();
+    executable(&fixture, "bin/mcp");
+    fixture.write_home(
+        ".arnes.yaml",
+        &manifest("\n  - { name: managed, agent: claude, scope: project, command: bin/mcp }"),
+    );
+    fixture.write_repository(
+        ".mcp.json",
+        r#"{"mcpServers":{"managed":{"command":"bin/mcp"}}}"#,
+    );
+
+    let output = fixture.command(["doctor", "-v"]);
+    let stdout = stdout(&output);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout.contains("MCP"));
+    assert!(stdout.contains("healthy mcp: claude project managed"));
+    assert!(stdout.contains("Skills · user scope"));
+}
+
+#[test]
+fn mismatches_are_redacted_and_undeclared_filters_are_unsupported() {
+    let fixture = Fixture::new();
+    executable(&fixture, "bin/mcp");
+    fixture.write_home(".arnes.yaml", &manifest("\n  - { name: managed, agent: cursor, scope: project, command: bin/mcp, args: [expected], environment: [TOKEN] }"));
+    fixture.write_repository(".cursor/mcp.json", r#"{"mcpServers":{"managed":{"command":"other","args":["actual"],"env":{"TOKEN":"actual-secret"}}}}"#);
+
+    let output = fixture.command(["doctor", "mcp", "--agent", "cursor", "--scope", "project"]);
+    let rendered = stdout(&output);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(rendered.contains("command differs"));
+    assert!(rendered.contains("ordered arguments differ"));
+    assert!(rendered.contains("environment references differ"));
+    assert!(!rendered.contains("actual-secret"));
+
+    let json = fixture.command([
+        "doctor", "mcp", "--agent", "cursor", "--scope", "project", "--format", "json",
+    ]);
+    assert!(!stdout(&json).contains("actual-secret"));
+
+    let unsupported = fixture.command(["doctor", "mcp", "--agent", "codex"]);
+    assert!(stdout(&unsupported).contains("unsupported mcp:"));
+}

--- a/tooling/arnes/tests/mcp_failures.rs
+++ b/tooling/arnes/tests/mcp_failures.rs
@@ -1,0 +1,194 @@
+mod support;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::symlink;
+use std::process::{Command, Output};
+use support::Fixture;
+
+fn manifest(scope: &str, command: &str) -> String {
+    format!(
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user, project]\nmcp:\n  - {{ name: managed, agent: claude, scope: {scope}, command: {command} }}\nresources: []\n"
+    )
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).unwrap()
+}
+
+fn command_with_path(fixture: &Fixture, args: &[&str], path: &std::ffi::OsStr) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_arnes"))
+        .args(args)
+        .current_dir(fixture.repository())
+        .env_clear()
+        .env("HOME", fixture.home())
+        .env("PATH", path)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn missing_configuration_and_registration_are_drift() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("project", "bin/mcp"));
+    let missing_configuration = fixture.command(["doctor", "mcp", "--scope", "project"]);
+    assert_eq!(missing_configuration.status.code(), Some(1));
+    assert!(stdout(&missing_configuration).contains("configuration is missing"));
+
+    fixture.write_repository(".mcp.json", r#"{"mcpServers":{}}"#);
+    let missing_registration = fixture.command(["doctor", "mcp", "--scope", "project"]);
+    assert_eq!(missing_registration.status.code(), Some(1));
+    assert!(stdout(&missing_registration).contains("registration is missing"));
+}
+
+#[test]
+fn same_name_in_the_other_scope_is_reported_as_collision() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("project", "bin/mcp"));
+    fixture.write_repository(".mcp.json", r#"{"mcpServers":{}}"#);
+    fixture.write_home(
+        ".claude.json",
+        r#"{"mcpServers":{"managed":{"command":"bin/mcp"}}}"#,
+    );
+
+    let output = fixture.command(["doctor", "mcp", "--scope", "project"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("registration exists in the wrong scope"));
+}
+
+#[test]
+fn malformed_configuration_and_non_executable_commands_are_errors() {
+    let malformed = Fixture::new();
+    malformed.write_home(".arnes.yaml", &manifest("project", "bin/mcp"));
+    malformed.write_repository(".mcp.json", r#"{"mcpServers":{"managed":true}}"#);
+    let malformed_output = malformed.command(["doctor", "mcp", "--scope", "project"]);
+    assert_eq!(malformed_output.status.code(), Some(2));
+    assert!(stdout(&malformed_output).contains("managed must be an object"));
+
+    let non_executable = Fixture::new();
+    non_executable.write_home(".arnes.yaml", &manifest("project", "bin/mcp"));
+    non_executable.write_repository(
+        ".mcp.json",
+        r#"{"mcpServers":{"managed":{"command":"bin/mcp"}}}"#,
+    );
+    non_executable.write_repository("bin/mcp", "never executed");
+    let output = non_executable.command(["doctor", "mcp", "--scope", "project"]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stdout(&output).contains("command is not executable"));
+}
+
+#[test]
+fn bare_path_commands_are_resolved_without_execution() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "managed-mcp"));
+    fixture.write_home(
+        ".claude.json",
+        r#"{"mcpServers":{"managed":{"command":"managed-mcp"}}}"#,
+    );
+    fixture.write_home("bin/managed-mcp", "#!/bin/sh\ntouch executed-sentinel\n");
+    let command = fixture.home().join("bin/managed-mcp");
+    let mut permissions = fs::metadata(&command).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(command, permissions).unwrap();
+
+    let before = fixture.snapshot();
+    let output = fixture.command(["doctor", "mcp", "-v"]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout(&output).contains("healthy mcp: claude user managed"));
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn path_lookup_skips_an_earlier_non_executable_candidate() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "managed-mcp"));
+    fixture.write_home(
+        ".claude.json",
+        r#"{"mcpServers":{"managed":{"command":"managed-mcp"}}}"#,
+    );
+    fixture.write_home("first/managed-mcp", "not executable");
+    fixture.write_home("second/managed-mcp", "#!/bin/sh\nexit 99\n");
+    let executable = fixture.home().join("second/managed-mcp");
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(executable, permissions).unwrap();
+    let path = std::env::join_paths([fixture.home().join("first"), fixture.home().join("second")])
+        .unwrap();
+
+    let output = command_with_path(&fixture, &["doctor", "mcp", "-v"], &path);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout(&output).contains("healthy mcp: claude user managed"));
+}
+
+#[test]
+fn absolute_commands_are_checked_without_execution() {
+    let fixture = Fixture::new();
+    fixture.write_repository("bin/absolute-mcp", "#!/bin/sh\ntouch executed-sentinel\n");
+    let command = fixture.repository().join("bin/absolute-mcp");
+    let mut permissions = fs::metadata(&command).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&command, permissions).unwrap();
+    fixture.write_home(
+        ".arnes.yaml",
+        &manifest("project", command.to_str().unwrap()),
+    );
+    fixture.write_repository(
+        ".mcp.json",
+        &format!(
+            r#"{{"mcpServers":{{"managed":{{"command":"{}"}}}}}}"#,
+            command.display()
+        ),
+    );
+
+    let before = fixture.snapshot();
+    let output = fixture.command(["doctor", "mcp", "--scope", "project", "-v"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn duplicate_scope_names_and_disabled_state_are_drift() {
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user, project]\nmcp:\n  - { name: managed, agent: claude, scope: user, command: mcp }\n  - { name: managed, agent: claude, scope: project, command: mcp, enabled: true }\nresources: []\n",
+    );
+    fixture.write_home(
+        ".claude.json",
+        &format!(
+            r#"{{"mcpServers":{{"managed":{{"command":"mcp"}}}},"projects":{{"{}":{{"disabledMcpServers":["managed"]}}}}}}"#,
+            fs::canonicalize(fixture.repository()).unwrap().display()
+        ),
+    );
+    fixture.write_repository(
+        ".mcp.json",
+        r#"{"mcpServers":{"managed":{"command":"mcp"}}}"#,
+    );
+
+    let output = fixture.command(["doctor", "mcp", "--scope", "project"]);
+    let rendered = stdout(&output);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(rendered.contains("registration also exists in user scope"));
+    assert!(rendered.contains("enabled state differs"), "{rendered}");
+}
+
+#[test]
+fn configuration_symlinks_cannot_escape_the_scope_root() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("project", "mcp"));
+    let outside = tempfile::tempdir().unwrap();
+    let external = outside.path().join("mcp.json");
+    fs::write(
+        &external,
+        r#"{"mcpServers":{"managed":{"command":"secret"}}}"#,
+    )
+    .unwrap();
+    symlink(&external, fixture.repository().join(".mcp.json")).unwrap();
+
+    let output = fixture.command(["doctor", "mcp", "--scope", "project"]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stdout(&output).contains("escapes its scope root"));
+    assert!(!stdout(&output).contains("secret"));
+}


### PR DESCRIPTION
## Description

Add static MCP registration diagnostics to `arnes doctor mcp` and the aggregate `arnes doctor` command.

- Model managed MCP registrations in the Arnes manifest.
- Read Claude, Cursor, and Codex native configuration without executing servers or commands.
- Compare command, ordered arguments, environment references, enabled state, scope collisions, and command availability.
- Redact observed environment values and preserve unrelated or plugin-owned registrations.
- Declare the project-scoped Apple Notes registration.

## Useful Links

- Issue: Closes #121
- Parent: #111

## How to Test

On macOS:

```sh
cd tooling/arnes
cargo test --locked
cargo clippy --all-targets -- -D warnings
cargo check --all-targets --locked
```

From the repository root:

```sh
prettier --check .github/workflows/lint.yml home/.arnes.yaml docs/superpowers/plans/2026-09-01-arnes-mcp-doctor.md docs/superpowers/specs/2026-09-01-arnes-mcp-doctor-design.md
git diff --check origin/main...HEAD
```

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes
