### PR TITLE
feat(arnes): diagnose Codex status lines

### DIFF
--- a/docs/superpowers/plans/2026-09-01-arnes-codex-statusline-doctor.md
+++ b/docs/superpowers/plans/2026-09-01-arnes-codex-statusline-doctor.md
@@ -25,6 +25,7 @@
 ### Task 1: Déclaration normalisée des status lines Codex
 
 **Files:**
+
 - Create: `tooling/arnes/src/manifest/statusline.rs`
 - Create: `tooling/arnes/src/manifest/validation/statusline.rs`
 - Create: `tooling/arnes/tests/manifest_statusline.rs`
@@ -32,6 +33,7 @@
 - Modify: `tooling/arnes/src/manifest/validation.rs`
 
 **Interfaces:**
+
 - Consumes: `Agent`, `Scope`, `ManifestError` et `validation::validate_target` existants.
 - Produces: `Statusline<'a> { agent: Agent, scope: Scope, items: &'a [String] }` et `Manifest::statuslines() -> impl Iterator<Item = Statusline<'_>>`.
 
@@ -166,6 +168,7 @@ git commit -m "feat(arnes): declare Codex status lines"
 ### Task 2: Lecture TOML stricte et diagnostic Doctor
 
 **Files:**
+
 - Create: `tooling/arnes/src/statusline.rs`
 - Create: `tooling/arnes/src/statusline/configuration.rs`
 - Create: `tooling/arnes/tests/statusline.rs`
@@ -173,6 +176,7 @@ git commit -m "feat(arnes): declare Codex status lines"
 - Modify: `tooling/arnes/src/doctor.rs`
 
 **Interfaces:**
+
 - Consumes: `Roots`, `Manifest::statuslines()`, `Diagnostic`, `State`, `Agent`, `Scope`.
 - Produces: `statusline::diagnose(roots: &Roots, manifest: &Manifest, agent: Option<Agent>, scope: Option<Scope>) -> Vec<Diagnostic>` et `configuration::load(roots: &Roots, scope: Scope) -> Result<Option<Vec<String>>, ConfigurationError>`.
 
@@ -399,9 +403,11 @@ git commit -m "feat(arnes): diagnose Codex status lines"
 ### Task 3: Déclaration maintenue et barrière complète
 
 **Files:**
+
 - Modify: `home/.arnes.yaml`
 
 **Interfaces:**
+
 - Consumes: le schéma `statuslines` et `arnes doctor statusline` ajoutés dans les tâches précédentes.
 - Produces: la projection utilisateur Codex maintenue par le dépôt, égale à la configuration actuelle attendue.
 

