### PR TITLE
feat(arnes): aggregate doctor resource checks

### DIFF
--- a/tooling/arnes/src/doctor.rs
+++ b/tooling/arnes/src/doctor.rs
@@ -136,9 +136,15 @@ fn diagnose_default(agent: Option<Agent>, scope: Option<Scope>) -> Vec<Diagnosti
         "manifest is valid",
     )];
     let user_scope = scope.or(Some(Scope::User));
+    diagnostics.extend(config::diagnose(&roots, &manifest, agent, user_scope));
+    diagnostics.extend(instructions::diagnose(&roots, &manifest, agent, user_scope));
     diagnostics.extend(skills::diagnose(&roots, &manifest, agent, user_scope));
+    diagnostics.extend(prompts::diagnose(&roots, &manifest, agent, user_scope));
+    diagnostics.extend(commands::diagnose(&roots, &manifest, agent, user_scope));
+    diagnostics.extend(rules::diagnose(&roots, &manifest, agent, user_scope));
     diagnostics.extend(hooks::diagnose(&roots, &manifest, agent, user_scope));
     diagnostics.extend(mcp::diagnose(&roots, &manifest, agent, scope));
+    diagnostics.extend(statusline::diagnose(&roots, &manifest, agent, scope));
     diagnostics
 }
 

--- a/tooling/arnes/src/doctor/render.rs
+++ b/tooling/arnes/src/doctor/render.rs
@@ -2,11 +2,17 @@ use crate::cli::Resource;
 use arnes::diagnostic::{Diagnostic, HumanContext, HumanOptions, Report};
 use arnes::manifest::{Agent, Scope};
 
