### PR TITLE
Install Semctx through the Moon harness

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,5 +1,6 @@
 projects:
   repository: .
+  harness: harness
   tooling/agent-handoff: tooling/agent-handoff
   tooling/arnes: tooling/arnes
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "oxlint": "1.80.0",
         "oxlint-tsgolint": "7.0.2001",
         "prettier": "3.9.6",
-        "semctx": "0.1.17",
+        "semctx": "0.1.18",
         "typescript": "7.0.2",
       },
     },
@@ -161,7 +161,7 @@
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
-    "semctx": ["semctx@0.1.17", "", { "bin": { "semctx": "dist/index.js" } }, "sha512-8W6Le+OHNR3C16Yju5EIx9UGmeYuT0yO1QtxtvZjWHAk7CkX9Rdb2KcMP5k0YNvmAtXxmqJ2vXdG4sSBo0GNug=="],
+    "semctx": ["semctx@0.1.18", "", { "bin": { "semctx": "dist/index.js" } }, "sha512-3XDQP6xZdbN6brVm8j66/43pAwpm8SmsxS/44Xsn8LG05AQcaRCTDBMVqlDW7cHGwUE5jqEdGWnQQ2TZfc1Pxg=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "oxlint": "1.80.0",
         "oxlint-tsgolint": "7.0.2001",
         "prettier": "3.9.6",
+        "semctx": "0.1.17",
         "typescript": "7.0.2",
       },
     },
@@ -159,6 +160,8 @@
     "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "semctx": ["semctx@0.1.17", "", { "bin": { "semctx": "dist/index.js" } }, "sha512-8W6Le+OHNR3C16Yju5EIx9UGmeYuT0yO1QtxtvZjWHAk7CkX9Rdb2KcMP5k0YNvmAtXxmqJ2vXdG4sSBo0GNug=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 

--- a/docs/superpowers/plans/2026-09-01-semctx-moon-harness.md
+++ b/docs/superpowers/plans/2026-09-01-semctx-moon-harness.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Le projet Bun racine verrouille le CLI `semctx` ; un projet Moon dédié sous `harness/` expose l'installation machine, l'initialisation de dépôt et le diagnostic comme trois effets distincts. Arnes autorise et observe les plugins et skills externes installés, sans devenir leur installateur.
 
-**Tech Stack:** Bun 1.4.0, semctx 0.1.17, Moon 2.5.3, YAML, Arnes/Rust
+**Tech Stack:** Bun 1.4.0, semctx 0.1.18, Moon 2.5.3, YAML, Arnes/Rust
 
 **Spec:** `docs/superpowers/specs/2026-09-01-semctx-moon-harness-design.md`
 
@@ -41,7 +41,7 @@
 **Interfaces:**
 
 - Consumes: la toolchain Bun 1.4.0 définie par `packageManager` et `.moon/toolchains.yml`.
-- Produces: le binaire local `semctx` en version exacte `0.1.17`, résolu par `bun run semctx`.
+- Produces: le binaire local `semctx` en version exacte `0.1.18`, résolu par `bun run semctx`.
 
 - [ ] **Step 1: Établir l'absence initiale du binaire projet**
 
@@ -65,7 +65,7 @@ Dans `package.json`, ajouter `semctx` aux `devDependencies` en conservant l'ordr
     "oxlint": "1.80.0",
     "oxlint-tsgolint": "7.0.2001",
     "prettier": "3.9.6",
-    "semctx": "0.1.17",
+    "semctx": "0.1.18",
     "typescript": "7.0.2"
   }
 }
@@ -79,7 +79,7 @@ Run:
 bun install --ignore-scripts --config=/dev/null --no-env-file
 ```
 
-Expected: `bun.lock` contient la résolution de `semctx@0.1.17`; aucun script de paquet n'est exécuté.
+Expected: `bun.lock` contient la résolution de `semctx@0.1.18`; aucun script de paquet n'est exécuté.
 
 - [ ] **Step 4: Vérifier la résolution et le gel**
 
@@ -91,7 +91,7 @@ bun install --frozen-lockfile --ignore-scripts --config=/dev/null --no-env-file
 bun run prettier --check package.json
 ```
 
-Expected: la première commande affiche `0.1.17`; l'installation gelée et Prettier réussissent.
+Expected: la première commande affiche `0.1.18`; l'installation gelée et Prettier réussissent.
 
 - [ ] **Step 5: Committer la toolchain verrouillée**
 