--- a/docs/superpowers/plans/2026-09-01-arnes-codex-statusline-doctor.md
+++ b/docs/superpowers/plans/2026-09-01-arnes-codex-statusline-doctor.md
@@ -1,0 +1,463 @@
+# Codex Statusline Doctor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter un diagnostic en lecture seule qui compare les déclarations de status line Codex du manifeste à `tui.status_line` dans la configuration native.
+
+**Architecture:** Le manifeste expose une projection Codex par scope avec une liste ordonnée d'identifiants opaques. Un module `statusline` dédié lit uniquement le fichier TOML du scope demandé, valide strictement le chemin `tui.status_line`, puis produit les diagnostics Doctor sans appeler Codex ni aucun shell. Claude et Cursor restent silencieusement hors périmètre, avec un unique commentaire de code sourcé qui documente cette frontière.
+
+**Tech Stack:** Rust 2024, `serde`, `serde_yaml_ng`, `toml`, `clap`, tests d'intégration Cargo avec fixtures isolées.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-arnes-codex-statusline-doctor-design.md`
+
+## Global Constraints
+
+- Le diagnostic est strictement en lecture seule et n'exécute ni Codex ni shell.
+- Claude et Cursor ne produisent aucun diagnostic `unsupported` ; le rendu vide commun reste inchangé.
+- Les identifiants de status line sont comparés comme des chaînes opaques et ordonnées.
+- Un format externe inattendu produit `error`, jamais une valeur de repli plausible.
+- Les clés TOML sans rapport et leurs valeurs ne doivent jamais apparaître dans la sortie.
+- `arnes doctor` n'agrège pas encore cette ressource ; l'issue #123 porte cette évolution.
+- Les fichiers de production restent sous 250 lignes et les fonctions sous 50 lignes logiques, sauf justification explicite.
+
+---
+
+### Task 1: Déclaration normalisée des status lines Codex
+
+**Files:**
+- Create: `tooling/arnes/src/manifest/statusline.rs`
+- Create: `tooling/arnes/src/manifest/validation/statusline.rs`
+- Create: `tooling/arnes/tests/manifest_statusline.rs`
+- Modify: `tooling/arnes/src/manifest.rs`
+- Modify: `tooling/arnes/src/manifest/validation.rs`
+
+**Interfaces:**
+- Consumes: `Agent`, `Scope`, `ManifestError` et `validation::validate_target` existants.
+- Produces: `Statusline<'a> { agent: Agent, scope: Scope, items: &'a [String] }` et `Manifest::statuslines() -> impl Iterator<Item = Statusline<'_>>`.
+
+- [ ] **Step 1: Écrire les tests de parsing et de validation qui échouent**
+
+Créer `tooling/arnes/tests/manifest_statusline.rs` avec un manifeste minimal et des attentes littérales :
+
+```rust
+use arnes::manifest::{self, Agent, Scope};
+
+fn input(statuslines: &str) -> String {
+    input_with_codex_scopes("user, project", statuslines)
+}
+
+fn input_with_codex_scopes(scopes: &str, statuslines: &str) -> String {
+    format!(
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user]\n  - id: cursor\n    scopes: [user]\n  - id: codex\n    scopes: [{scopes}]\nstatuslines:{statuslines}\nresources: []\n"
+    )
+}
+
+fn error(statuslines: &str) -> String {
+    manifest::parse(&input(statuslines))
+        .err()
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn parses_ordered_codex_statusline_projections() {
+    let manifest = manifest::parse(&input(
+        "\n  - { agent: codex, scope: user, items: [model-with-reasoning, current-dir] }\n  - { agent: codex, scope: project, items: [context-used] }",
+    ))
+    .unwrap();
+    let projections = manifest.statuslines().collect::<Vec<_>>();
+
+    assert_eq!(projections.len(), 2);
+    assert_eq!((projections[0].agent, projections[0].scope), (Agent::Codex, Scope::User));
+    assert_eq!(projections[0].items, ["model-with-reasoning", "current-dir"]);
+    assert_eq!((projections[1].agent, projections[1].scope), (Agent::Codex, Scope::Project));
+}
+
+#[test]
+fn absent_statusline_declarations_remain_compatible() {
+    assert_eq!(manifest::parse(&input(" []")).unwrap().statuslines().count(), 0);
+}
+
+#[test]
+fn rejects_unsupported_duplicate_and_empty_statuslines() {
+    for (statuslines, expected) in [
+        ("\n  - { agent: claude, scope: user, items: [model] }", "statuslines[0].agent: only codex status lines are supported"),
+        ("\n  - { agent: cursor, scope: user, items: [model] }", "statuslines[0].agent: only codex status lines are supported"),
+        ("\n  - { agent: codex, scope: user, items: [] }", "statuslines[0].items: cannot be empty"),
+        ("\n  - { agent: codex, scope: user, items: [''] }", "statuslines[0].items[0]: cannot be blank"),
+        ("\n  - { agent: codex, scope: user, items: [model] }\n  - { agent: codex, scope: user, items: [dir] }", "statuslines[1].scope: duplicates statuslines[0] projection"),
+    ] {
+        assert_eq!(error(statuslines), expected);
+    }
+}
+
+#[test]
+fn statusline_target_must_be_declared() {
+    assert_eq!(
+        manifest::parse(&input_with_codex_scopes(
+            "user",
+            "\n  - { agent: codex, scope: project, items: [model] }",
+        ))
+        .err()
+        .unwrap()
+        .to_string(),
+        "statuslines[0].scope: scope is not declared for this agent"
+    );
+}
+```
+
+- [ ] **Step 2: Exécuter le test ciblé et vérifier l'échec RED**
+
+Run: `cargo test --locked --test manifest_statusline`
+
+Expected: FAIL à la compilation car `Manifest::statuslines` et le modèle de déclaration n'existent pas.
+
+- [ ] **Step 3: Implémenter le modèle et sa validation minimale**
+
+Créer `tooling/arnes/src/manifest/statusline.rs` :
+
+```rust
+use super::{Agent, Manifest, Scope};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct StatuslineDeclaration {
+    pub(super) agent: Agent,
+    pub(super) scope: Scope,
+    pub(super) items: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+pub struct Statusline<'a> {
+    pub agent: Agent,
+    pub scope: Scope,
+    pub items: &'a [String],
+}
+
+impl Manifest {
+    pub fn statuslines(&self) -> impl Iterator<Item = Statusline<'_>> {
+        self.statuslines.iter().map(|declaration| Statusline {
+            agent: declaration.agent,
+            scope: declaration.scope,
+            items: &declaration.items,
+        })
+    }
+}
+```
+
+Brancher `mod statusline`, `pub use statusline::Statusline`, le champ `#[serde(default)] statuslines`, puis `statusline::validate(...)` dans `Manifest` et sa validation. La validation dédiée doit appliquer `validate_target`, refuser tout agent autre que Codex, une liste vide, un item `trim().is_empty()` et les doublons `(agent, scope)` avec les messages testés.
+
+- [ ] **Step 4: Exécuter les tests du manifeste et vérifier GREEN**
+
+Run: `cargo test --locked --test manifest_statusline --test manifest --test manifest_mcp`
+
+Expected: PASS, sans warning.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tooling/arnes/src/manifest.rs tooling/arnes/src/manifest/statusline.rs tooling/arnes/src/manifest/validation.rs tooling/arnes/src/manifest/validation/statusline.rs tooling/arnes/tests/manifest_statusline.rs
+git commit -m "feat(arnes): declare Codex status lines"
+```
+
+---
+
+### Task 2: Lecture TOML stricte et diagnostic Doctor
+
+**Files:**
+- Create: `tooling/arnes/src/statusline.rs`
+- Create: `tooling/arnes/src/statusline/configuration.rs`
+- Create: `tooling/arnes/tests/statusline.rs`
+- Modify: `tooling/arnes/src/lib.rs`
+- Modify: `tooling/arnes/src/doctor.rs`
+
+**Interfaces:**
+- Consumes: `Roots`, `Manifest::statuslines()`, `Diagnostic`, `State`, `Agent`, `Scope`.
+- Produces: `statusline::diagnose(roots: &Roots, manifest: &Manifest, agent: Option<Agent>, scope: Option<Scope>) -> Vec<Diagnostic>` et `configuration::load(roots: &Roots, scope: Scope) -> Result<Option<Vec<String>>, ConfigurationError>`.
+
+- [ ] **Step 1: Écrire les tests CLI de frontière et la caractérisation du silence existant**
+
+Créer le helper suivant dans `tooling/arnes/tests/statusline.rs` :
+
+```rust
+mod support;
+
+use support::Fixture;
+
+fn manifest(scope: &str, items: &str) -> String {
+    format!(
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user, project]\n  - id: cursor\n    scopes: [user, project]\n  - id: codex\n    scopes: [user, project]\nstatuslines:\n  - {{ agent: codex, scope: {scope}, items: [{items}] }}\nresources: []\n"
+    )
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).unwrap()
+}
+```
+
+Ajouter quatre tests indépendants :
+
+```rust
+#[test]
+fn matching_user_statusline_is_healthy_without_mutation() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model-with-reasoning, current-dir"));
+    fixture.write_home(
+        ".codex/config.toml",
+        "secret = \"not-rendered\"\n[tui]\nstatus_line = [\"model-with-reasoning\", \"current-dir\"]\n",
+    );
+    let before = fixture.snapshot();
+
+    let output = fixture.command(["doctor", "statusline", "--agent", "codex", "--scope", "user", "-v"]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout(&output).contains("healthy statusline: codex user"));
+    assert!(!stdout(&output).contains("not-rendered"));
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn ordered_statusline_mismatch_is_drift() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model-with-reasoning, current-dir"));
+    fixture.write_home(
+        ".codex/config.toml",
+        "[tui]\nstatus_line = [\"current-dir\", \"model-with-reasoning\"]\n",
+    );
+
+    let output = fixture.command(["doctor", "statusline", "--agent", "codex"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("ordered items differ"));
+}
+
+#[test]
+fn missing_statusline_is_drift() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+
+    let output = fixture.command(["doctor", "statusline"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("configuration is missing"));
+}
+
+#[test]
+fn unsupported_agents_and_undeclared_scopes_are_silent() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+
+    for args in [
+        ["doctor", "statusline", "--agent", "claude", "--format", "json"],
+        ["doctor", "statusline", "--agent", "cursor", "--format", "json"],
+        ["doctor", "statusline", "--scope", "project", "--format", "json"],
+    ] {
+        let output = fixture.command(args);
+        assert_eq!(output.status.code(), Some(0));
+        assert_eq!(stdout(&output), "[]\n");
+    }
+}
+```
+
+Ajouter dans le même fichier les cas de format externe invalide, de scope projet et de clé absente :
+
+```rust
+#[test]
+fn malformed_or_wrongly_typed_codex_configuration_is_error() {
+    for (contents, expected) in [
+        ("not = [", "Codex configuration is malformed"),
+        ("tui = true", "tui must be a table"),
+        ("[tui]\nstatus_line = true", "tui.status_line must be an array of strings"),
+        ("[tui]\nstatus_line = [1]", "tui.status_line must be an array of strings"),
+    ] {
+        let fixture = Fixture::new();
+        fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+        fixture.write_home(".codex/config.toml", contents);
+
+        let output = fixture.command(["doctor", "statusline"]);
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(stdout(&output).contains(expected));
+    }
+}
+
+#[test]
+fn project_scope_reads_only_project_codex_configuration() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("project", "project-item"));
+    fixture.write_home(".codex/config.toml", "[tui]\nstatus_line = [\"wrong-user-item\"]\n");
+    fixture.write_repository(".codex/config.toml", "[tui]\nstatus_line = [\"project-item\"]\n");
+
+    let output = fixture.command(["doctor", "statusline", "--scope", "project", "-v"]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout(&output).contains("healthy statusline: codex project"));
+}
+```
+
+Ajouter les deux frontières restantes :
+
+```rust
+#[test]
+fn missing_statusline_key_is_drift() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+    fixture.write_home(".codex/config.toml", "[tui]\nanimations = false\n");
+
+    let output = fixture.command(["doctor", "statusline"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("configuration is missing"));
+}
+
+#[test]
+fn configuration_symlink_cannot_escape_scope_root() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+    let outside = tempfile::tempdir().unwrap();
+    let external = outside.path().join("config.toml");
+    fs::write(&external, "secret = \"outside\"\n[tui]\nstatus_line = [\"model\"]\n").unwrap();
+    fs::create_dir_all(fixture.home().join(".codex")).unwrap();
+    symlink(&external, fixture.home().join(".codex/config.toml")).unwrap();
+
+    let output = fixture.command(["doctor", "statusline"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stdout(&output).contains("escapes its scope root"));
+    assert!(!stdout(&output).contains("outside"));
+}
+```
+
+- [ ] **Step 2: Exécuter les tests ciblés et vérifier l'échec RED**
+
+Run: `cargo test --locked --test statusline`
+
+Expected: les cas Codex échouent parce que `doctor.rs` renvoie encore un rapport vide ; le test de
+silence peut déjà passer comme caractérisation du fallback existant. Confirmer que les autres
+échecs viennent du comportement absent et non des fixtures.
+
+- [ ] **Step 3: Implémenter le diagnostic et le lecteur minimal**
+
+Dans `tooling/arnes/src/statusline.rs`, filtrer les déclarations par agent et scope, puis produire exactement un diagnostic par déclaration. Ne produire aucun diagnostic quand la sélection est vide. Ajouter près de ce filtre l'unique commentaire de production demandé :
+
+```rust
+// Claude Code status lines execute shell commands (code.claude.com/docs/en/statusline), while Cursor publishes no persistent schema; only Codex tui.status_line is diagnosed statically.
+```
+
+Le lecteur `configuration::load` choisit `~/.codex/config.toml` pour `user` et `.codex/config.toml` pour `project`, refuse les symlinks qui sortent de la racine via `canonical_within`, puis parse uniquement la valeur utile :
+
+```rust
+let value = toml::from_str::<toml::Value>(input)
+    .map_err(|_| ConfigurationError::new("Codex configuration is malformed"))?;
+let Some(tui) = value.get("tui") else {
+    return Ok(None);
+};
+let tui = tui
+    .as_table()
+    .ok_or_else(|| ConfigurationError::new("tui must be a table"))?;
+let Some(status_line) = tui.get("status_line") else {
+    return Ok(None);
+};
+status_line
+    .as_array()
+    .ok_or_else(|| ConfigurationError::new("tui.status_line must be an array of strings"))?
+    .iter()
+    .map(|item| {
+        item.as_str()
+            .map(str::to_owned)
+            .ok_or_else(|| ConfigurationError::new("tui.status_line must be an array of strings"))
+    })
+    .collect::<Result<Vec<_>, _>>()
+    .map(Some)
+```
+
+Pour un fichier, une table ou une clé absente, retourner `Ok(None)` afin que l'orchestrateur produise
+`drift`. Pour un document illisible, non UTF-8, mal formé ou mal typé, retourner une
+`ConfigurationError` sans contenu du fichier. Dans `doctor.rs`, remplacer le fallback de
+`Resource::Statusline` par un branchement analogue à `Mcp`, sans modifier `diagnose_default`.
+Exporter `pub mod statusline` depuis `lib.rs`.
+
+- [ ] **Step 4: Exécuter le test ciblé et vérifier GREEN**
+
+Run: `cargo test --locked --test statusline`
+
+Expected: PASS, sans warning.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tooling/arnes/src/lib.rs tooling/arnes/src/statusline.rs tooling/arnes/src/statusline/configuration.rs tooling/arnes/src/doctor.rs tooling/arnes/tests/statusline.rs
+git commit -m "feat(arnes): diagnose Codex status lines"
+```
+
+---
+
+### Task 3: Déclaration maintenue et barrière complète
+
+**Files:**
+- Modify: `home/.arnes.yaml`
+
+**Interfaces:**
+- Consumes: le schéma `statuslines` et `arnes doctor statusline` ajoutés dans les tâches précédentes.
+- Produces: la projection utilisateur Codex maintenue par le dépôt, égale à la configuration actuelle attendue.
+
+- [ ] **Step 1: Ajouter la déclaration maintenue**
+
+Ajouter avant `mcp:` dans `home/.arnes.yaml` :
+
+```yaml
+statuslines:
+  - agent: codex
+    scope: user
+    items:
+      - model-with-reasoning
+      - current-dir
+      - context-used
+      - context-window-size
+```
+
+- [ ] **Step 2: Vérifier le diagnostic réel sans exécution**
+
+Run depuis `tooling/arnes` : `cargo run --locked -- doctor statusline --agent codex --scope user --verbose`
+
+Expected sur le macOS de développement : exit `0` et un diagnostic `healthy statusline: codex user`; si l'état local a changé depuis la discovery, conserver la dérive comme preuve réelle et ne pas modifier silencieusement la déclaration.
+
+- [ ] **Step 3: Exécuter la barrière complète**
+
+Run depuis `tooling/arnes` :
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --locked -- -D warnings
+cargo check --all-targets --locked
+cargo test --locked
+```
+
+Run depuis la racine : `git diff --check`
+
+Expected: toutes les commandes sortent avec le code `0`. Si Moon est disponible, exécuter aussi `moon run arnes:fmt arnes:clippy arnes:check arnes:test`; sinon consigner son absence et les commandes Cargo équivalentes déjà exercées.
+
+- [ ] **Step 4: Vérifier les limites de taille et les commentaires**
+
+Run : `wc -l tooling/arnes/src/manifest.rs tooling/arnes/src/doctor.rs tooling/arnes/src/statusline.rs tooling/arnes/src/statusline/configuration.rs tooling/arnes/tests/statusline.rs`
+
+Expected: chaque fichier de production manuscrit reste sous 250 lignes ; inspecter toute fonction de production modifiée et confirmer qu'elle reste sous 50 lignes logiques. Vérifier que le seul commentaire de production ajouté est celui qui documente la frontière Claude/Cursor et noter son fait externe dans la livraison.
+
+- [ ] **Step 5: Vérifier le diff sémantique et auto-relire**
+
+Exécuter `semctx_verify_change` si le dépôt devient initialisé ; sinon consigner le no-op. Relire le diff contre la spec et appliquer les dix classes de `harness/skills/pr-verdict/references/failure-classes.md`, en particulier parsing versus assertion et claim stronger than mechanism.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add home/.arnes.yaml
+git commit -m "chore(arnes): declare Codex status line"
+```
+
+- [ ] **Step 7: Demander une revue indépendante**
+
+Fournir au reviewer la spec, ce plan et le diff entre `origin/main` et `HEAD`. Corriger tout constat Critical ou Important, puis rejouer la barrière complète avant d'annoncer la fin.

--- a/docs/superpowers/specs/2026-09-01-arnes-codex-statusline-doctor-design.md
+++ b/docs/superpowers/specs/2026-09-01-arnes-codex-statusline-doctor-design.md
@@ -66,10 +66,11 @@ initiale de l'issue #122 qui demandait un état explicite pour les combinaisons 
 ## Frontières et erreurs
 
 Le contrôle est strictement en lecture seule. Il ne lance ni Codex ni shell, ne résout aucun
-exécutable, ne lit aucune variable d'environnement, ne modifie aucun fichier et ne contacte aucun
-réseau. Aucune status line ne référence d'artefact local dans la représentation Codex prise en
-charge ; les contrôles de présence et de permission prévus par l'issue initiale ne s'appliquent donc
-pas.
+exécutable, ne lit aucune variable d'environnement contenue dans ou référencée par la configuration
+inspectée, ne modifie aucun fichier et ne contacte aucun réseau. `HOME`, pour résoudre le scope
+utilisateur, et `NO_COLOR`, pour le rendu CLI, restent des entrées légitimes. Aucune status line ne
+référence d'artefact local dans la représentation Codex prise en charge ; les contrôles de présence
+et de permission prévus par l'issue initiale ne s'appliquent donc pas.
 
 Les valeurs externes sont parsées sans valeur de repli permissive. Un format inattendu reste une
 erreur observable plutôt que d'être transformé en configuration absente ou divergente. Le