-const DEFAULT_RESOURCES: [Resource; 4] = [
+const DEFAULT_RESOURCES: [Resource; 10] = [
     Resource::Manifest,
+    Resource::Config,
+    Resource::Instructions,
     Resource::Skills,
+    Resource::Prompts,
+    Resource::Commands,
+    Resource::Rules,
     Resource::Hooks,
     Resource::Mcp,
+    Resource::Statusline,
 ];
 
 pub(super) fn human(
@@ -34,7 +40,7 @@ pub(super) fn human(
         if !output.is_empty() {
             output.push_str("\n\n");
         }
-        let section_scope = if section == Resource::Mcp {
+        let section_scope = if matches!(section, Resource::Mcp | Resource::Statusline) {
             scope
         } else {
             scope.or(Some(Scope::User))

--- a/tooling/arnes/tests/commands.rs
+++ b/tooling/arnes/tests/commands.rs
@@ -239,3 +239,28 @@ fn crlf_frontmatter_is_supported() {
     assert!(stdout.contains("healthy     deploy · current"));
     assert!(stderr.is_empty());
 }
+
+#[test]
+fn default_doctor_reuses_filtered_command_diagnostics() {
+    let fixture = configured_fixture();
+    let (_, direct, _) = run(
+        &fixture,
+        &[
+            "doctor", "commands", "--agent", "claude", "--scope", "user", "--format", "json",
+        ],
+    );
+    let (_, aggregate, _) = run(
+        &fixture,
+        &[
+            "doctor", "--agent", "claude", "--scope", "user", "--format", "json",
+        ],
+    );
+    let direct: Vec<serde_json::Value> = serde_json::from_str(&direct).unwrap();
+    let aggregate: Vec<serde_json::Value> = serde_json::from_str(&aggregate).unwrap();
+    let aggregate = aggregate
+        .into_iter()
+        .filter(|diagnostic| diagnostic["resource"] == "commands")
+        .collect::<Vec<_>>();
+
+    assert_eq!(aggregate, direct);
+}

--- a/tooling/arnes/tests/config.rs
+++ b/tooling/arnes/tests/config.rs
@@ -262,6 +262,31 @@ fn config_doctor_is_read_only() {
     assert_eq!(fixture.snapshot(), before);
 }
 
+#[test]
+fn default_doctor_reuses_filtered_config_diagnostics() {
+    let fixture = configured_fixture();
+    let (_, direct, _) = run(
+        &fixture,
+        &[
+            "doctor", "config", "--agent", "codex", "--scope", "user", "--format", "json",
+        ],
+    );
+    let (_, aggregate, _) = run(
+        &fixture,
+        &[
+            "doctor", "--agent", "codex", "--scope", "user", "--format", "json",
+        ],
+    );
+    let direct: Vec<serde_json::Value> = serde_json::from_str(&direct).unwrap();
+    let aggregate: Vec<serde_json::Value> = serde_json::from_str(&aggregate).unwrap();
+    let aggregate = aggregate
+        .into_iter()
+        .filter(|diagnostic| diagnostic["resource"] == "config")
+        .collect::<Vec<_>>();
+
+    assert_eq!(aggregate, direct);
+}
+
 fn set_mode(path: &std::path::Path, mode: u32) {
     let mut permissions = fs::metadata(path).unwrap().permissions();
     permissions.set_mode(mode);

--- a/tooling/arnes/tests/doctor_aggregate.rs
+++ b/tooling/arnes/tests/doctor_aggregate.rs
@@ -1,0 +1,151 @@
+#[path = "support/doctor_aggregate.rs"]
+mod aggregate_support;
+mod support;
+
+use aggregate_support::{ORDER, configured_fixture, set_mode};
+use serde_json::Value;
+use std::fs;
+
+fn json(output: &std::process::Output) -> Vec<Value> {
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn healthy_aggregate_is_deterministic_ordered_and_read_only() {
+    let fixture = configured_fixture();
+    let before = fixture.snapshot();
+    let human = fixture.command(["doctor", "-v"]);
+    let repeated_human = fixture.command(["doctor", "-v"]);
+    let structured = fixture.command(["doctor", "--format", "json"]);
+    let repeated_structured = fixture.command(["doctor", "--format", "json"]);
+
+    assert_eq!(
+        human.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&human.stdout)
+    );
+    assert_eq!(human.stdout, repeated_human.stdout);
+    assert_eq!(structured.status.code(), Some(0));
+    assert_eq!(structured.stdout, repeated_structured.stdout);
+    assert_eq!(fixture.snapshot(), before);
+    let human = String::from_utf8(human.stdout).unwrap();
+    let positions = [
+        "Manifest\n",
+        "\n\nConfig · user scope\n",
+        "\n\nInstructions · user scope\n",
+        "\n\nSkills · user scope · 1 agent\n",
+        "\n\nPrompts · user scope\n",
+        "\n\nCommands · user scope\n",
+        "\n\nRules · user scope\n",
+        "\n\nHooks · user scope\n",
+        "\n\nMCP\n",
+        "\n\nStatusline\n",
+    ]
+    .map(|heading| {
+        human
+            .find(heading)
+            .unwrap_or_else(|| panic!("missing {heading:?}: {human}"))
+    });
+    assert!(positions.windows(2).all(|pair| pair[0] < pair[1]));
+    let diagnostics = json(&structured);
+    for resource in ORDER {
+        assert!(
+            diagnostics.iter().any(|diagnostic| {
+                diagnostic["resource"] == resource && diagnostic["state"] == "healthy"
+            }),
+            "missing healthy {resource} diagnostic"
+        );
+    }
+    let groups = diagnostics
+        .iter()
+        .fold(Vec::new(), |mut groups, diagnostic| {
+            let resource = diagnostic["resource"].as_str().unwrap();
+            if groups.last() != Some(&resource) {
+                groups.push(resource);
+            }
+            groups
+        });
+    assert_eq!(groups, ORDER);
+}
+
+#[test]
+fn filtered_aggregate_reuses_each_direct_resource_diagnostic() {
+    let fixture = configured_fixture();
+
+    for resource in ORDER {
+        let (agent, scope) = match resource {
+            "mcp" => ("claude", "project"),
+            "statusline" => ("codex", "project"),
+            _ => ("claude", "user"),
+        };
+        let aggregate = fixture.command([
+            "doctor", "--agent", agent, "--scope", scope, "--format", "json",
+        ]);
+        let aggregate = json(&aggregate);
+        let direct = fixture.command([
+            "doctor", resource, "--agent", agent, "--scope", scope, "--format", "json",
+        ]);
+        let expected = json(&direct);
+        let actual = aggregate
+            .iter()
+            .filter(|diagnostic| diagnostic["resource"] == resource)
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected, "{resource}");
+    }
+}
+
+#[test]
+fn aggregate_surfaces_every_drift_without_mutation() {
+    let fixture = configured_fixture();
+    fs::remove_file(fixture.home().join(".claude/settings.json")).unwrap();
+    fs::remove_file(fixture.home().join(".claude/CLAUDE.md")).unwrap();
+    fs::remove_file(fixture.home().join(".claude/skills/alpha")).unwrap();
+    fixture.write_home(".claude/commands/deploy.md", "stale\n");
+    fs::remove_file(fixture.home().join(".claude/rules/aggregate.md")).unwrap();
+    fixture.write_repository(
+        ".mcp.json",
+        r#"{"mcpServers":{"managed":{"command":"other"}}}"#,
+    );
+    fixture.write_repository(
+        ".codex/config.toml",
+        "[tui]\nstatus_line = [\"current-dir\", \"model\"]\n",
+    );
+    let before = fixture.snapshot();
+
+    let output = fixture.command(["doctor", "--format", "json"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(fixture.snapshot(), before);
+    let drifted = json(&output)
+        .into_iter()
+        .filter(|diagnostic| diagnostic["state"] == "drift")
+        .map(|diagnostic| diagnostic["resource"].as_str().unwrap().to_owned())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        drifted,
+        ORDER[1..]
+            .iter()
+            .map(|resource| (*resource).to_owned())
+            .collect()
+    );
+}
+
+#[test]
+fn operational_error_does_not_suppress_later_resources() {
+    let fixture = configured_fixture();
+    set_mode(&fixture.repository().join("harness/AGENTS.md"), 0o000);
+
+    let output = fixture.command(["doctor", "--format", "json"]);
+
+    set_mode(&fixture.repository().join("harness/AGENTS.md"), 0o600);
+    assert_eq!(output.status.code(), Some(2));
+    let diagnostics = json(&output);
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["resource"] == "instructions" && diagnostic["state"] == "error"
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["resource"] == "statusline" && diagnostic["state"] == "healthy"
+    }));
+}

--- a/tooling/arnes/tests/instructions.rs
+++ b/tooling/arnes/tests/instructions.rs
@@ -136,12 +136,34 @@ fn instructions_doctor_is_read_only() {
 }
 
 #[test]
-fn doctor_without_resource_does_not_aggregate_instructions() {
+fn default_doctor_reuses_filtered_instruction_diagnostics() {
     let fixture = configured_fixture();
     fs::remove_file(fixture.home().join(".codex/AGENTS.md")).unwrap();
-    let (code, stdout, _) = run(&fixture, &["doctor"]);
+    let (_, direct, _) = run(
+        &fixture,
+        &[
+            "doctor",
+            "instructions",
+            "--agent",
+            "codex",
+            "--scope",
+            "user",
+            "--format",
+            "json",
+        ],
+    );
+    let (_, aggregate, _) = run(
+        &fixture,
+        &[
+            "doctor", "--agent", "codex", "--scope", "user", "--format", "json",
+        ],
+    );
+    let direct: Vec<serde_json::Value> = serde_json::from_str(&direct).unwrap();
+    let aggregate: Vec<serde_json::Value> = serde_json::from_str(&aggregate).unwrap();
+    let aggregate = aggregate
+        .into_iter()
+        .filter(|diagnostic| diagnostic["resource"] == "instructions")
+        .collect::<Vec<_>>();
 
-    assert_eq!(code, 0);
-    assert!(stdout.contains("Skills · user scope"));
-    assert!(!stdout.contains("Instructions"));
+    assert_eq!(aggregate, direct);
 }

--- a/tooling/arnes/tests/mcp.rs
+++ b/tooling/arnes/tests/mcp.rs
@@ -94,7 +94,7 @@ fn default_doctor_checks_project_mcp_without_changing_other_scope_defaults() {
     let output = fixture.command(["doctor", "-v"]);
     let stdout = stdout(&output);
 
-    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(output.status.code(), Some(1));
     assert!(stdout.contains("MCP"));
     assert!(stdout.contains("healthy mcp: claude project managed"));
     assert!(stdout.contains("Skills · user scope"));

--- a/tooling/arnes/tests/prompts.rs
+++ b/tooling/arnes/tests/prompts.rs
@@ -195,14 +195,27 @@ fn unmanaged_and_plugin_owned_commands_are_ignored_and_preserved() {
 }
 
 #[test]
-fn doctor_without_resource_does_not_aggregate_prompts() {
+fn default_doctor_reuses_filtered_prompt_diagnostics() {
     let fixture = configured_fixture();
     fixture.write_home(".claude/commands/deploy.md", "stale\n");
+    let (_, direct, _) = run(
+        &fixture,
+        &[
+            "doctor", "prompts", "--agent", "claude", "--scope", "user", "--format", "json",
+        ],
+    );
+    let (_, aggregate, _) = run(
+        &fixture,
+        &[
+            "doctor", "--agent", "claude", "--scope", "user", "--format", "json",
+        ],
+    );
+    let direct: Vec<Value> = serde_json::from_str(&direct).unwrap();
+    let aggregate: Vec<Value> = serde_json::from_str(&aggregate).unwrap();
+    let aggregate = aggregate
+        .into_iter()
+        .filter(|diagnostic| diagnostic["resource"] == "prompts")
+        .collect::<Vec<_>>();
 
-    let (code, stdout, stderr) = run(&fixture, &["doctor"]);
-
-    assert_eq!(code, 0);
-    assert!(stdout.contains("Skills · user scope"));
-    assert!(!stdout.contains("Prompts"));
-    assert!(stderr.is_empty());
+    assert_eq!(aggregate, direct);
 }

--- a/tooling/arnes/tests/rules.rs
+++ b/tooling/arnes/tests/rules.rs
@@ -129,3 +129,28 @@ fn rules_doctor_is_read_only() {
     assert_eq!(code, 0);
     assert_eq!(fixture.snapshot(), before);
 }
+
+#[test]
+fn default_doctor_reuses_filtered_rule_diagnostics() {
+    let fixture = configured_fixture();
+    let (_, direct, _) = run(
+        &fixture,
+        &[
+            "doctor", "rules", "--agent", "claude", "--scope", "user", "--format", "json",
+        ],
+    );
+    let (_, aggregate, _) = run(
+        &fixture,
+        &[
+            "doctor", "--agent", "claude", "--scope", "user", "--format", "json",
+        ],
+    );
+    let direct: Vec<serde_json::Value> = serde_json::from_str(&direct).unwrap();
+    let aggregate: Vec<serde_json::Value> = serde_json::from_str(&aggregate).unwrap();
+    let aggregate = aggregate
+        .into_iter()
+        .filter(|diagnostic| diagnostic["resource"] == "rules")
+        .collect::<Vec<_>>();
+
+    assert_eq!(aggregate, direct);
+}

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -96,13 +96,24 @@ fn skills_doctor_is_isolated_and_read_only() {
 }
 
 #[test]
-fn doctor_without_resource_reports_manifest_then_skills() {
+fn doctor_without_resource_reports_resources_in_canonical_order() {
     let fixture = configured_fixture();
     let (code, stdout, _) = run(&fixture, &["doctor"]);
 
-    assert_eq!(code, 0);
+    assert_eq!(code, 1);
+    let positions = [
+        "Manifest",
+        "Config · user scope",
+        "Instructions · user scope",
+        "Skills · user scope",
+        "Prompts · user scope",
+        "Commands · user scope",
+        "Rules · user scope",
+        "Hooks · user scope",
+    ]
+    .map(|heading| stdout.find(heading).unwrap());
     assert!(
-        stdout.starts_with("Manifest\n✓ 1 healthy\n\nSkills · user scope · 3 agents\n"),
+        positions.windows(2).all(|pair| pair[0] < pair[1]),
         "{stdout}"
     );
 }
@@ -115,31 +126,43 @@ fn doctor_without_resource_fails_when_skills_drift() {
     let (code, stdout, _) = run(&fixture, &["doctor"]);
 
     assert_eq!(code, 1, "{stdout}");
-    assert!(stdout.starts_with("Manifest\n✓ 1 healthy\n\nSkills · user scope"));
+    assert!(stdout.starts_with("Manifest\n✓ 1 healthy"));
+    assert!(stdout.contains("Skills · user scope"));
     assert!(stdout.contains("DRIFT alpha"));
 }
 
 #[test]
-fn json_doctor_without_resource_includes_manifest_skills_and_hooks() {
+fn json_doctor_without_resource_preserves_canonical_resource_order() {
     let fixture = configured_fixture();
     let (code, stdout, _) = run(&fixture, &["doctor", "--format", "json"]);
     let diagnostics: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     let diagnostics = diagnostics.as_array().unwrap();
 
-    assert_eq!(code, 0, "{stdout}");
-    assert_eq!(diagnostics[0]["resource"], "manifest");
+    assert_eq!(code, 1, "{stdout}");
     let resources = diagnostics
         .iter()
-        .skip(1)
         .map(|diagnostic| diagnostic["resource"].as_str().unwrap())
         .collect::<Vec<_>>();
-    assert!(resources.contains(&"skills"), "{stdout}");
-    assert!(resources.contains(&"hooks"), "{stdout}");
-    assert!(
-        resources
-            .iter()
-            .all(|resource| matches!(*resource, "skills" | "hooks")),
-        "{stdout}"
+    let resource_groups = resources
+        .into_iter()
+        .fold(Vec::new(), |mut groups, resource| {
+            if groups.last() != Some(&resource) {
+                groups.push(resource);
+            }
+            groups
+        });
+    assert_eq!(
+        resource_groups,
+        [
+            "manifest",
+            "config",
+            "instructions",
+            "skills",
+            "prompts",
+            "commands",
+            "rules",
+            "hooks",
+        ]
     );
 }
 

--- a/tooling/arnes/tests/statusline.rs
+++ b/tooling/arnes/tests/statusline.rs
@@ -211,3 +211,31 @@ fn configuration_symlink_cannot_escape_scope_root() {
     assert!(stdout(&output).contains("escapes its scope root"));
     assert!(!stdout(&output).contains("outside"));
 }
+
+#[test]
+fn default_doctor_reuses_filtered_statusline_diagnostics() {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", &manifest("user", "model"));
+    fixture.write_home(".codex/config.toml", "[tui]\nstatus_line = [\"model\"]\n");
+    let direct = fixture.command([
+        "doctor",
+        "statusline",
+        "--agent",
+        "codex",
+        "--scope",
+        "user",
+        "--format",
+        "json",
+    ]);
+    let aggregate = fixture.command([
+        "doctor", "--agent", "codex", "--scope", "user", "--format", "json",
+    ]);
+    let direct: Vec<serde_json::Value> = serde_json::from_str(&stdout(&direct)).unwrap();
+    let aggregate: Vec<serde_json::Value> = serde_json::from_str(&stdout(&aggregate)).unwrap();
+    let aggregate = aggregate
+        .into_iter()
+        .filter(|diagnostic| diagnostic["resource"] == "statusline")
+        .collect::<Vec<_>>();
+
+    assert_eq!(aggregate, direct);
+}

--- a/tooling/arnes/tests/support/doctor_aggregate.rs
+++ b/tooling/arnes/tests/support/doctor_aggregate.rs
@@ -1,0 +1,121 @@
+use crate::support::Fixture;
+use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
+
+const MANIFEST: &str = "version: 1
+agents:
+  - id: claude
+    scopes: [user, project]
+  - id: codex
+    scopes: [project]
+skills:
+  - slug: alpha
+    installations:
+      - { agent: claude, scope: user }
+prompts:
+  - id: deploy
+    source: { root: repository, path: harness/prompts/deploy.md }
+    includes: []
+    variables: []
+    projections:
+      - agent: claude
+        scope: user
+        representation: rendered
+        destination: { root: home, path: .claude/commands/deploy.md }
+commands:
+  - name: deploy
+    description: Deploy safely
+    prompt: deploy
+    bindings:
+      - { agent: claude, scope: user }
+hooks:
+  - id: handoff
+    installations:
+      - { agent: claude, scope: user }
+mcp:
+  - { name: managed, agent: claude, scope: project, command: bin/mcp }
+statuslines:
+  - { agent: codex, scope: project, items: [model, current-dir] }
+resources:
+  - id: claude-user-instructions
+    kind: instructions
+    agent: claude
+    scope: user
+    source: { root: repository, path: harness/AGENTS.md }
+    destination: { root: home, path: .claude/CLAUDE.md }
+  - id: claude-user-skills
+    kind: skills
+    agent: claude
+    scope: user
+    layout: leaves
+    source: { root: repository, path: harness/skills }
+    destination: { root: home, path: .claude/skills }
+  - id: aggregate-rule
+    kind: rules
+    agent: claude
+    scope: user
+    source: { root: repository, path: harness/rules/aggregate.md }
+    destination: { root: home, path: .claude/rules/aggregate.md }
+";
+
+const COMMAND: &str = "---\ndescription: Deploy safely\n---\nDeploy now\n";
+pub const ORDER: [&str; 10] = [
+    "manifest",
+    "config",
+    "instructions",
+    "skills",
+    "prompts",
+    "commands",
+    "rules",
+    "hooks",
+    "mcp",
+    "statusline",
+];
+
+pub fn configured_fixture() -> Fixture {
+    let fixture = Fixture::new();
+    fixture.write_home(".arnes.yaml", MANIFEST);
+    fixture.write_repository("harness/AGENTS.md", "agent instructions\n");
+    fixture.write_repository("harness/skills/alpha/SKILL.md", "# Alpha\n");
+    fixture.write_repository("harness/prompts/deploy.md", COMMAND);
+    fixture.write_repository("harness/rules/aggregate.md", "rule\n");
+    fixture.write_home(".claude/commands/deploy.md", COMMAND);
+    link_home(&fixture, "harness/AGENTS.md", ".claude/CLAUDE.md");
+    link_home(&fixture, "harness/skills/alpha", ".claude/skills/alpha");
+    link_home(
+        &fixture,
+        "harness/rules/aggregate.md",
+        ".claude/rules/aggregate.md",
+    );
+    fixture.write_repository("bin/mcp", "#!/bin/sh\nexit 99\n");
+    set_mode(&fixture.repository().join("bin/mcp"), 0o700);
+    fixture.write_repository(
+        ".mcp.json",
+        r#"{"mcpServers":{"managed":{"command":"bin/mcp"}}}"#,
+    );
+    fixture.write_repository(
+        ".codex/config.toml",
+        "[tui]\nstatus_line = [\"model\", \"current-dir\"]\n",
+    );
+    fixture.write_home(".local/bin/agent-handoff", "binary\n");
+    set_mode(&fixture.home().join(".local/bin/agent-handoff"), 0o700);
+    let setup = fixture.command(["setup", "hooks", "--agent", "claude"]);
+    assert_eq!(setup.status.code(), Some(0));
+    fixture
+}
+
+fn link_home(fixture: &Fixture, source: &str, destination: &str) {
+    let destination = fixture.home().join(destination);
+    fs::create_dir_all(destination.parent().unwrap()).unwrap();
+    symlink(
+        fs::canonicalize(fixture.repository().join(source)).unwrap(),
+        destination,
+    )
+    .unwrap();
+}
+
+pub fn set_mode(path: &std::path::Path, mode: u32) {
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(mode);
+    fs::set_permissions(path, permissions).unwrap();
+}


### PR DESCRIPTION
## Description

- Aggregate all ten Doctor resource families in the documented stable order.
- Reuse each direct resource diagnostic while preserving agent and scope filters.
- Cover deterministic human and JSON output, exit status precedence, independent drift and error reporting, and read-only execution with an isolated fixture.

## Useful Links

- Closes #123

## How to Test

```sh
cargo fmt --manifest-path tooling/arnes/Cargo.toml --check
cargo clippy --manifest-path tooling/arnes/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path tooling/arnes/Cargo.toml
```

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