@@ -167,7 +167,7 @@ tasks:
       outputStyle: stream
   semctx-status:
     description: Inspect local Semctx plugin delivery without network attestation
-    command: bun run semctx install --host auto --skip-setup --dry-run --json
+    command: bun run semctx plugin-status --host auto --json
 ```
 
 Le mutex commun empêche l'installation machine et l'initialisation du dépôt de muter simultanément des états Semctx ; le diagnostic reste indépendant et en lecture seule.
@@ -377,7 +377,7 @@ Après intégration des commits dans le checkout canonique :
 2. Présenter les identifiants et sources exacts de la marketplace locale à retirer, puis demander une autorisation explicite.
 3. Après autorisation, retirer uniquement le plugin et la marketplace Semctx locaux observés ; ne jamais coder ces commandes dans Moon.
 4. Exécuter `moon run harness:install` depuis le checkout canonique.
-5. Exiger `ok: true` et, pour chaque hôte détecté, un plugin installé, activé et à la version `0.1.17` avant de déclarer l'installation convergée.
+5. Exiger `ok: true` et, pour chaque hôte détecté, un plugin installé, activé et à la version `0.1.18` avant de déclarer l'installation convergée.
 6. Ouvrir une nouvelle tâche Codex ou recharger les plugins Claude Code selon les actions retournées par Semctx.
 7. Exécuter `moon run harness:semctx-status`; rapporter séparément delivery, activation de session et toute preuve absente.
 8. Exécuter `moon run harness:semctx-setup` seulement sur demande explicite d'initialiser le dépôt courant, puis vérifier séparément binding, freshness, coverage et diagnostics workspace.

--- a/docs/superpowers/plans/2026-09-01-semctx-moon-harness.md
+++ b/docs/superpowers/plans/2026-09-01-semctx-moon-harness.md
@@ -1,0 +1,383 @@
+# Semctx Moon Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Installer durablement les plugins Semctx détectés au moyen de Bun et de tâches Moon sous le namespace `harness:*`, sans modifier les profils Make.
+
+**Architecture:** Le projet Bun racine verrouille le CLI `semctx` ; un projet Moon dédié sous `harness/` expose l'installation machine, l'initialisation de dépôt et le diagnostic comme trois effets distincts. Arnes autorise et observe les plugins et skills externes installés, sans devenir leur installateur.
+
+**Tech Stack:** Bun 1.4.0, semctx 0.1.17, Moon 2.5.3, YAML, Arnes/Rust
+
+**Spec:** `docs/superpowers/specs/2026-09-01-semctx-moon-harness-design.md`
+
+## Global Constraints
+
+- Ne modifier ni `make minimal`, ni `make optional`, ni leurs dépendances.
+- `package.json` est l'unique source de version Semctx ; `bun.lock` verrouille sa résolution exacte.
+- Les tâches qui lisent ou modifient l'état du poste désactivent le cache Moon et ne s'exécutent pas dans `moon ci`.
+- `harness:install` installe le plugin mais n'initialise jamais `.semctx/`.
+- `harness:semctx-setup` reste une action volontaire séparée et utilise la configuration v2 `--polyglot` pour un dépôt neuf.
+- Aucun chemin utilisateur, secret ou retrait de marketplace n'entre dans les fichiers versionnés.
+- Le worktree vérifie la configuration sans installer, retirer ou mettre à jour un plugin réel.
+- L'installation réelle et la migration du canal local s'exécutent seulement depuis le checkout canonique après intégration.
+
+---
+
+## File Structure
+
+- Modify: `package.json` — déclare la version exacte du CLI Semctx utilisée par Moon.
+- Modify: `bun.lock` — verrouille l'artefact npm et ses dépendances.
+- Modify: `.moon/workspace.yml` — enregistre le projet Moon `harness`.
+- Create: `harness/moon.yml` — possède exclusivement les tâches `harness:*` et leurs contrats d'effets.
+- Modify: `home/.arnes.yaml` — autorise l'inventaire externe Semctx pour Claude Code et Codex.
+
+### Task 1: Verrouiller le CLI Semctx avec Bun
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `bun.lock`
+
+**Interfaces:**
+
+- Consumes: la toolchain Bun 1.4.0 définie par `packageManager` et `.moon/toolchains.yml`.
+- Produces: le binaire local `semctx` en version exacte `0.1.17`, résolu par `bun run semctx`.
+
+- [ ] **Step 1: Établir l'absence initiale du binaire projet**
+
+Run:
+
+```bash
+bun run semctx --version
+```
+
+Expected: FAIL avec `Could not locate executable semctx` ou un diagnostic équivalent ; un binaire global éventuel ne satisfait pas ce contrôle.
+
+- [ ] **Step 2: Déclarer la dépendance exacte**
+
+Dans `package.json`, ajouter `semctx` aux `devDependencies` en conservant l'ordre alphabétique :
+
+```json
+{
+  "devDependencies": {
+    "@types/bun": "1.4.0",
+    "oxfmt": "0.64.0",
+    "oxlint": "1.80.0",
+    "oxlint-tsgolint": "7.0.2001",
+    "prettier": "3.9.6",
+    "semctx": "0.1.17",
+    "typescript": "7.0.2"
+  }
+}
+```
+
+- [ ] **Step 3: Régénérer mécaniquement le lockfile**
+
+Run:
+
+```bash
+bun install --ignore-scripts --config=/dev/null --no-env-file
+```
+
+Expected: `bun.lock` contient la résolution de `semctx@0.1.17`; aucun script de paquet n'est exécuté.
+
+- [ ] **Step 4: Vérifier la résolution et le gel**
+
+Run:
+
+```bash
+bun run semctx --version
+bun install --frozen-lockfile --ignore-scripts --config=/dev/null --no-env-file
+bun run prettier --check package.json
+```
+
+Expected: la première commande affiche `0.1.17`; l'installation gelée et Prettier réussissent.
+
+- [ ] **Step 5: Committer la toolchain verrouillée**
+
+```bash
+git add package.json bun.lock
+git commit -m "build(harness): pin semctx CLI"
+```
+
+### Task 2: Ajouter le projet et les tâches Moon du harnais
+
+**Files:**
+
+- Modify: `.moon/workspace.yml`
+- Create: `harness/moon.yml`
+
+**Interfaces:**
+
+- Consumes: `bun run semctx` produit par Task 1 et le projet racine Moon existant.
+- Produces: `harness:install`, `harness:semctx-install`, `harness:semctx-setup` et `harness:semctx-status`.
+
+- [ ] **Step 1: Prouver que le namespace n'existe pas encore**
+
+Run:
+
+```bash
+moon project harness --json
+```
+
+Expected: FAIL avec un projet `harness` inconnu.
+
+- [ ] **Step 2: Enregistrer le projet dans le workspace**
+
+Dans `.moon/workspace.yml`, ajouter l'entrée suivante à `projects`, entre `repository` et les projets `tooling/*` :
+
+```yaml
+projects:
+  repository: .
+  harness: harness
+  tooling/agent-handoff: tooling/agent-handoff
+  tooling/arnes: tooling/arnes
+```
+
+- [ ] **Step 3: Créer les quatre tâches avec leurs frontières d'effets**
+
+Créer `harness/moon.yml` avec ce contenu :
+
+```yaml
+language: typescript
+layer: configuration
+
+taskOptions:
+  cache: false
+  runFromWorkspaceRoot: true
+  runInCI: false
+
+tasks:
+  install:
+    description: Install every declared harness capability
+    command: noop
+    deps:
+      - ~:semctx-install
+  semctx-install:
+    description: Install or update Semctx plugins for detected agent hosts
+    command: bun run semctx install --host auto --skip-setup --json
+    options:
+      mutex: harness-mutation
+      outputStyle: stream
+  semctx-setup:
+    description: Initialize Semctx in the current Git repository
+    command: bun run semctx setup --polyglot --json
+    options:
+      mutex: harness-mutation
+      outputStyle: stream
+  semctx-status:
+    description: Inspect local Semctx plugin delivery without network attestation
+    command: bun run semctx plugin-status --host auto --json
+```
+
+Le mutex commun empêche l'installation machine et l'initialisation du dépôt de muter simultanément des états Semctx ; le diagnostic reste indépendant et en lecture seule.
+
+- [ ] **Step 4: Vérifier le schéma, les options et le graphe sans exécuter les tâches**
+
+Run:
+
+```bash
+moon project harness --json
+moon task harness:install --json
+moon task harness:semctx-install --json
+moon task harness:semctx-setup --json
+moon task harness:semctx-status --json
+moon task-graph harness:install --json
+```
+
+Expected:
+
+- les six commandes réussissent ;
+- les quatre tâches ont `cache: false`, `runInCI: false` et le workspace root comme répertoire d'exécution ;
+- `harness:install` dépend uniquement de `harness:semctx-install` ;
+- seules les deux tâches mutantes portent le mutex `harness-mutation`.
+
+- [ ] **Step 5: Vérifier le format YAML**
+
+Run:
+
+```bash
+bun run prettier --check .moon/workspace.yml harness/moon.yml
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Committer le namespace Moon**
+
+```bash
+git add .moon/workspace.yml harness/moon.yml
+git commit -m "feat(harness): add Semctx Moon tasks"
+```
+
+### Task 3: Déclarer Semctx dans la politique externe Arnes
+
+**Files:**
+
+- Modify: `home/.arnes.yaml`
+- Test: `tooling/arnes/tests/manifest.rs`
+
+**Interfaces:**
+
+- Consumes: les identifiants publiés `semctx@semctx-stable` pour Claude Code et `semctx-control@semctx-stable` pour Codex.
+- Produces: une politique Arnes qui autorise explicitement chaque plugin et chaque skill exposé, sans en exiger la présence.
+
+- [ ] **Step 1: Établir que le manifeste courant reste valide avant modification**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --locked --test manifest repository_manifest_is_valid -- --exact
+```
+
+Expected: PASS ; ce test exerce le vrai parseur sur `home/.arnes.yaml`.
+
+- [ ] **Step 2: Autoriser les deux plugins externes**
+
+Dans `home/.arnes.yaml`, ajouter à `external.plugins` :
+
+```yaml
+- { agent: claude, scope: user, id: semctx@semctx-stable }
+- { agent: codex, scope: user, id: semctx-control@semctx-stable }
+```
+
+Conserver les entrées regroupées par agent, puis par identifiant.
+
+- [ ] **Step 3: Autoriser chaque skill publiée par ces plugins**
+
+Dans `external.skills`, ajouter exactement :
+
+```yaml
+- {
+    agent: claude,
+    scope: user,
+    origin: plugin,
+    plugin: semctx@semctx-stable,
+    slug: semctx-control,
+  }
+- {
+    agent: claude,
+    scope: user,
+    origin: plugin,
+    plugin: semctx@semctx-stable,
+    slug: semctx-semantic,
+  }
+- {
+    agent: claude,
+    scope: user,
+    origin: plugin,
+    plugin: semctx@semctx-stable,
+    slug: semctx-verify,
+  }
+- {
+    agent: codex,
+    scope: user,
+    origin: plugin,
+    plugin: semctx-control@semctx-stable,
+    slug: semctx-control,
+  }
+```
+
+Ces autorisations ne rendent pas les plugins obligatoires et n'adoptent pas leurs fichiers dans `harness/skills/`.
+
+- [ ] **Step 4: Vérifier le manifeste et les gates Arnes affectées**
+
+Run:
+
+```bash
+cargo test --manifest-path tooling/arnes/Cargo.toml --locked --test manifest repository_manifest_is_valid -- --exact
+moon run tooling/arnes:fmt tooling/arnes:clippy tooling/arnes:test
+bun run prettier --check home/.arnes.yaml
+```
+
+Expected: tous les contrôles passent sur macOS ; aucun diagnostic de duplication plugin/skill n'apparaît.
+
+- [ ] **Step 5: Committer la politique d'observation**
+
+```bash
+git add home/.arnes.yaml
+git commit -m "chore(arnes): allow Semctx plugins"
+```
+
+### Task 4: Vérifier la tranche sans muter le poste
+
+**Files:**
+
+- Verify: `package.json`
+- Verify: `bun.lock`
+- Verify: `.moon/workspace.yml`
+- Verify: `harness/moon.yml`
+- Verify: `home/.arnes.yaml`
+
+**Interfaces:**
+
+- Consumes: les livrables des Tasks 1 à 3.
+- Produces: les preuves locales de résolution, formatage, typage et graphe ; aucune preuve d'installation effective sur le poste.
+
+- [ ] **Step 1: Vérifier le diff et les fichiers manuscrits**
+
+Run:
+
+```bash
+git diff --check HEAD~3..HEAD
+bun run prettier --check package.json .moon/workspace.yml harness/moon.yml home/.arnes.yaml
+```
+
+Expected: PASS ; `harness/moon.yml` reste largement sous le seuil de 250 lignes et ne contient aucun commentaire.
+
+- [ ] **Step 2: Exécuter les gates racine affectées par le manifeste Bun et Moon**
+
+Run:
+
+```bash
+moon run repository:typescript-lint repository:typescript-typecheck repository:typescript-format-check repository:prettier-check
+bun test
+```
+
+Expected: PASS sur macOS avec Moon 2.5.3 et Bun 1.4.0.
+
+- [ ] **Step 3: Réinspecter le projet et son graphe final**
+
+Run:
+
+```bash
+moon project harness --json
+moon task-graph harness:install --json
+```
+
+Expected: le projet expose exactement les quatre tâches prévues et l'agrégateur ne contient que l'arête vers `harness:semctx-install`.
+
+- [ ] **Step 4: Prévisualiser l'installateur Semctx directement**
+
+Run:
+
+```bash
+bun run semctx install --host auto --skip-setup --dry-run --json
+```
+
+Expected sur le poste actuel: FAIL fermé signalant que `semctx-stable` pointe vers une source locale non publique. Conserver le code de sortie et le reason code exacts ; ce refus prouve la protection contre l'écrasement, pas la convergence du poste.
+
+- [ ] **Step 5: Documenter la limite de preuve dans la livraison**
+
+La livraison doit distinguer :
+
+```text
+Repository configuration: verified in the Codex worktree on macOS
+Plugin installation: not run from the worktree
+Local marketplace migration: pending explicit authorization in the canonical checkout
+Repository setup: not run; harness:semctx-setup remains explicit
+```
+
+Ne pas déclarer Semctx installé ou actif tant que le chemin opérateur ci-dessous n'a pas produit son propre rapport vert.
+
+## Canonical-checkout Operator Handoff
+
+Après intégration des commits dans le checkout canonique :
+
+1. Inspecter `codex plugin marketplace list --json`, `codex plugin list --json` et l'inventaire Claude Code sans mutation.
+2. Présenter les identifiants et sources exacts de la marketplace locale à retirer, puis demander une autorisation explicite.
+3. Après autorisation, retirer uniquement le plugin et la marketplace Semctx locaux observés ; ne jamais coder ces commandes dans Moon.
+4. Exécuter `moon run harness:install` depuis le checkout canonique.
+5. Exiger `ok: true` et, pour chaque hôte détecté, un plugin installé, activé et à la version `0.1.17` avant de déclarer l'installation convergée.
+6. Ouvrir une nouvelle tâche Codex ou recharger les plugins Claude Code selon les actions retournées par Semctx.
+7. Exécuter `moon run harness:semctx-status`; rapporter séparément delivery, activation de session et toute preuve absente.
+8. Exécuter `moon run harness:semctx-setup` seulement sur demande explicite d'initialiser le dépôt courant, puis vérifier séparément binding, freshness, coverage et diagnostics workspace.

--- a/docs/superpowers/plans/2026-09-01-semctx-moon-harness.md
+++ b/docs/superpowers/plans/2026-09-01-semctx-moon-harness.md
@@ -318,7 +318,7 @@ git commit -m "chore(arnes): allow Semctx plugins"
 Run:
 
 ```bash
-git diff --check HEAD~3..HEAD
+git diff --check 540653025faf1cdb98f9bc136acb5e2cbe88c26e..HEAD
 bun run prettier --check package.json .moon/workspace.yml harness/moon.yml home/.arnes.yaml
 ```
 

--- a/docs/superpowers/plans/2026-09-01-semctx-moon-harness.md
+++ b/docs/superpowers/plans/2026-09-01-semctx-moon-harness.md
@@ -167,7 +167,7 @@ tasks:
       outputStyle: stream
   semctx-status:
     description: Inspect local Semctx plugin delivery without network attestation
-    command: bun run semctx plugin-status --host auto --json
+    command: bun run semctx install --host auto --skip-setup --dry-run --json
 ```
 
 Le mutex commun empêche l'installation machine et l'initialisation du dépôt de muter simultanément des états Semctx ; le diagnostic reste indépendant et en lecture seule.

--- a/docs/superpowers/specs/2026-09-01-semctx-moon-harness-design.md
+++ b/docs/superpowers/specs/2026-09-01-semctx-moon-harness-design.md
@@ -55,9 +55,9 @@ preuve négative.
 ### `harness:semctx-status`
 
 Exécute le diagnostic local de livraison des plugins en JSON. Il ne modifie rien et n'effectue pas
-d'attestation réseau implicite. Elle utilise `bun run semctx install --host auto --skip-setup
---dry-run --json` pour produire ce rapport en lecture seule. La tâche reste non cachée, car son
-résultat dépend de l'état du poste hors du graphe Moon.
+d'attestation réseau implicite. Elle utilise `bun run semctx plugin-status --host auto --json` pour
+produire ce rapport en lecture seule. La tâche reste non cachée, car son résultat dépend de l'état
+du poste hors du graphe Moon.
 
 ## Migration du canal local
 
@@ -89,8 +89,9 @@ La modification est vérifiée sans installer réellement de plugin depuis le wo
 2. résolution du projet et des quatre tâches par Moon ;
 3. inspection du graphe de dépendances de `harness:install` ;
 4. `semctx install --host auto --skip-setup --dry-run --json` ;
-5. Arnes Doctor sur les plugins, skills et MCP déclarés ;
-6. formatage YAML/Markdown et gates TypeScript existantes affectées par le lockfile.
+5. `semctx plugin-status --host auto --json` ;
+6. Arnes Doctor sur les plugins, skills et MCP déclarés ;
+7. formatage YAML/Markdown et gates TypeScript existantes affectées par le lockfile.
 
 L'installation réelle est exécutée depuis le checkout canonique seulement après la migration
 explicite de la marketplace locale. L'initialisation `.semctx/` constitue une action séparée et

--- a/docs/superpowers/specs/2026-09-01-semctx-moon-harness-design.md
+++ b/docs/superpowers/specs/2026-09-01-semctx-moon-harness-design.md
@@ -55,8 +55,9 @@ preuve négative.
 ### `harness:semctx-status`
 
 Exécute le diagnostic local de livraison des plugins en JSON. Il ne modifie rien et n'effectue pas
-d'attestation réseau implicite. La tâche reste non cachée, car son résultat dépend de l'état du
-poste hors du graphe Moon.
+d'attestation réseau implicite. Elle utilise `bun run semctx install --host auto --skip-setup
+--dry-run --json` pour produire ce rapport en lecture seule. La tâche reste non cachée, car son
+résultat dépend de l'état du poste hors du graphe Moon.
 
 ## Migration du canal local
 

--- a/docs/superpowers/specs/2026-09-01-semctx-moon-harness-design.md
+++ b/docs/superpowers/specs/2026-09-01-semctx-moon-harness-design.md
@@ -1,0 +1,105 @@
+# Installation durable de Semctx par Moon
+
+## Intention
+
+Installer et maintenir les plugins Semctx du poste par une tâche Moon dédiée au harnais, sans
+ajouter Semctx aux profils `make minimal` ou `make optional`. Bun porte la version reproductible du
+CLI Semctx ; Moon porte l'orchestration ; Arnes observe les capacités externes installées.
+
+Cette tranche introduit le premier point d'entrée `harness:*` dans Moon. Elle ne remplace pas encore
+Make comme installateur public du poste et ne modifie aucune ADR en vigueur.
+
+## Architecture
+
+Le répertoire `harness/` devient un projet Moon explicite, enregistré sous l'identifiant `harness`
+dans `.moon/workspace.yml`. Son `moon.yml` contient uniquement les tâches qui opèrent sur le harnais
+multi-agent ; il ne contient aucune logique d'installation métier.
+
+Le paquet `semctx` est une dépendance de développement exacte du projet Bun racine. `package.json`
+est la source de sa version et `bun.lock` rend sa résolution reproductible. Les tâches Moon
+invoquent le binaire résolu dans `node_modules`; elles ne recopient pas la version dans leur YAML et
+n'utilisent pas `bunx semctx@latest`.
+
+Le manifeste `home/.arnes.yaml` autorise les plugins et skills Semctx exposés par les hôtes détectés.
+Cette déclaration observe une capacité externe : elle ne possède ni le plugin, ni son cache, ni sa
+configuration native.
+
+## Tâches Moon
+
+### `harness:semctx-install`
+
+Exécute `semctx install --host auto --skip-setup --json`. Le mode `auto` converge tous les hôtes
+Codex ou Claude Code détectés sans rendre obligatoire un hôte absent. `--skip-setup` maintient une
+frontière stricte entre installation machine et initialisation du dépôt courant.
+
+La tâche possède des effets externes : réseau, marketplaces, caches de plugins et configurations
+utilisateur des agents. Elle désactive donc le cache Moon, ne s'exécute pas en CI et utilise un mutex
+commun aux mutations du harnais.
+
+### `harness:install`
+
+Agrège les installations du harnais. Dans cette tranche, sa seule dépendance est
+`harness:semctx-install`. L'ajout ultérieur d'une capacité exige sa propre tâche avec un contrat
+d'effets explicite ; l'agrégateur ne devient pas un script impératif.
+
+### `harness:semctx-setup`
+
+Exécute explicitement `semctx setup --polyglot` depuis le dépôt Git courant. Cette tâche initialise
+ou met à jour `.semctx/`, construit l'index et valide le modèle sémantique. Elle est non cachée,
+exclue de CI et n'est jamais une dépendance de `harness:install`.
+
+Le choix `--polyglot` crée la configuration v2 pour ce dépôt neuf et conserve séparément les
+langages supportés, partiels et non supportés. Il ne transforme pas l'absence d'analyseur Rust en
+preuve négative.
+
+### `harness:semctx-status`
+
+Exécute le diagnostic local de livraison des plugins en JSON. Il ne modifie rien et n'effectue pas
+d'attestation réseau implicite. La tâche reste non cachée, car son résultat dépend de l'état du
+poste hors du graphe Moon.
+
+## Migration du canal local
+
+L'installation actuelle de Codex utilise une marketplace `semctx-stable` liée au checkout local
+`/Users/sebastien/Code/semctx`. L'installateur officiel refuse volontairement d'écraser une
+marketplace homonyme dont la source n'est pas le dépôt public attendu.
+
+La migration initiale est donc séparée de la tâche durable : inspecter l'état natif, retirer
+explicitement le plugin et la marketplace locaux après autorisation, puis lancer
+`harness:semctx-install`. Aucun chemin personnel ni commande de suppression n'est inscrit dans le
+projet Moon.
+
+## Gestion des erreurs
+
+- Une dépendance Bun absente ou un lockfile désynchronisé échoue avant toute mutation de plugin.
+- Un conflit de marketplace reste un échec de l'installateur Semctx et conserve son diagnostic.
+- Un hôte absent est ignoré par `--host auto`; un hôte détecté mais non convergé fait échouer la
+  tâche.
+- `harness:semctx-setup` ne masque ni `SETUP_NOT_READY`, ni une couverture partielle, ni un index
+  invalide.
+- Une nouvelle session Codex ou un rechargement Claude Code reste nécessaire lorsque le rapport
+  Semctx le demande ; le cache installé n'est pas présenté comme la version active de la session.
+
+## Vérification
+
+La modification est vérifiée sans installer réellement de plugin depuis le worktree :
+
+1. installation Bun gelée et cohérence de `package.json` avec `bun.lock` ;
+2. résolution du projet et des quatre tâches par Moon ;
+3. inspection du graphe de dépendances de `harness:install` ;
+4. `semctx install --host auto --skip-setup --dry-run --json` ;
+5. Arnes Doctor sur les plugins, skills et MCP déclarés ;
+6. formatage YAML/Markdown et gates TypeScript existantes affectées par le lockfile.
+
+L'installation réelle est exécutée depuis le checkout canonique seulement après la migration
+explicite de la marketplace locale. L'initialisation `.semctx/` constitue une action séparée et
+requiert sa propre exécution volontaire.
+
+## Hors périmètre
+
+- ajout de Semctx à `make minimal` ou `make optional` ;
+- remplacement général de Make par Moon ;
+- installation automatique de Moon sur un poste neuf ;
+- hook bloquant, intégration CI Semctx ou attestation réseau automatique ;
+- support d'analyse Rust par Semctx ;
+- suppression automatique d'une marketplace ou d'un cache existant.

--- a/harness/moon.yml
+++ b/harness/moon.yml
@@ -1,0 +1,29 @@
+language: typescript
+layer: configuration
+
+taskOptions:
+  cache: false
+  runFromWorkspaceRoot: true
+  runInCI: false
+
+tasks:
+  install:
+    description: Install every declared harness capability
+    command: noop
+    deps:
+      - ~:semctx-install
+  semctx-install:
+    description: Install or update Semctx plugins for detected agent hosts
+    command: bun run semctx install --host auto --skip-setup --json
+    options:
+      mutex: harness-mutation
+      outputStyle: stream
+  semctx-setup:
+    description: Initialize Semctx in the current Git repository
+    command: bun run semctx setup --polyglot --json
+    options:
+      mutex: harness-mutation
+      outputStyle: stream
+  semctx-status:
+    description: Inspect local Semctx plugin delivery without network attestation
+    command: bun run semctx plugin-status --host auto --json

--- a/harness/moon.yml
+++ b/harness/moon.yml
@@ -26,4 +26,4 @@ tasks:
       outputStyle: stream
   semctx-status:
     description: Inspect local Semctx plugin delivery without network attestation
-    command: bun run semctx plugin-status --host auto --json
+    command: bun run semctx install --host auto --skip-setup --dry-run --json

--- a/harness/moon.yml
+++ b/harness/moon.yml
@@ -26,4 +26,4 @@ tasks:
       outputStyle: stream
   semctx-status:
     description: Inspect local Semctx plugin delivery without network attestation
-    command: bun run semctx install --host auto --skip-setup --dry-run --json
+    command: bun run semctx plugin-status --host auto --json

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -132,10 +132,12 @@ external:
       origin: system
       location: { root: home, path: .codex/skills/.system }
   plugins:
+    - { agent: claude, scope: user, id: semctx@semctx-stable }
     - { agent: claude, scope: user, id: superpowers@claude-plugins-official }
     - { agent: cursor, scope: user, id: superpowers }
     - { agent: codex, scope: user, id: codex-app-tools@openai-bundled }
     - { agent: codex, scope: user, id: github@openai-curated }
+    - { agent: codex, scope: user, id: semctx-control@semctx-stable }
     - { agent: codex, scope: user, id: superpowers@openai-curated }
   skills:
     - agent: codex
@@ -146,6 +148,27 @@ external:
         agent: claude,
         scope: user,
         origin: plugin,
+        plugin: semctx@semctx-stable,
+        slug: semctx-control,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: semctx@semctx-stable,
+        slug: semctx-semantic,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
+        plugin: semctx@semctx-stable,
+        slug: semctx-verify,
+      }
+    - {
+        agent: claude,
+        scope: user,
+        origin: plugin,
         plugin: superpowers@claude-plugins-official,
         slug: brainstorming,
       }
@@ -435,6 +458,13 @@ external:
         origin: plugin,
         plugin: superpowers@openai-curated,
         slug: writing-skills,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
+        plugin: semctx-control@semctx-stable,
+        slug: semctx-control,
       }
 mcp:
   - name: apple-notes

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -365,6 +365,13 @@ external:
         agent: codex,
         scope: user,
         origin: plugin,
+        plugin: semctx-control@semctx-stable,
+        slug: semctx-control,
+      }
+    - {
+        agent: codex,
+        scope: user,
+        origin: plugin,
         plugin: superpowers@openai-curated,
         slug: brainstorming,
       }
@@ -458,13 +465,6 @@ external:
         origin: plugin,
         plugin: superpowers@openai-curated,
         slug: writing-skills,
-      }
-    - {
-        agent: codex,
-        scope: user,
-        origin: plugin,
-        plugin: semctx-control@semctx-stable,
-        slug: semctx-control,
       }
 mcp:
   - name: apple-notes

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "oxlint": "1.80.0",
     "oxlint-tsgolint": "7.0.2001",
     "prettier": "3.9.6",
+    "semctx": "0.1.17",
     "typescript": "7.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "oxlint": "1.80.0",
     "oxlint-tsgolint": "7.0.2001",
     "prettier": "3.9.6",
-    "semctx": "0.1.17",
+    "semctx": "0.1.18",
     "typescript": "7.0.2"
   }
 }


### PR DESCRIPTION
## Description

- Pin the project-local Semctx CLI to `0.1.18` with Bun.
- Add a dedicated Moon `harness` project for plugin installation, explicit repository setup, and read-only delivery status.
- Allow the published Semctx plugins and skills through Arnes without adding Semctx to Make profiles.
- Keep the existing local marketplace migration and repository setup as explicit operator actions; this PR does not install plugins or create `.semctx/`.

## Useful Links

- Issue: N/A

## How to Test

- `bun install --frozen-lockfile --ignore-scripts --config=/dev/null --no-env-file`
- `MOON_TOOLCHAIN_FORCE_GLOBALS=true moon run repository:typescript-lint repository:typescript-typecheck repository:typescript-format-check repository:prettier-check`
- `moon project harness --json`
- `moon task-graph harness:install --json`
- `moon run harness:semctx-status` (expected to fail closed with `UNKNOWN` while the local marketplace remains unattested)
- `bun test`

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated
- [x] No breaking changes introduced