--- a/docs/superpowers/specs/2026-09-01-arnes-codex-statusline-doctor-design.md
+++ b/docs/superpowers/specs/2026-09-01-arnes-codex-statusline-doctor-design.md
@@ -1,0 +1,100 @@
+# Diagnostic de la status line Codex dans Arnes Doctor
+
+## Intention
+
+`arnes doctor statusline` doit vérifier statiquement la status line Codex déclarée par le dépôt.
+Le diagnostic compare la liste ordonnée `tui.status_line` attendue à la configuration TOML native,
+sans lancer Codex, exécuter de commande ni afficher d'autres réglages.
+
+Claude Code et Cursor sont volontairement hors périmètre. Claude Code représente une status line
+par une commande shell, dont la validité réelle ne peut pas être prouvée par une lecture statique.
+Cursor expose une fonctionnalité de status line, mais ne publie pas de schéma persistant suffisant
+pour construire un contrôle stable. Cette limite est documentée par un commentaire dans le code,
+mais ne produit aucun diagnostic `unsupported` dans la sortie utilisateur.
+
+## Source canonique
+
+Le manifeste Arnes ajoute une collection normalisée `statuslines`. Chaque déclaration contient :
+
+- `agent`, qui doit être `codex` ;
+- `scope`, `user` ou `project` ;
+- `items`, la liste ordonnée et non vide des identifiants attendus.
+
+Une seule déclaration est admise par paire `(agent, scope)`. Chaque item doit être une chaîne non
+vide. Les identifiants restent opaques : Arnes ne maintient pas de liste fermée, car la
+documentation Codex ne garantit pas que la liste publiée soit exhaustive ou stable.
+
+Le manifeste maintenu déclare uniquement la configuration utilisateur actuellement attendue :
+
+```yaml
+statuslines:
+  - agent: codex
+    scope: user
+    items:
+      - model-with-reasoning
+      - current-dir
+      - context-used
+      - context-window-size
+```
+
+## Configuration observée
+
+Le scope `user` lit `~/.codex/config.toml` et le scope `project` lit
+`.codex/config.toml`. Le diagnostic extrait exclusivement `tui.status_line` et ignore toutes les
+autres tables et clés.
+
+La valeur doit être une liste TOML de chaînes. Un fichier illisible, un TOML mal formé, une table
+`tui` de type inattendu, une valeur `status_line` de type inattendu ou un élément qui n'est pas une
+chaîne produit un état `error`. Une configuration absente, une table ou une clé absente, ou une
+liste différente produit un état `drift`. Une liste strictement égale, ordre compris, produit un
+état `healthy`.
+
+Le message d'une différence peut montrer les identifiants attendus et observés, puisqu'ils sont les
+seules valeurs lues et ne sont pas des secrets. Il ne sérialise jamais le document TOML complet.
+
+## Sélection et rendu
+
+Le diagnostic ne considère que les déclarations du manifeste qui correspondent aux filtres
+`--agent` et `--scope`. Sans filtre, `arnes doctor statusline` examine toutes les déclarations
+Codex. Une combinaison Claude, Cursor ou sans déclaration ne produit aucun diagnostic de ressource :
+le rendu commun reste `No diagnostics` en humain, `[]` en JSON et le code de sortie vaut `0`.
+
+La status line n'est pas ajoutée au diagnostic agrégé `arnes doctor` dans cette issue ; cette
+agrégation appartient à l'issue #123. Ce choix remplace, pour ce périmètre Codex, l'exigence
+initiale de l'issue #122 qui demandait un état explicite pour les combinaisons non supportées.
+
+## Frontières et erreurs
+
+Le contrôle est strictement en lecture seule. Il ne lance ni Codex ni shell, ne résout aucun
+exécutable, ne lit aucune variable d'environnement, ne modifie aucun fichier et ne contacte aucun
+réseau. Aucune status line ne référence d'artefact local dans la représentation Codex prise en
+charge ; les contrôles de présence et de permission prévus par l'issue initiale ne s'appliquent donc
+pas.
+
+Les valeurs externes sont parsées sans valeur de repli permissive. Un format inattendu reste une
+erreur observable plutôt que d'être transformé en configuration absente ou divergente. Le
+diagnostic ne garantit que l'égalité statique du champ configuré ; il ne prétend pas que Codex
+reconnaît chaque identifiant ni que l'interface TUI l'affichera.
+
+## Preuves attendues
+
+Les tests emploient des homes et dépôts isolés et exercent le vrai binaire Arnes. Ils prouvent au
+minimum :
+
+- la validation des déclarations Codex utilisateur et projet ;
+- le refus de Claude, Cursor, des doublons et des listes ou items vides ;
+- une liste saine et la sensibilité à l'ordre ;
+- l'absence du fichier, de la table ou de la clé ;
+- le TOML mal formé et chaque type inattendu sur le chemin lu ;
+- le silence pour Claude, Cursor et les scopes non déclarés ;
+- l'ignorance des réglages sans rapport et l'absence de mutation des fixtures.
+
+La vérification finale couvre le formatage, le lint Rust et les tests Arnes sur macOS. Les garanties
+sur d'autres plateformes restent limitées aux environnements réellement exercés par la CI.
+
+## Limites
+
+La synchronisation, la validation dynamique d'une status line, l'inspection de commandes Claude,
+le support Cursor et l'agrégation dans `arnes doctor` restent hors périmètre. Cette conception
+implémente la partie statiquement vérifiable de l'issue #122 sous le contrat en lecture seule de
+l'issue parente #111.

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -436,6 +436,14 @@ external:
         plugin: superpowers@openai-curated,
         slug: writing-skills,
       }
+statuslines:
+  - agent: codex
+    scope: user
+    items:
+      - model-with-reasoning
+      - current-dir
+      - context-used
+      - context-window-size
 mcp:
   - name: apple-notes
     agent: claude

--- a/tooling/agent-memory/src/memory/process/deadline/supervisor/tests.rs
+++ b/tooling/agent-memory/src/memory/process/deadline/supervisor/tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::memory::process::deadline::cleanup::SystemGroupController;
 use crate::memory::process::deadline::readers::{ReaderPipe, ReaderSpawner, ReaderState};
-use rustix::process::{Pid, Signal, kill_process, kill_process_group, test_kill_process};
+use rustix::process::{
+    Pid, Signal, WaitOptions, kill_process, kill_process_group, test_kill_process, waitpid,
+};
 use std::io;
 use std::os::unix::process::CommandExt;
 use std::process::Stdio;
@@ -168,7 +170,7 @@ fn returns_promptly_when_group_kill_fails_but_the_leader_is_live() {
 
     assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
     assert!(started.elapsed() < Duration::from_millis(250));
-    assert!(test_kill_process(spawner.pid()).is_err());
+    assert_child_reaped(spawner.pid());
 }
 
 #[test]
@@ -231,7 +233,14 @@ fn assert_reader_failure_reaps(fail_on: usize) {
 
     assert_eq!(error.kind(), io::ErrorKind::Other);
     assert_eq!(readers.attempts.load(Ordering::Acquire), fail_on);
-    assert!(test_kill_process(spawner.pid()).is_err());
+    assert_child_reaped(spawner.pid());
+}
+
+fn assert_child_reaped(pid: Pid) {
+    assert!(matches!(
+        waitpid(Some(pid), WaitOptions::NOHANG),
+        Err(rustix::io::Errno::CHILD)
+    ));
 }
 
 fn sleep_command() -> Command {

--- a/tooling/arnes/src/doctor.rs
+++ b/tooling/arnes/src/doctor.rs
@@ -11,6 +11,7 @@ use arnes::mcp;
 use arnes::prompts;
 use arnes::rules;
 use arnes::skills;
+use arnes::statusline;
 use std::io::{self, IsTerminal};
 use std::process::ExitCode;
 
@@ -111,7 +112,14 @@ fn diagnose(
             Ok(roots) => diagnose_mcp(&roots, agent, scope.or(Some(Scope::User))),
             Err(error) => vec![Diagnostic::new("mcp", State::Error, error.to_string())],
         },
-        _ => Vec::new(),
+        Some(Resource::Statusline) => match Roots::from_environment() {
+            Ok(roots) => diagnose_statusline(&roots, agent, scope.or(Some(Scope::User))),
+            Err(error) => vec![Diagnostic::new(
+                "statusline",
+                State::Error,
+                error.to_string(),
+            )],
+        },
     }
 }
 
