### PR TITLE
fix(arnes): resolve user skills from deployed checkout

### DIFF
--- a/tooling/arnes/src/roots.rs
+++ b/tooling/arnes/src/roots.rs
@@ -1,40 +1,56 @@
 use std::env;
 use std::fmt::{self, Display};
+use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Roots {
     repository: PathBuf,
+    deployment_repository: PathBuf,
     home: PathBuf,
 }
 
 impl Roots {
     pub fn new(repository: impl Into<PathBuf>, home: impl Into<PathBuf>) -> Self {
+        let repository = repository.into();
         Self {
-            repository: repository.into(),
+            deployment_repository: repository.clone(),
+            repository,
             home: home.into(),
         }
     }
 
     pub fn from_environment() -> Result<Self, RootsError> {
         let repository = env::current_dir()
-            .map_err(|_| RootsError("repository: current directory is unavailable"))?;
+            .map_err(|_| RootsError::new("repository: current directory is unavailable"))?;
         let home = env::var_os("HOME")
             .map(PathBuf::from)
-            .ok_or(RootsError("HOME: environment variable is required"))?;
+            .ok_or_else(|| RootsError::new("HOME: environment variable is required"))?;
         if home.as_os_str().is_empty() {
-            return Err(RootsError("HOME: environment variable cannot be empty"));
+            return Err(RootsError::new(
+                "HOME: environment variable cannot be empty",
+            ));
         }
         if !home.is_absolute() {
-            return Err(RootsError(
+            return Err(RootsError::new(
                 "HOME: environment variable must be an absolute path",
             ));
         }
-        Ok(Self::new(repository, home))
+        let deployment_repository = deployment_repository(&repository, &home)?;
+        Ok(Self {
+            repository,
+            deployment_repository,
+            home,
+        })
     }
 
     pub fn repository(&self) -> &Path {
         &self.repository
+    }
+
+    pub fn deployment_repository(&self) -> &Path {
+        &self.deployment_repository
     }
 
     pub fn home(&self) -> &Path {
@@ -43,12 +59,47 @@ impl Roots {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct RootsError(&'static str);
+pub struct RootsError(String);
+
+impl RootsError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
 
 impl Display for RootsError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.0)
+        formatter.write_str(&self.0)
     }
 }
 
 impl std::error::Error for RootsError {}
+
+fn deployment_repository(repository: &Path, home: &Path) -> Result<PathBuf, RootsError> {
+    let manifest = home.join(".arnes.yaml");
+    let metadata = match fs::symlink_metadata(&manifest) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(repository.to_owned()),
+        Err(_) => {
+            return Err(RootsError::new(
+                "repository: deployed .arnes.yaml could not be inspected",
+            ));
+        }
+    };
+    if !metadata.file_type().is_symlink() {
+        return Ok(repository.to_owned());
+    }
+    let manifest = fs::canonicalize(&manifest).map_err(|_| {
+        RootsError::new("repository: deployed .arnes.yaml symlink could not be resolved")
+    })?;
+    manifest
+        .file_name()
+        .filter(|name| *name == ".arnes.yaml")
+        .and_then(|_| manifest.parent())
+        .filter(|directory| directory.file_name().is_some_and(|name| name == "home"))
+        .and_then(Path::parent)
+        .map(Path::to_owned)
+        .ok_or_else(|| {
+            RootsError::new("repository: deployed .arnes.yaml must resolve from home/.arnes.yaml")
+        })
+}

--- a/tooling/arnes/src/skills/projection.rs
+++ b/tooling/arnes/src/skills/projection.rs
@@ -15,12 +15,17 @@ pub fn leaf(roots: &Roots, resource: &SkillProjection<'_>, name: &str) -> Diagno
         resource.scope,
         label(resource.scope, &installed)
     );
-    let source = roots.repository().join(resource.source).join(name);
+    let source_root = match resource.scope {
+        Scope::User => roots.deployment_repository(),
+        Scope::Project => roots.repository(),
+    };
+    let source = source_root.join(resource.source).join(name);
     let destination = destination(roots, resource.scope, &installed);
     let human = ProjectionHuman::new(name, label(resource.scope, &installed));
     match expected_link(
         roots,
         resource.scope,
+        source_root,
         &source,
         &destination,
         &subject,
@@ -53,6 +58,7 @@ pub fn root(
     expected_link(
         roots,
         resource.scope,
+        roots.repository(),
         &source,
         &destination,
         &subject,
@@ -121,12 +127,13 @@ impl ProjectionHuman {
 fn expected_link(
     roots: &Roots,
     scope: Scope,
+    source_root: &Path,
     source: &Path,
     destination: &Path,
     subject: &str,
     human: &ProjectionHuman,
 ) -> Result<(), Diagnostic> {
-    let expected = source_directory(source, roots.repository(), subject)?;
+    let expected = source_directory(source, source_root, subject)?;
     let boundary = match scope {
         Scope::User => roots.home(),
         Scope::Project => roots.repository(),

--- a/tooling/arnes/tests/roots.rs
+++ b/tooling/arnes/tests/roots.rs
@@ -1,5 +1,9 @@
+mod support;
+
 use arnes::Roots;
+use std::os::unix::fs::symlink;
 use std::path::Path;
+use support::Fixture;
 
 #[test]
 fn repository_and_home_roots_are_injectable() {
@@ -7,4 +11,29 @@ fn repository_and_home_roots_are_injectable() {
 
     assert_eq!(roots.repository(), Path::new("fixture/repository"));
     assert_eq!(roots.home(), Path::new("fixture/home"));
+}
+
+#[test]
+fn manifest_doctor_rejects_a_deployment_link_without_the_repository_layout() {
+    for target in ["manifest.yaml", "home/other.yaml"] {
+        let fixture = Fixture::new();
+        fixture.write_repository(target, "version: 1\nagents: []\nresources: []\n");
+        symlink(
+            fixture.repository().join(target),
+            fixture.home().join(".arnes.yaml"),
+        )
+        .unwrap();
+        let before = fixture.snapshot();
+
+        let output = fixture.command(["doctor", "manifest"]);
+
+        assert_eq!(output.status.code(), Some(2), "{target}");
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            "Manifest\n✓ 0 healthy\n\nerror manifest: repository: deployed .arnes.yaml must resolve from home/.arnes.yaml\n",
+            "{target}"
+        );
+        assert!(output.stderr.is_empty());
+        assert_eq!(fixture.snapshot(), before);
+    }
 }

--- a/tooling/arnes/tests/skills.rs
+++ b/tooling/arnes/tests/skills.rs
@@ -3,6 +3,10 @@ pub mod skill_support;
 pub mod support;
 
 use skill_support::{MANIFEST, configured_fixture, run};
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use std::process::Command;
 use support::Fixture;
 
 #[test]
@@ -17,6 +21,66 @@ fn user_scope_is_default_for_declared_skills() {
         assert!(stdout.contains(expected), "missing {expected}: {stdout}");
     }
     assert!(stderr.is_empty());
+}
+
+#[test]
+fn user_skill_targets_from_the_deployed_checkout_are_healthy_from_a_worktree() {
+    let fixture = configured_fixture();
+    fixture.write_repository("home/.arnes.yaml", MANIFEST);
+    fs::remove_file(fixture.home().join(".arnes.yaml")).unwrap();
+    symlink(
+        fixture.repository().join("home/.arnes.yaml"),
+        fixture.home().join(".arnes.yaml"),
+    )
+    .unwrap();
+    let worktree = fixture.repository().parent().unwrap().join("worktree");
+    create_worktree(fixture.repository(), &worktree);
+    let before = fixture.snapshot();
+
+    let output = fixture.command_from(
+        &worktree,
+        ["doctor", "skills", "--agent", "codex", "--scope", "user"],
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("✓ 1 healthy"), "{stdout}");
+    assert_eq!(fixture.snapshot(), before);
+}
+
+fn create_worktree(repository: &Path, worktree: &Path) {
+    for arguments in [
+        vec!["init", "--quiet"],
+        vec!["add", "."],
+        vec![
+            "-c",
+            "user.name=Arnes Test",
+            "-c",
+            "user.email=arnes@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "fixture",
+        ],
+    ] {
+        assert!(
+            Command::new("git")
+                .args(arguments)
+                .current_dir(repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+    assert!(
+        Command::new("git")
+            .args(["worktree", "add", "--quiet", "--detach"])
+            .arg(worktree)
+            .current_dir(repository)
+            .status()
+            .unwrap()
+            .success()
+    );
 }
 
 #[test]

--- a/tooling/arnes/tests/support/mod.rs
+++ b/tooling/arnes/tests/support/mod.rs
@@ -39,9 +39,17 @@ impl Fixture {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
+        self.command_from(&self.repository, args)
+    }
+
+    pub fn command_from<I, S>(&self, directory: &Path, args: I) -> Output
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
         Command::new(env!("CARGO_BIN_EXE_arnes"))
             .args(args)
-            .current_dir(&self.repository)
+            .current_dir(directory)
             .env_clear()
             .env("HOME", &self.home)
             .env("PATH", self.home.join("bin"))


### PR DESCRIPTION
## Description

- Resolve user skill sources from the checkout that deployed `~/.arnes.yaml`.
- Keep project skill sources anchored to the checkout where Arnes runs.
- Fail closed when the deployed manifest link does not resolve from `<repository>/home/.arnes.yaml`.
- Cover the regression with a real detached Git worktree and read-only filesystem snapshots.

## Useful Links

- Issue: N/A

## How to Test

- `cd tooling/arnes && cargo fmt --check`
- `cd tooling/arnes && cargo clippy --all-targets --locked -- -D warnings`
- `cd tooling/arnes && cargo check --all-targets --locked`
- `cd tooling/arnes && cargo test --locked`
- Run the debug Arnes binary from both the canonical checkout and the Codex worktree: Codex reports 20 healthy managed user skills and the same 17 external plugin drifts in both locations.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
