### PR TITLE
fix(arnes): resolve user instructions from deployed checkout

### DIFF
--- a/tooling/arnes/src/instructions/projection.rs
+++ b/tooling/arnes/src/instructions/projection.rs
@@ -31,25 +31,40 @@ pub fn diagnose(
     resources: &[InstructionResource<'_>],
     projection: Projection,
 ) -> Diagnostic {
-    let source = roots.repository().join(resource.source);
+    let source_root = match resource.scope {
+        Scope::User => roots.deployment_repository(),
+        Scope::Project => roots.repository(),
+    };
+    let source = source_root.join(resource.source);
     let destination = destination(roots, resource);
     let subject = format!(
         "{} {} instructions {}",
         resource.agent, resource.scope, resource.id
     );
-    let source_contents = match includes::read_regular(&source, roots.repository()) {
+    let source_contents = match includes::read_regular(&source, source_root) {
         Ok(contents) => contents,
         Err(error) => return source_diagnostic(&subject, error),
     };
 
     match projection {
-        Projection::Link => {
-            diagnose_link(roots, resource, resources, &source, &destination, &subject)
-        }
+        Projection::Link => diagnose_link(
+            roots,
+            resource,
+            resources,
+            source_root,
+            &source,
+            &destination,
+            &subject,
+        ),
         Projection::Include => diagnose_include(roots, &source, &destination, &subject),
-        Projection::Generated => {
-            diagnose_generated(roots, &source, &destination, &source_contents, &subject)
-        }
+        Projection::Generated => diagnose_generated(
+            roots,
+            source_root,
+            &source,
+            &destination,
+            &source_contents,
+            &subject,
+        ),
     }
 }
 
@@ -57,6 +72,7 @@ fn diagnose_link(
     roots: &Roots,
     resource: &InstructionResource<'_>,
     resources: &[InstructionResource<'_>],
+    source_root: &Path,
     source: &Path,
     destination: &Path,
     subject: &str,
@@ -67,10 +83,10 @@ fn diagnose_link(
     let aliases = resources.iter().map(|candidate| {
         (
             roots.home().join(candidate.destination),
-            roots.repository().join(candidate.source),
+            source_root.join(candidate.source),
         )
     });
-    let resolver = Resolver::with_aliases(roots.home(), roots.repository(), aliases);
+    let resolver = Resolver::with_aliases(roots.home(), source_root, aliases);
     match resolver.walk(destination) {
         Ok(_) => healthy(subject, destination_label(resource)),
         Err(error) => include_diagnostic(subject, error, State::Error),
@@ -98,6 +114,7 @@ fn diagnose_include(roots: &Roots, source: &Path, destination: &Path, subject: &
 
 fn diagnose_generated(
     roots: &Roots,
+    source_root: &Path,
     source: &Path,
     destination: &Path,
     source_contents: &str,
@@ -106,13 +123,13 @@ fn diagnose_generated(
     if let Err(diagnostic) = expected_file(destination, roots.home(), subject) {
         return diagnostic;
     }
-    let resolver = Resolver::new(roots.repository());
+    let resolver = Resolver::new(source_root);
     if let Err(error) = resolver.walk(source) {
         return include_diagnostic(subject, error, State::Error);
     }
     let mut expected = includes::without_leading_imports(source_contents);
     for include in includes::leading_imports(source_contents) {
-        let path = match resolver.resolve(source.parent().unwrap_or(roots.repository()), &include) {
+        let path = match resolver.resolve(source.parent().unwrap_or(source_root), &include) {
             Ok(path) => path,
             Err(error) => return include_diagnostic(subject, error, State::Error),
         };

--- a/tooling/arnes/tests/instructions.rs
+++ b/tooling/arnes/tests/instructions.rs
@@ -4,6 +4,9 @@ pub mod support;
 
 use instruction_support::{configured_fixture, run};
 use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use std::process::Command;
 use support::Fixture;
 
 #[test]
@@ -24,6 +27,73 @@ fn user_scope_is_default_for_supported_and_unsupported_projections() {
         assert!(stdout.contains(expected), "missing {expected}: {stdout}");
     }
     assert!(stderr.is_empty());
+}
+
+#[test]
+fn user_instruction_targets_from_the_deployed_checkout_are_healthy_from_a_worktree() {
+    let fixture = configured_fixture();
+    fixture.write_repository("home/.arnes.yaml", instruction_support::MANIFEST);
+    fs::remove_file(fixture.home().join(".arnes.yaml")).unwrap();
+    symlink(
+        fixture.repository().join("home/.arnes.yaml"),
+        fixture.home().join(".arnes.yaml"),
+    )
+    .unwrap();
+    let worktree = fixture.repository().parent().unwrap().join("worktree");
+    create_worktree(fixture.repository(), &worktree);
+    let before = fixture.snapshot();
+
+    let output = fixture.command_from(
+        &worktree,
+        [
+            "doctor",
+            "instructions",
+            "--agent",
+            "claude",
+            "--scope",
+            "user",
+        ],
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(stdout.contains("✓ 3 healthy"), "{stdout}");
+    assert_eq!(fixture.snapshot(), before);
+}
+
+fn create_worktree(repository: &Path, worktree: &Path) {
+    for arguments in [
+        vec!["init", "--quiet"],
+        vec!["add", "."],
+        vec![
+            "-c",
+            "user.name=Arnes Test",
+            "-c",
+            "user.email=arnes@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "fixture",
+        ],
+    ] {
+        assert!(
+            Command::new("git")
+                .args(arguments)
+                .current_dir(repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+    assert!(
+        Command::new("git")
+            .args(["worktree", "add", "--quiet", "--detach"])
+            .arg(worktree)
+            .current_dir(repository)
+            .status()
+            .unwrap()
+            .success()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

- Resolve user-scoped instruction sources and include boundaries from the checkout selected by the deployed `~/.arnes.yaml`.
- Keep project-scoped instruction diagnostics anchored to the current checkout.
- Add a regression test exercising the real doctor from a Git worktree and asserting the three Claude projections stay healthy and read-only.

## Useful Links

- Issue: none

## How to Test

- `cargo fmt --check`
- `cargo check --all-targets --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- Run `arnes doctor instructions --scope user` from both the canonical checkout and a linked worktree; both report 4 healthy projections and only the non-blocking Cursor limitation.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary (not needed: existing root contract unchanged)
- [x] No breaking changes