@@ -204,5 +212,20 @@ fn diagnose_mcp(roots: &Roots, agent: Option<Agent>, scope: Option<Scope>) -> Ve
     match manifest::load(roots.home()) {
         Ok(manifest) => mcp::diagnose(roots, &manifest, agent, scope),
         Err(error) => vec![Diagnostic::new("mcp", State::Error, error.to_string())],
+    }
+}
+
+fn diagnose_statusline(
+    roots: &Roots,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    match manifest::load(roots.home()) {
+        Ok(manifest) => statusline::diagnose(roots, &manifest, agent, scope),
+        Err(error) => vec![Diagnostic::new(
+            "statusline",
+            State::Error,
+            error.to_string(),
+        )],
     }
 }

--- a/tooling/arnes/src/doctor.rs
+++ b/tooling/arnes/src/doctor.rs
@@ -41,14 +41,12 @@ pub(super) fn run(
         io::stdout().is_terminal(),
         std::env::var_os("NO_COLOR").as_deref(),
     );
+    let rendered_scope = match resource {
+        Some(Resource::Statusline) => scope,
+        _ => resource.and(scope.or(Some(Scope::User))).or(scope),
+    };
     let (output, exit_code) = match format {
-        Format::Human => render::human(
-            diagnostics,
-            resource,
-            agent,
-            resource.and(scope.or(Some(Scope::User))).or(scope),
-            human_options,
-        ),
+        Format::Human => render::human(diagnostics, resource, agent, rendered_scope, human_options),
         Format::Json => {
             let report = Report::new(diagnostics);
             (
@@ -113,7 +111,7 @@ fn diagnose(
             Err(error) => vec![Diagnostic::new("mcp", State::Error, error.to_string())],
         },
         Some(Resource::Statusline) => match Roots::from_environment() {
-            Ok(roots) => diagnose_statusline(&roots, agent, scope.or(Some(Scope::User))),
+            Ok(roots) => diagnose_statusline(&roots, agent, scope),
             Err(error) => vec![Diagnostic::new(
                 "statusline",
                 State::Error,

--- a/tooling/arnes/src/lib.rs
+++ b/tooling/arnes/src/lib.rs
@@ -12,5 +12,6 @@ pub mod prompts;
 pub mod roots;
 pub mod rules;
 pub mod skills;
+pub mod statusline;
 
 pub use roots::Roots;

--- a/tooling/arnes/src/manifest.rs
+++ b/tooling/arnes/src/manifest.rs
@@ -11,6 +11,7 @@ mod mcp;
 mod parsing;
 mod prompts;
 mod rules;
+mod statusline;
 mod validation;
 
 pub use commands::{Command, CommandBinding};
@@ -22,6 +23,7 @@ pub use mcp::McpRegistration;
 pub use parsing::{load, parse};
 pub use prompts::{Prompt, PromptProjection, PromptRepresentation};
 pub use rules::RuleResource;
+pub use statusline::Statusline;
 
 const MANIFEST_FILE: &str = ".arnes.yaml";
 const SCHEMA_VERSION: u64 = 1;
@@ -44,6 +46,8 @@ pub struct Manifest {
     hooks: Vec<hooks::HookDeclaration>,
     #[serde(default)]
     mcp: Vec<mcp::McpDeclaration>,
+    #[serde(default)]
+    statuslines: Vec<statusline::StatuslineDeclaration>,
     resources: Vec<ResourceDeclaration>,
 }
 

--- a/tooling/arnes/src/manifest/statusline.rs
+++ b/tooling/arnes/src/manifest/statusline.rs
@@ -1,0 +1,27 @@
+use super::{Agent, Manifest, Scope};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct StatuslineDeclaration {
+    pub(super) agent: Agent,
+    pub(super) scope: Scope,
+    pub(super) items: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+pub struct Statusline<'a> {
+    pub agent: Agent,
+    pub scope: Scope,
+    pub items: &'a [String],
+}
+
+impl Manifest {
+    pub fn statuslines(&self) -> impl Iterator<Item = Statusline<'_>> {
+        self.statuslines.iter().map(|declaration| Statusline {
+            agent: declaration.agent,
+            scope: declaration.scope,
+            items: &declaration.items,
+        })
+    }
+}

--- a/tooling/arnes/src/manifest/validation.rs
+++ b/tooling/arnes/src/manifest/validation.rs
@@ -99,7 +99,6 @@ fn validate_resources(
     let mut identifiers = HashMap::new();
     let mut destinations = HashMap::new();
     let mut skill_projections = HashMap::new();
-
     for (index, resource) in resources.iter().enumerate() {
         let field = |name: &str| format!("resources[{index}].{name}");
         if resource.id.is_empty() {
@@ -153,6 +152,7 @@ fn validate_normalized_resource_kind(
     let name = match resource.kind {
         super::ResourceKind::Prompts => "prompts",
         super::ResourceKind::Commands => "commands",
+        super::ResourceKind::Statusline => "statuslines",
         _ => return Ok(()),
     };
     Err(ManifestError::new(

--- a/tooling/arnes/src/manifest/validation.rs
+++ b/tooling/arnes/src/manifest/validation.rs
@@ -10,6 +10,7 @@ mod mcp;
 mod prompts;
 mod rules;
 mod skills;
+mod statusline;
 
 pub(super) fn validate_value(value: &Value) -> Result<(), ManifestError> {
     let mapping = value
@@ -86,6 +87,7 @@ pub(super) fn validate(manifest: &Manifest) -> Result<(), ManifestError> {
     commands::validate(&manifest.commands, &manifest.prompts, &agents)?;
     hooks::validate(&manifest.hooks, &agents)?;
     mcp::validate(&manifest.mcp, &agents)?;
+    statusline::validate(&manifest.statuslines, &agents)?;
     skills::validate(&manifest.skills, &manifest.resources, &agents)?;
     external::validate(&manifest.external, &agents)
 }

--- a/tooling/arnes/src/manifest/validation/statusline.rs
+++ b/tooling/arnes/src/manifest/validation/statusline.rs
@@ -1,0 +1,38 @@
+use super::super::statusline::StatuslineDeclaration;
+use super::super::{Agent, ManifestError, Scope};
+use std::collections::{HashMap, HashSet};
+
+pub(super) fn validate(
+    declarations: &[StatuslineDeclaration],
+    agents: &HashMap<Agent, HashSet<Scope>>,
+) -> Result<(), ManifestError> {
+    let mut projections = HashMap::new();
+    for (index, declaration) in declarations.iter().enumerate() {
+        let field = |name: &str| format!("statuslines[{index}].{name}");
+        super::validate_target(&field, declaration.agent, declaration.scope, agents)?;
+        if declaration.agent != Agent::Codex {
+            return Err(ManifestError::new(
+                field("agent"),
+                "only codex status lines are supported",
+            ));
+        }
+        if declaration.items.is_empty() {
+            return Err(ManifestError::new(field("items"), "cannot be empty"));
+        }
+        for (item_index, item) in declaration.items.iter().enumerate() {
+            if item.trim().is_empty() {
+                return Err(ManifestError::new(
+                    format!("statuslines[{index}].items[{item_index}]"),
+                    "cannot be blank",
+                ));
+            }
+        }
+        if let Some(previous) = projections.insert((declaration.agent, declaration.scope), index) {
+            return Err(ManifestError::new(
+                field("scope"),
+                format!("duplicates statuslines[{previous}] projection"),
+            ));
+        }
+    }
+    Ok(())
+}

--- a/tooling/arnes/src/statusline.rs
+++ b/tooling/arnes/src/statusline.rs
@@ -10,7 +10,7 @@ pub fn diagnose(
     agent: Option<Agent>,
     scope: Option<Scope>,
 ) -> Vec<Diagnostic> {
-    // Claude Code status lines execute shell commands (code.claude.com/docs/en/statusline), while Cursor publishes no persistent schema; only Codex tui.status_line is diagnosed statically.
+    // Claude Code status lines execute shell commands (code.claude.com/docs/en/statusline); Cursor documents /statusline and CLI configuration but no persistent schema sufficient for static validation of a custom status line, so only Codex tui.status_line is diagnosed.
     manifest
         .statuslines()
         .filter(|statusline| agent.is_none_or(|agent| agent == statusline.agent))

--- a/tooling/arnes/src/statusline.rs
+++ b/tooling/arnes/src/statusline.rs
@@ -1,0 +1,42 @@
+pub mod configuration;
+
+use crate::Roots;
+use crate::diagnostic::{Diagnostic, State};
+use crate::manifest::{Agent, Manifest, Scope, Statusline};
+
+pub fn diagnose(
+    roots: &Roots,
+    manifest: &Manifest,
+    agent: Option<Agent>,
+    scope: Option<Scope>,
+) -> Vec<Diagnostic> {
+    // Claude Code status lines execute shell commands (code.claude.com/docs/en/statusline), while Cursor publishes no persistent schema; only Codex tui.status_line is diagnosed statically.
+    manifest
+        .statuslines()
+        .filter(|statusline| agent.is_none_or(|agent| agent == statusline.agent))
+        .filter(|statusline| scope.is_none_or(|scope| scope == statusline.scope))
+        .map(|statusline| diagnose_statusline(roots, statusline))
+        .collect()
+}
+
+fn diagnose_statusline(roots: &Roots, statusline: Statusline<'_>) -> Diagnostic {
+    let identity = format!("{} {}", statusline.agent, statusline.scope);
+    match configuration::load(roots, statusline.scope) {
+        Ok(Some(items)) if items == statusline.items => Diagnostic::new(
+            "statusline",
+            State::Healthy,
+            format!("{identity}: status line matches manifest"),
+        ),
+        Ok(Some(_)) => Diagnostic::new(
+            "statusline",
+            State::Drift,
+            format!("{identity}: ordered items differ"),
+        ),
+        Ok(None) => Diagnostic::new(
+            "statusline",
+            State::Drift,
+            format!("{identity}: configuration is missing"),
+        ),
+        Err(error) => Diagnostic::new("statusline", State::Error, format!("{identity}: {error}")),
+    }
+}

--- a/tooling/arnes/src/statusline/configuration.rs
+++ b/tooling/arnes/src/statusline/configuration.rs
@@ -1,0 +1,73 @@
+use crate::Roots;
+use crate::files::paths::canonical_within;
+use crate::manifest::Scope;
+use std::fmt::{self, Display};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+
+#[derive(Debug)]
+pub struct ConfigurationError(String);
+
+impl ConfigurationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl Display for ConfigurationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+pub fn load(roots: &Roots, scope: Scope) -> Result<Option<Vec<String>>, ConfigurationError> {
+    let root = match scope {
+        Scope::User => roots.home(),
+        Scope::Project => roots.repository(),
+    };
+    let path = root.join(".codex/config.toml");
+    let Some(bytes) = read_optional(&path, root)? else {
+        return Ok(None);
+    };
+    let input = std::str::from_utf8(&bytes)
+        .map_err(|_| ConfigurationError::new("Codex configuration is not UTF-8"))?;
+    let value = toml::from_str::<toml::Value>(input)
+        .map_err(|_| ConfigurationError::new("Codex configuration is malformed"))?;
+    let Some(tui) = value.get("tui") else {
+        return Ok(None);
+    };
+    let tui = tui
+        .as_table()
+        .ok_or_else(|| ConfigurationError::new("tui must be a table"))?;
+    let Some(status_line) = tui.get("status_line") else {
+        return Ok(None);
+    };
+    status_line
+        .as_array()
+        .ok_or_else(|| ConfigurationError::new("tui.status_line must be an array of strings"))?
+        .iter()
+        .map(|item| {
+            item.as_str().map(str::to_owned).ok_or_else(|| {
+                ConfigurationError::new("tui.status_line must be an array of strings")
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+fn read_optional(path: &Path, root: &Path) -> Result<Option<Vec<u8>>, ConfigurationError> {
+    match fs::symlink_metadata(path) {
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Ok(_) if canonical_within(path, root).is_none() => {
+            return Err(ConfigurationError::new(format!(
+                "{} escapes its scope root",
+                path.display()
+            )));
+        }
+        Err(_) | Ok(_) => {}
+    }
+    fs::read(path)
+        .map(Some)
+        .map_err(|_| ConfigurationError::new(format!("could not read {}", path.display())))
+}

--- a/tooling/arnes/src/statusline/configuration.rs
+++ b/tooling/arnes/src/statusline/configuration.rs
@@ -57,17 +57,25 @@ pub fn load(roots: &Roots, scope: Scope) -> Result<Option<Vec<String>>, Configur
 }
 
 fn read_optional(path: &Path, root: &Path) -> Result<Option<Vec<u8>>, ConfigurationError> {
-    match fs::symlink_metadata(path) {
+    let canonical = match fs::symlink_metadata(path) {
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
-        Ok(_) if canonical_within(path, root).is_none() => {
-            return Err(ConfigurationError::new(format!(
-                "{} escapes its scope root",
-                path.display()
-            )));
-        }
-        Err(_) | Ok(_) => {}
+        Ok(_) => canonical_within(path, root).ok_or_else(|| {
+            ConfigurationError::new(format!("{} escapes its scope root", path.display()))
+        })?,
+        Err(_) => return Err(could_not_read(path)),
+    };
+    let metadata = fs::metadata(&canonical).map_err(|_| could_not_read(path))?;
+    if !metadata.is_file() {
+        return Err(ConfigurationError::new(format!(
+            "{} must be a regular file",
+            path.display()
+        )));
     }
-    fs::read(path)
+    fs::read(canonical)
         .map(Some)
-        .map_err(|_| ConfigurationError::new(format!("could not read {}", path.display())))
+        .map_err(|_| could_not_read(path))
+}
+
+fn could_not_read(path: &Path) -> ConfigurationError {
+    ConfigurationError::new(format!("could not read {}", path.display()))
 }

--- a/tooling/arnes/tests/manifest_statusline.rs
+++ b/tooling/arnes/tests/manifest_statusline.rs
@@ -43,12 +43,18 @@ fn parses_ordered_codex_statusline_projections() {
 
 #[test]
 fn absent_statusline_declarations_remain_compatible() {
+    let input = "version: 1\nagents:\n  - id: codex\n    scopes: [user, project]\nresources: []\n";
+
+    assert_eq!(manifest::parse(input).unwrap().statuslines().count(), 0);
+}
+
+#[test]
+fn legacy_statusline_resources_are_rejected_in_favor_of_top_level_declarations() {
+    let input = "version: 1\nagents:\n  - id: codex\n    scopes: [user]\nstatuslines:\n  - { agent: codex, scope: user, items: [model] }\nresources:\n  - id: legacy-statusline\n    kind: statusline\n    agent: codex\n    scope: user\n    source: { root: repository, path: config.toml }\n    destination: { root: home, path: .codex/config.toml }\n";
+
     assert_eq!(
-        manifest::parse(&input(" []"))
-            .unwrap()
-            .statuslines()
-            .count(),
-        0
+        manifest::parse(input).err().unwrap().to_string(),
+        "resources[0].kind: statuslines must use normalized top-level declarations"
     );
 }
 

--- a/tooling/arnes/tests/manifest_statusline.rs
+++ b/tooling/arnes/tests/manifest_statusline.rs
@@ -38,6 +38,7 @@ fn parses_ordered_codex_statusline_projections() {
         (projections[1].agent, projections[1].scope),
         (Agent::Codex, Scope::Project)
     );
+    assert_eq!(projections[1].items, ["context-used"]);
 }
 
 #[test]

--- a/tooling/arnes/tests/manifest_statusline.rs
+++ b/tooling/arnes/tests/manifest_statusline.rs
@@ -1,0 +1,94 @@
+use arnes::manifest::{self, Agent, Scope};
+
+fn input(statuslines: &str) -> String {
+    input_with_codex_scopes("user, project", statuslines)
+}
+
+fn input_with_codex_scopes(scopes: &str, statuslines: &str) -> String {
+    format!(
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user]\n  - id: cursor\n    scopes: [user]\n  - id: codex\n    scopes: [{scopes}]\nstatuslines:{statuslines}\nresources: []\n"
+    )
+}
+
+fn error(statuslines: &str) -> String {
+    manifest::parse(&input(statuslines))
+        .err()
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn parses_ordered_codex_statusline_projections() {
+    let manifest = manifest::parse(&input(
+        "\n  - { agent: codex, scope: user, items: [model-with-reasoning, current-dir] }\n  - { agent: codex, scope: project, items: [context-used] }",
+    ))
+    .unwrap();
+    let projections = manifest.statuslines().collect::<Vec<_>>();
+
+    assert_eq!(projections.len(), 2);
+    assert_eq!(
+        (projections[0].agent, projections[0].scope),
+        (Agent::Codex, Scope::User)
+    );
+    assert_eq!(
+        projections[0].items,
+        ["model-with-reasoning", "current-dir"]
+    );
+    assert_eq!(
+        (projections[1].agent, projections[1].scope),
+        (Agent::Codex, Scope::Project)
+    );
+}
+
+#[test]
+fn absent_statusline_declarations_remain_compatible() {
+    assert_eq!(
+        manifest::parse(&input(" []"))
+            .unwrap()
+            .statuslines()
+            .count(),
+        0
+    );
+}
+
+#[test]
+fn rejects_unsupported_duplicate_and_empty_statuslines() {
+    for (statuslines, expected) in [
+        (
+            "\n  - { agent: claude, scope: user, items: [model] }",
+            "statuslines[0].agent: only codex status lines are supported",
+        ),
+        (
+            "\n  - { agent: cursor, scope: user, items: [model] }",
+            "statuslines[0].agent: only codex status lines are supported",
+        ),
+        (
+            "\n  - { agent: codex, scope: user, items: [] }",
+            "statuslines[0].items: cannot be empty",
+        ),
+        (
+            "\n  - { agent: codex, scope: user, items: [''] }",
+            "statuslines[0].items[0]: cannot be blank",
+        ),
+        (
+            "\n  - { agent: codex, scope: user, items: [model] }\n  - { agent: codex, scope: user, items: [dir] }",
+            "statuslines[1].scope: duplicates statuslines[0] projection",
+        ),
+    ] {
+        assert_eq!(error(statuslines), expected);
+    }
+}
+
+#[test]
+fn statusline_target_must_be_declared() {
+    assert_eq!(
+        manifest::parse(&input_with_codex_scopes(
+            "user",
+            "\n  - { agent: codex, scope: project, items: [model] }",
+        ))
+        .err()
+        .unwrap()
+        .to_string(),
+        "statuslines[0].scope: scope is not declared for this agent"
+    );
+}

--- a/tooling/arnes/tests/statusline.rs
+++ b/tooling/arnes/tests/statusline.rs
@@ -1,0 +1,188 @@
+mod support;
+
+use support::Fixture;
+
+fn manifest(scope: &str, items: &str) -> String {
+    format!(
+        "version: 1\nagents:\n  - id: claude\n    scopes: [user, project]\n  - id: cursor\n    scopes: [user, project]\n  - id: codex\n    scopes: [user, project]\nstatuslines:\n  - {{ agent: codex, scope: {scope}, items: [{items}] }}\nresources: []\n"
+    )
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).unwrap()
+}
+
+#[test]
+fn matching_user_statusline_is_healthy_without_mutation() {
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        &manifest("user", "model-with-reasoning, current-dir"),
+    );
+    fixture.write_home(
+        ".codex/config.toml",
+        "secret = \"not-rendered\"\n[tui]\nstatus_line = [\"model-with-reasoning\", \"current-dir\"]\n",
+    );
+    let before = fixture.snapshot();
+
+    let output = fixture.command([
+        "doctor",
+        "statusline",
+        "--agent",
+        "codex",
+        "--scope",
+        "user",
+        "-v",
+    ]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout(&output).contains("healthy statusline: codex user"));
+    assert!(!stdout(&output).contains("not-rendered"));
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn ordered_statusline_mismatch_is_drift() {
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        &manifest("user", "model-with-reasoning, current-dir"),
+    );
+    fixture.write_home(
+        ".codex/config.toml",
+        "[tui]\nstatus_line = [\"current-dir\", \"model-with-reasoning\"]\n",
+    );
+
+    let output = fixture.command(["doctor", "statusline", "--agent", "codex"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("ordered items differ"));
+}
+
+#[test]
+fn missing_statusline_is_drift() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+
+    let output = fixture.command(["doctor", "statusline"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("configuration is missing"));
+}
+
+#[test]
+fn unsupported_agents_and_undeclared_scopes_are_silent() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+
+    for args in [
+        [
+            "doctor",
+            "statusline",
+            "--agent",
+            "claude",
+            "--format",
+            "json",
+        ],
+        [
+            "doctor",
+            "statusline",
+            "--agent",
+            "cursor",
+            "--format",
+            "json",
+        ],
+        [
+            "doctor",
+            "statusline",
+            "--scope",
+            "project",
+            "--format",
+            "json",
+        ],
+    ] {
+        let output = fixture.command(args);
+        assert_eq!(output.status.code(), Some(0));
+        assert_eq!(stdout(&output), "[]\n");
+    }
+}
+
+#[test]
+fn malformed_or_wrongly_typed_codex_configuration_is_error() {
+    for (contents, expected) in [
+        ("not = [", "Codex configuration is malformed"),
+        ("tui = true", "tui must be a table"),
+        (
+            "[tui]\nstatus_line = true",
+            "tui.status_line must be an array of strings",
+        ),
+        (
+            "[tui]\nstatus_line = [1]",
+            "tui.status_line must be an array of strings",
+        ),
+    ] {
+        let fixture = Fixture::new();
+        fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+        fixture.write_home(".codex/config.toml", contents);
+
+        let output = fixture.command(["doctor", "statusline"]);
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(stdout(&output).contains(expected));
+    }
+}
+
+#[test]
+fn project_scope_reads_only_project_codex_configuration() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("project", "project-item"));
+    fixture.write_home(
+        ".codex/config.toml",
+        "[tui]\nstatus_line = [\"wrong-user-item\"]\n",
+    );
+    fixture.write_repository(
+        ".codex/config.toml",
+        "[tui]\nstatus_line = [\"project-item\"]\n",
+    );
+
+    let output = fixture.command(["doctor", "statusline", "--scope", "project", "-v"]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout(&output).contains("healthy statusline: codex project"));
+}
+
+#[test]
+fn missing_statusline_key_is_drift() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+    fixture.write_home(".codex/config.toml", "[tui]\nanimations = false\n");
+
+    let output = fixture.command(["doctor", "statusline"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("configuration is missing"));
+}
+
+#[test]
+fn configuration_symlink_cannot_escape_scope_root() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+    let outside = tempfile::tempdir().unwrap();
+    let external = outside.path().join("config.toml");
+    fs::write(
+        &external,
+        "secret = \"outside\"\n[tui]\nstatus_line = [\"model\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(fixture.home().join(".codex")).unwrap();
+    symlink(&external, fixture.home().join(".codex/config.toml")).unwrap();
+
+    let output = fixture.command(["doctor", "statusline"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stdout(&output).contains("escapes its scope root"));
+    assert!(!stdout(&output).contains("outside"));
+}

--- a/tooling/arnes/tests/statusline.rs
+++ b/tooling/arnes/tests/statusline.rs
@@ -1,5 +1,6 @@
 mod support;
 
+use std::fs;
 use support::Fixture;
 
 fn manifest(scope: &str, items: &str) -> String {
@@ -140,15 +141,40 @@ fn project_scope_reads_only_project_codex_configuration() {
         ".codex/config.toml",
         "[tui]\nstatus_line = [\"wrong-user-item\"]\n",
     );
-    fixture.write_repository(
-        ".codex/config.toml",
+    let project_configuration = fixture.repository().join(".codex/config.toml");
+    fs::create_dir_all(project_configuration.parent().unwrap()).unwrap();
+    fs::write(
+        project_configuration,
         "[tui]\nstatus_line = [\"project-item\"]\n",
-    );
+    )
+    .unwrap();
 
     let output = fixture.command(["doctor", "statusline", "--scope", "project", "-v"]);
 
     assert_eq!(output.status.code(), Some(0));
     assert!(stdout(&output).contains("healthy statusline: codex project"));
+}
+
+#[test]
+fn unscoped_statusline_diagnoses_all_declared_scopes_without_a_scope_qualifier() {
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        "version: 1\nagents:\n  - id: codex\n    scopes: [user, project]\nstatuslines:\n  - { agent: codex, scope: user, items: [model] }\n  - { agent: codex, scope: project, items: [current-dir] }\nresources: []\n",
+    );
+    fixture.write_home(".codex/config.toml", "[tui]\nstatus_line = [\"model\"]\n");
+    fixture.write_repository(
+        ".codex/config.toml",
+        "[tui]\nstatus_line = [\"current-dir\"]\n",
+    );
+
+    let output = fixture.command(["doctor", "statusline", "-v"]);
+    let rendered = stdout(&output);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(rendered.contains("healthy statusline: codex user"));
+    assert!(rendered.contains("healthy statusline: codex project"));
+    assert!(!rendered.contains("Statusline · user scope"));
 }
 
 #[test]
@@ -165,7 +191,6 @@ fn missing_statusline_key_is_drift() {
 
 #[test]
 fn configuration_symlink_cannot_escape_scope_root() {
-    use std::fs;
     use std::os::unix::fs::symlink;
 
     let fixture = Fixture::new();

--- a/tooling/arnes/tests/statusline_boundaries.rs
+++ b/tooling/arnes/tests/statusline_boundaries.rs
@@ -1,0 +1,162 @@
+mod support;
+
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+use support::Fixture;
+
+fn manifest() -> &'static str {
+    "version: 1\nagents:\n  - id: codex\n    scopes: [user]\nstatuslines:\n  - { agent: codex, scope: user, items: [model] }\nresources: []\n"
+}
+
+fn spawn_statusline_doctor(fixture: &Fixture) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_arnes"))
+        .args(["doctor", "statusline"])
+        .current_dir(fixture.repository())
+        .env_clear()
+        .env("HOME", fixture.home())
+        .env("PATH", fixture.home().join("bin"))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap()
+}
+
+fn wait_for_output(mut child: Child, timeout: Duration) -> Output {
+    let started = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            let mut stdout = Vec::new();
+            let mut stderr = Vec::new();
+            child
+                .stdout
+                .take()
+                .unwrap()
+                .read_to_end(&mut stdout)
+                .unwrap();
+            child
+                .stderr
+                .take()
+                .unwrap()
+                .read_to_end(&mut stderr)
+                .unwrap();
+            return Output {
+                status,
+                stdout,
+                stderr,
+            };
+        }
+        if started.elapsed() >= timeout {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            panic!("statusline doctor did not return before the deadline");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn rendered(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8(output.stdout.clone()).unwrap(),
+        String::from_utf8(output.stderr.clone()).unwrap()
+    )
+}
+
+#[test]
+fn fifo_configuration_is_rejected_without_opening_or_blocking() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", manifest());
+    let configuration = fixture.home().join(".codex/config.toml");
+    fs::create_dir_all(configuration.parent().unwrap()).unwrap();
+    assert!(
+        Command::new("mkfifo")
+            .arg(&configuration)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        fs::symlink_metadata(&configuration)
+            .unwrap()
+            .file_type()
+            .is_fifo()
+    );
+
+    let output = wait_for_output(spawn_statusline_doctor(&fixture), Duration::from_secs(2));
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(rendered(&output).contains("must be a regular file"));
+}
+
+#[test]
+fn non_utf8_configuration_is_error_without_content_leak() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", manifest());
+    let configuration = fixture.home().join(".codex/config.toml");
+    fs::create_dir_all(configuration.parent().unwrap()).unwrap();
+    fs::write(
+        configuration,
+        b"sensitive-non-utf8-marker = \"private\"\n[tui]\nstatus_line = [\"\xff\"]\n",
+    )
+    .unwrap();
+    let before = fixture.snapshot();
+
+    let output = fixture.command(["doctor", "statusline"]);
+    let rendered = rendered(&output);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(rendered.contains("Codex configuration is not UTF-8"));
+    assert!(!rendered.contains("sensitive-non-utf8-marker"));
+    assert!(!rendered.contains("private"));
+    assert_eq!(fixture.snapshot(), before);
+}
+
+#[test]
+fn unreadable_configuration_is_error_without_content_leak() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", manifest());
+    let configuration = fixture.home().join(".codex/config.toml");
+    fs::create_dir_all(configuration.parent().unwrap()).unwrap();
+    fs::write(
+        &configuration,
+        "sensitive-unreadable-marker = \"private\"\n[tui]\nstatus_line = [\"model\"]\n",
+    )
+    .unwrap();
+    fs::set_permissions(&configuration, fs::Permissions::from_mode(0o000)).unwrap();
+    assert_eq!(
+        fs::read(&configuration).unwrap_err().kind(),
+        std::io::ErrorKind::PermissionDenied
+    );
+
+    let output = fixture.command(["doctor", "statusline"]);
+    fs::set_permissions(&configuration, fs::Permissions::from_mode(0o600)).unwrap();
+    let rendered = rendered(&output);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(rendered.contains("could not read"));
+    assert!(!rendered.contains("sensitive-unreadable-marker"));
+    assert!(!rendered.contains("private"));
+}
+
+#[test]
+fn missing_tui_table_is_drift_without_content_leak() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", manifest());
+    fixture.write_home(
+        ".codex/config.toml",
+        "sensitive-missing-tui-marker = \"private\"\n[other]\nenabled = true\n",
+    );
+
+    let output = fixture.command(["doctor", "statusline"]);
+    let rendered = rendered(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(rendered.contains("configuration is missing"));
+    assert!(!rendered.contains("sensitive-missing-tui-marker"));
+    assert!(!rendered.contains("private"));
+}


### PR DESCRIPTION
## Description

- ajoute une déclaration normalisée des status lines Codex dans le manifeste Arnes ;
- compare statiquement la liste ordonnée `tui.status_line` pour les scopes user et project ;
- traite les configurations absentes ou divergentes comme drift, et les fichiers mal formés, non UTF-8, illisibles, hors racine ou spéciaux comme error ;
- reste strictement en lecture seule, sans lancer Codex ni shell et sans rendre les autres réglages TOML ;
- laisse Claude et Cursor silencieusement hors périmètre, conformément au cadrage validé ;
- conserve l’agrégation dans `arnes doctor` pour l’issue #123.

## Useful Links

- Issue: Closes #122
- Parent: #111

## How to Test

Depuis `tooling/arnes` :

```bash
cargo fmt --check
cargo clippy --all-targets --locked -- -D warnings
cargo check --all-targets --locked
cargo test --locked
```

Depuis la racine :

```bash
git diff --check origin/main..HEAD
```

Toutes les commandes sortent avec le code `0` sur macOS. `cargo test` émet des warnings hôte existants `xcrun/confstr` liés à `DARWIN_USER_TEMP_DIR`; Clippy all-targets reste sans warning.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
