### PR TITLE
test(arnes): cover statuslines in instructions doctor

### DIFF
--- a/tooling/arnes/tests/instructions.rs
+++ b/tooling/arnes/tests/instructions.rs
@@ -88,6 +88,7 @@ fn undeclared_filtered_combinations_are_unsupported() {
 fn codex_generated_content_must_match_declared_composition() {
     let fixture = configured_fixture();
     fixture.write_home(".codex/AGENTS.md", "rules\nsoul\nold user\n");
+    let before = fixture.snapshot();
     let (code, stdout, _) = run(
         &fixture,
         &[
@@ -102,6 +103,7 @@ fn codex_generated_content_must_match_declared_composition() {
 
     assert_eq!(code, 1);
     assert!(stdout.contains("generated file ~/.codex/AGENTS.md is stale"));
+    assert_eq!(fixture.snapshot(), before);
 }
 
 #[test]

--- a/tooling/arnes/tests/support/instructions.rs
+++ b/tooling/arnes/tests/support/instructions.rs
@@ -11,6 +11,14 @@ agents:
     scopes: [user, project]
   - id: codex
     scopes: [user, project]
+statuslines:
+  - agent: codex
+    scope: user
+    items:
+      - model-with-reasoning
+      - current-dir
+      - context-used
+      - context-window-size
 resources:
   - id: claude-user-instructions
     kind: instructions


### PR DESCRIPTION
## Description

- exercise the instructions doctor with the canonical top-level statuslines declaration
- prove a stale Codex projection is still diagnosed through that manifest
- prove the filtered drift check remains read-only

The installed failure came from a pre-statuslines Arnes artifact, not from an invalid manifest or missing source support.

## How to Test

- cargo fmt --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo check --all-targets --locked
- cargo test --locked
- arnes doctor instructions --agent codex --scope user --color never

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes