### PR TITLE
fix(memory): make CLI rejections actionable and redacted

### DIFF
--- a/harness/skills/memory-governance/references/entry-contract.md
+++ b/harness/skills/memory-governance/references/entry-contract.md
@@ -51,6 +51,94 @@ oracle:
 Source kinds are `git-file`, `local-file`, `official-url`, and `user-decision`. The runtime assigns
 the ID, resolved scope key, source fingerprints, status, and timestamps.
 
+## Validation rules before admission
+
+The runtime accepts one UTF-8 YAML mapping, at most **1,048,576 bytes (1 MiB)** including YAML
+syntax and whitespace. JSON is also accepted as YAML. Mapping keys must be unique; extra keys are
+rejected at every schema level. Do not submit runtime-assigned fields (`id`, `status`, timestamps,
+fingerprints, or transitions). `schema_version` is the integer `1`; other versions are rejected.
+
+Text limits below are inclusive and count **Unicode scalar values**, as Rust `str.chars()` does:
+not UTF-8 bytes, grapheme clusters, or tokens. An accented scalar counts once; a combining sequence
+counts each scalar separately. Text is checked before identity normalization; whitespace counts
+toward length. Persisted text fields reject non-string scalars (including numbers, booleans, null),
+mappings, sequences, and custom YAML tags; a custom tag on top-level `kind` is historically accepted. Use quoted strings when a YAML scalar could otherwise be interpreted as another type.
+
+| Field                     | Required shape and bounds                                                                                      |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `kind`                    | `goal`, `decision`, `evidence`, `invariant`, `unknown`, or `assumption`                                        |
+| `statement`               | String, 1–500 Unicode scalar values                                                                            |
+| `scope`                   | `project` or `user`; omission defaults to `project`                                                            |
+| `retrieval_terms`         | Sequence of 1–20 strings, each 1–100 Unicode scalar values                                                     |
+| `proof`                   | Mapping with `summary` and `sources`                                                                           |
+| `proof.summary`           | String, 1–1,000 Unicode scalar values                                                                          |
+| `proof.sources`           | Sequence of 1–20 mappings, each with `kind` and `locator`                                                      |
+| `proof.sources[].kind`    | `git-file`, `local-file`, `official-url`, or `user-decision`                                                   |
+| `proof.sources[].locator` | String satisfying the source rules below; no separate text-length cap beyond the document limit                |
+| `oracle`                  | Mapping with `human_fallback`, `outcomes`, and `automated` when required                                       |
+| `oracle.automated`        | When present and non-null: mapping with `kind: source-fingerprint` and `expected: all-proof-sources-unchanged` |
+| `oracle.human_fallback`   | Mapping with `question` and `valid_when`, each a string of 1–500 Unicode scalar values                         |
+| `oracle.outcomes`         | Mapping with `valid` and `invalidated`, each a string of 1–500 Unicode scalar values                           |
+
+Only `scope` and `oracle.automated` may be omitted. A missing or null automated oracle is accepted
+only when **every** proof source is a `user-decision`; the human fallback and both outcomes remain
+mandatory. Empty source and retrieval-term sequences are rejected. The 500-scalar statement cap
+keeps the retrieved statement bounded; put supporting detail in the proof and primary source rather
+than silently truncating a human-approved statement.
+
+### Source prerequisites
+
+- `git-file`: a nonempty relative path from the command's current directory, using normal path
+  components (no parent traversal or leading `./`). The resolved file must remain within the current
+  Git worktree and be tracked by Git. Admission stores a worktree-relative locator. User-scoped
+  entries cannot use Git sources. Project identity requires an accessible, unambiguous, absolute
+  canonical `git-common-dir`; worktrees share an identity, separate clones and moved repositories
+  do not.
+- `local-file`: an absolute path. Local and Git sources must exist and end in a regular file, not a
+  symlink or directory; the parent directory is canonicalized. Their bytes must be readable and
+  total at most 1,048,576. Missing files are rejected; an oversized file or an access/tool failure
+  is unavailable (exit `4`).
+- `official-url`: HTTPS with a domain name, no literal IP, credentials, or fragment. The final URL
+  must satisfy the same restrictions. Fetching permits at most five HTTPS redirects, five seconds
+  to connect, fifteen seconds overall, and 1,048,576 response-body bytes. A successful response must
+  be HTTP 2xx; HTTP 404/410 is rejected, other fetch failures are unavailable. The draft must also
+  contain a `user-decision` source recording the human decision that the domain is authoritative;
+  a successful fetch does not establish officiality. `curl` and Git must be available when used.
+- `user-decision`: the locator is the explicit human decision text, fingerprinted without fetching.
+  The runtime checks its type and sensitive/executable content; the human and skill establish its
+  substance and authority. An empty locator is not a useful proof even though it has no separate
+  minimum-length validator.
+
+All proof sources are rechecked during admission. A changed fingerprint produces a conflict;
+revalidate the proof before resubmitting. An unavailable dependency cannot be repaired by shortening
+or weakening the draft: preserve the accepted draft and restore the dependency.
+
+### Content exclusions
+
+Every persisted text sink is checked: statement, retrieval terms, proof summary, source locators,
+human fallback, outcomes, and confirmation reason. Diagnostics never include their values.
+The existing deterministic sensitive checks are ASCII-case-insensitive and recognize:
+
+- private-key PEM headers;
+- URL authority userinfo containing `@`;
+- `authorization` followed by a colon;
+- assignments to `password`, `secret`, `token`, or `api` + separator + `key`, using `=` or `:`;
+  API-key separators may be whitespace, `_`, `-`, or `.`;
+- credential prefixes `sk-`, `ghp_`, `github_pat_`, `xoxb-`, `xoxa-`, `xoxp-`, `xoxr-`, `xoxs-`;
+- prompt markers `system prompt:`, `<|system|>`, `[system]`, or `begin system prompt`;
+- at least two lines prefixed by `user:`, `assistant:`, or `system:` after optional whitespace or
+  Markdown list/quote/heading markers.
+
+Assignments and credential prefixes use lexical boundaries; they do not reject every incidental
+word containing these letters. These are named-pattern checks, not universal detection of secrets
+or unmarked private prompts/transcripts. The skill's broader refusal rule still applies even when
+the runtime would accept the text; do not encode or disguise sensitive content to evade detection.
+
+Executable text is also refused: command substitution opening `$(`, shell shebangs, shell code
+fences, lines starting with `$ ` or `% `, `sh`/`bash`/`zsh`/`fish` with `-c` and a command, or a pipe
+into one of those shells. Code-fence languages include `shell`; executable paths use their basename.
+Keep a declarative summary instead of executable material.
+
 ## Commands
 
 Pass the full value on stdin and wait for completion:
@@ -66,3 +154,90 @@ Valid human statuses are `achieved` or `abandoned` for goals, `superseded` for d
 `resolved` for unknowns, and `confirmed` for assumptions. Evidence and invariants have no human
 terminal status. Exit `0` means success or duplicate, `2` means usage error or rejection, `3` means
 conflict, and `4` means unavailable. Stdout is JSON; stderr diagnostics are redacted JSON.
+
+## Diagnosing a failed command
+
+Every CLI error retains `error.code` and `error.field` and adds a redacted English `error.message`
+that names the failed criterion and the next action. Length/count failures also return inclusive
+`minimum`, `maximum`, and `unit` (`unicode_scalars`, `items`, or `bytes`). A list member may carry
+`item_index` (zero-based); YAML errors may carry `line` and `column` (one-based parser locations,
+sometimes the beginning of the containing mapping). Field paths contain only known schema names;
+unknown keys, values, source paths, URLs, prompts, transcripts, and parser excerpts are never echoed.
+
+For example, an overlong statement returns exit `2` and this diagnostic:
+
+```json
+{
+  "error": {
+    "code": "invalid_field",
+    "field": "statement",
+    "message": "Adjust the string length to the inclusive bounds; length counts Unicode scalar values, not bytes, graphemes or tokens.",
+    "minimum": 1,
+    "maximum": 500,
+    "unit": "unicode_scalars"
+  }
+}
+```
+
+Use the supplied criterion and bounds to repair the draft locally. Preserve its accepted meaning;
+if repair changes the claim, proof, scope, or oracle substantively, present the revised draft for
+acceptance before admission. The command reports the first failure in validation order, so check
+the complete contract before resubmitting. There is no dry-run/validate command: never use repeated
+`admit` calls to discover a constraint, because a successful call persists an entry.
+
+| Rejection code                                   | Correction                                                                               |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `invalid_field`                                  | Supply the named required field with the expected type/value or obey the returned bounds |
+| `missing_proof`                                  | Add at least one primary proof source                                                    |
+| `missing_oracle`                                 | Supply the source-fingerprint oracle unless all sources are user decisions               |
+| `unsupported_schema`                             | Use integer schema version 1                                                             |
+| `too_many_items`                                 | Reduce the named sequence to its returned maximum                                        |
+| `sensitive_content`                              | Remove the forbidden content; retain a safe summary without encoding the original        |
+| `shell_command`                                  | Replace executable material with a declarative statement                                 |
+| `invalid_source_kind`                            | Select one of the four supported source kinds                                            |
+| `unknown_field`                                  | Remove keys outside the named mapping's allowed set; omit runtime-assigned fields        |
+| `duplicate_field`                                | Keep each mapping key once near the reported location                                    |
+| `malformed_yaml`                                 | Repair the document syntax near the reported location                                    |
+| `input_too_large`                                | Reduce the full serialized input to 1 MiB                                                |
+| `invalid_utf8`, `empty_stdin`, `empty_query`     | Supply valid UTF-8 and the required nonempty text/document                               |
+| `source_invalid`                                 | Follow the specific source criterion in the message and the source index when provided   |
+| `scope_unavailable`, `scope_mismatch`            | Run from the authorized Git project; do not switch to user scope without consent         |
+| `admission_not_authorized`                       | Obtain explicit persistence authorization                                                |
+| `invalid_memory_id`, `entry_not_found`           | Use the ID returned by successful admission in the same configured store                 |
+| `invalid_transition_reason`                      | Supply a nonblank, bounded, declarative reason                                           |
+| `invalid_human_conclusion`, `entry_not_terminal` | Use a human terminal status compatible with the actual entry kind                        |
+| `invalid_arguments`                              | Follow the command syntax and closed option values given in the message                  |
+| `missing_hook_*`, `invalid_hook_*`               | Repair the named hook input criterion described below                                    |
+
+`entry_conflict`, `source_changed`, `entry_not_active`, `selection_stale`, and `store_lock_timeout`
+remain conflicts (exit `3`); their messages distinguish reconciliation, source revalidation,
+terminal-state refusal, fresh retrieval, and waiting for another writer. Storage, permission,
+oracle, source, input/output, trace, and retrieval-deadline failures remain unavailable (exit `4`).
+Preserve the draft on failure, do not claim it was stored, and never repair the store by directly
+editing files. After `output_unavailable` or a trace failure, the write may already have completed;
+restore the channel and reconcile rather than assuming nothing was persisted.
+
+## Retrieve, confirm, and hook inputs
+
+`retrieve` requires nonempty UTF-8 stdin with at least one non-whitespace character and the common
+1 MiB limit. It does not persist the query or run persisted-text rejection on it. Memory omitted
+by relevance, limits, freshness, or oracle verdict is not an input rejection; consume only the
+successfully injected subset. Stored-document validation failures remain omitted, with their check
+codes, rather than exposing invalid stored content. An empty result is not proof of admission failure.
+
+`confirm` requires an ID of `mem_` followed by exactly 24 lowercase hexadecimal digits, an active
+entry, and a human status compatible with its kind. Its reason is UTF-8, 1–500 Unicode scalar values,
+contains a non-whitespace character, and obeys all persisted-text exclusions. It must arrive on
+stdin with `--reason-stdin`. Terminal entries cannot be reactivated. Generated transition records
+start from `active`, end at the resulting status, and have verdict `valid` for human conclusions or
+`invalid` for automated invalidation.
+
+`hook --agent codex|claude` accepts one JSON object of at most 1 MiB, with these required strings:
+
+- `hook_event_name`: exactly `UserPromptSubmit`;
+- `prompt`: the complete prompt, nonempty after trimming whitespace;
+- `cwd`: a nonempty absolute path, without NUL or parent traversal.
+
+Do not duplicate those keys. Extra hook fields are allowed. The hook does not persist its prompt
+and returns only a sanitized injection; its overall retrieval deadline is 25 seconds. A rejection
+returns a redacted diagnostic and no context. On any hook failure, apply no memory.

--- a/tooling/agent-memory/src/cli.rs
+++ b/tooling/agent-memory/src/cli.rs
@@ -61,15 +61,26 @@ fn complete(
 }
 
 fn write_failure(diagnostics: &mut dyn io::Write, failure: CliFailure) -> u8 {
-    let value = json!({"error": {"code": failure.code, "field": failure.field}});
+    let mut error = serde_json::to_value(
+        failure
+            .diagnostic
+            .as_deref()
+            .copied()
+            .unwrap_or_else(|| crate::Diagnostic::for_code(failure.code, failure.field)),
+    )
+    .expect("diagnostics contain only static text and integers");
+    error["code"] = json!(failure.code);
+    error["field"] = json!(failure.field);
+    let value = json!({"error": error});
     write_json(diagnostics, &value).map_or(4, |()| failure.exit)
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct CliFailure {
     exit: u8,
     code: &'static str,
     field: &'static str,
+    diagnostic: Option<Box<crate::Diagnostic>>,
 }
 
 impl CliFailure {
@@ -78,6 +89,7 @@ impl CliFailure {
             exit: 2,
             code: "invalid_arguments",
             field: "arguments",
+            diagnostic: None,
         }
     }
 
@@ -86,6 +98,7 @@ impl CliFailure {
             exit: 4,
             code: "evaluation_trace_unavailable",
             field: "trace",
+            diagnostic: None,
         }
     }
 
@@ -99,6 +112,7 @@ impl CliFailure {
             exit,
             code: error.code(),
             field: error.field(),
+            diagnostic: Some(Box::new(error.diagnostic())),
         }
     }
 
@@ -111,6 +125,7 @@ impl CliFailure {
             exit,
             code: error.code(),
             field: error.field(),
+            diagnostic: None,
         }
     }
 }

--- a/tooling/agent-memory/src/cli/boundary.rs
+++ b/tooling/agent-memory/src/cli/boundary.rs
@@ -29,7 +29,12 @@ pub(super) fn write_json(output: &mut dyn Write, value: &impl Serialize) -> Resu
 }
 
 fn failure(exit: u8, code: &'static str, field: &'static str) -> CliFailure {
-    CliFailure { exit, code, field }
+    CliFailure {
+        exit,
+        code,
+        field,
+        diagnostic: None,
+    }
 }
 
 #[cfg(test)]

--- a/tooling/agent-memory/src/cli/commands.rs
+++ b/tooling/agent-memory/src/cli/commands.rs
@@ -190,5 +190,6 @@ fn output_failure() -> CliFailure {
         exit: 4,
         code: "output_unavailable",
         field: "stdout",
+        diagnostic: None,
     }
 }

--- a/tooling/agent-memory/src/diagnostic.rs
+++ b/tooling/agent-memory/src/diagnostic.rs
@@ -1,0 +1,55 @@
+mod messages;
+
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct Diagnostic {
+    pub message: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<usize>,
+}
+
+impl Diagnostic {
+    pub(crate) const fn new(message: &'static str) -> Self {
+        Self {
+            message,
+            minimum: None,
+            maximum: None,
+            unit: None,
+            item_index: None,
+            line: None,
+            column: None,
+        }
+    }
+
+    pub(crate) fn for_code(code: &str, field: &str) -> Self {
+        let diagnostic = Self::new(messages::message(code, field));
+        if code == "input_too_large" {
+            diagnostic.bounds(1, 1_048_576, "bytes")
+        } else {
+            diagnostic
+        }
+    }
+
+    pub(crate) const fn bounds(
+        mut self,
+        minimum: usize,
+        maximum: usize,
+        unit: &'static str,
+    ) -> Self {
+        self.minimum = Some(minimum);
+        self.maximum = Some(maximum);
+        self.unit = Some(unit);
+        self
+    }
+}

--- a/tooling/agent-memory/src/diagnostic/messages.rs
+++ b/tooling/agent-memory/src/diagnostic/messages.rs
@@ -1,0 +1,202 @@
+pub(super) fn message(code: &str, field: &str) -> &'static str {
+    match code {
+        "invalid_field" => field_requirement(field),
+        "unsupported_schema" => "Use schema_version: 1; other schema versions are not supported.",
+        "missing_proof" => "Provide at least one primary proof source in proof.sources.",
+        "missing_oracle" => {
+            "Provide oracle.automated with kind: source-fingerprint and expected: all-proof-sources-unchanged unless every source is a user-decision."
+        }
+        "too_many_items" => "Reduce the number of items to the published maximum.",
+        "invalid_source_kind" => {
+            "Use one source kind: git-file, local-file, official-url, or user-decision."
+        }
+        "duplicate_field" => {
+            "Each YAML mapping key must occur once; remove duplicate keys near the reported location."
+        }
+        "malformed_yaml" => {
+            "Provide one well-formed YAML mapping document; repair syntax near the reported location. No input excerpt is returned."
+        }
+        "unknown_field" => {
+            "Remove fields not defined for this mapping in the entry contract; runtime-assigned fields do not belong in an admission draft."
+        }
+        "input_too_large" => {
+            "Reduce stdin to at most 1048576 bytes (1 MiB), including serialization whitespace."
+        }
+        "invalid_utf8" => "Encode the complete stdin value as valid UTF-8.",
+        "empty_stdin" => {
+            "Provide the command's required document or text on stdin; the stream must not be empty."
+        }
+        "empty_query" => "Provide a query containing at least one non-whitespace character.",
+        "sensitive_content" => {
+            "Remove secrets, credentials, credential-bearing URLs, authorization headers, marked private prompts, and role-prefixed transcripts; retain only a safe durable summary."
+        }
+        "shell_command" => {
+            "Replace executable shell text with a declarative durable statement; commands and command substitutions cannot be persisted."
+        }
+        "invalid_transition_reason" => {
+            "Provide a reason containing a non-whitespace character and at most 500 Unicode scalar values."
+        }
+        "invalid_memory_id" => {
+            "Use mem_ followed by exactly 24 lowercase hexadecimal digits, as returned by admit."
+        }
+        "entry_not_found" => {
+            "No stored entry matches this id; use the id from the successful admission in the same configured memory store."
+        }
+        "invalid_human_conclusion" => {
+            "Choose a compatible human status: goal achieved/abandoned, decision superseded, unknown resolved, assumption confirmed; evidence/invariant have none."
+        }
+        "entry_not_active" => {
+            "Only an active entry can transition; terminal entries cannot be changed or reactivated."
+        }
+        "entry_not_terminal" => {
+            "Supply a terminal status compatible with the entry kind; active is not a terminal status."
+        }
+        "entry_conflict" => {
+            "This identity already has different canonical content; reconcile the accepted draft with the existing memory before another write."
+        }
+        "source_changed" => {
+            "A proof source changed during admission; revalidate the proof and accepted draft before resubmitting."
+        }
+        "source_invalid" => {
+            "Provide a supported, accessible primary source satisfying the source rules in the entry contract."
+        }
+        "source_unavailable" => {
+            "The proof source could not be read or verified; preserve the draft and restore source access before resubmitting."
+        }
+        "scope_unavailable" => {
+            "Project scope requires an accessible Git worktree with an unambiguous absolute canonical git-common-dir; run from that project. User scope requires separate explicit authorization."
+        }
+        "scope_mismatch" => {
+            "The resolved project scope must match the entry scope; submit from the authorized project."
+        }
+        "admission_not_authorized" => {
+            "Obtain an explicit persistence request or acceptance of the complete draft before admission."
+        }
+        "missing_hook_event" | "invalid_hook_event" => {
+            "Set the JSON string hook_event_name to exactly UserPromptSubmit."
+        }
+        "missing_hook_query" | "invalid_hook_query" => {
+            "Provide prompt as a JSON string containing at least one non-whitespace character."
+        }
+        "missing_hook_cwd" | "invalid_hook_cwd" => {
+            "Provide cwd as an absolute JSON path string, nonempty and without NUL, parent traversal, or a leading dot component."
+        }
+        "invalid_hook_payload" => {
+            "Provide one JSON object with string fields hook_event_name, prompt, cwd; do not repeat these keys."
+        }
+        "invalid_arguments" => {
+            "Use admit --format json; retrieve --query-stdin --format json; confirm --id ID --status achieved|abandoned|superseded|resolved|confirmed --reason-stdin; hook --agent codex|claude; audit --format json [--include-terminal]. Do not repeat options or add positional arguments."
+        }
+        "invalid_kind_status" => {
+            "Stored status must match kind: active/invalidated for all, achieved/abandoned for goal, superseded for decision, resolved for unknown, confirmed for assumption."
+        }
+        "unexpected_transition" => "An active stored entry must not contain a transition.",
+        "missing_transition" => {
+            "A terminal stored entry requires a transition recording its conclusion."
+        }
+        "invalid_transition" => {
+            "A stored transition must start at active, end at the entry status, and use invalid for invalidated or valid for a human terminal status."
+        }
+        _ => availability_message(code),
+    }
+}
+
+fn availability_message(code: &str) -> &'static str {
+    match code {
+        "stdin_unavailable" => {
+            "The stdin stream could not be read; restore the input pipe and preserve the draft."
+        }
+        "output_unavailable" => {
+            "The output stream could not be written or flushed; a write may already have succeeded. Restore the stream and reconcile before retrying."
+        }
+        "evaluation_trace_unavailable" => {
+            "The optional evaluation trace is unavailable; check AGENT_MEMORY_EVAL_TRACE and AGENT_MEMORY_EVAL_AGENT configuration. A command may already have completed."
+        }
+        "retrieval_deadline_exceeded" => {
+            "The hook's 25-second retrieval deadline expired; apply no memory and restore source availability before a later retrieval."
+        }
+        "oracle_unavailable" => {
+            "The proof oracle is unavailable; apply no memory until sources can be verified or the required human confirmation is supplied."
+        }
+        "selection_stale" => "Memory changed after selection; retrieve again before consuming it.",
+        "store_lock_timeout" => {
+            "The store write lock timed out; wait for the competing writer to finish before retrying the accepted operation."
+        }
+        "store_permissions_unavailable" => {
+            "Private store permissions could not be established (directories 0700, files 0600); preserve the draft and have the installation repaired."
+        }
+        "unsafe_store_path" => {
+            "The store requires an absolute path, safe directory components, no symlinks and singly linked regular files; preserve the draft and have the installation repaired."
+        }
+        "memory_root_unavailable" => {
+            "Configure an absolute AGENT_MEMORY_ROOT or a usable HOME for the default memory root."
+        }
+        "store_unavailable" | "store_lock_unavailable" | "cache_unavailable" => {
+            "Local memory storage is unavailable; preserve the draft and have storage access repaired through supported tooling."
+        }
+        "entry_identity_mismatch" | "entry_path_mismatch" => {
+            "Stored entry identity or scope does not match its canonical location; apply no memory and request store repair through supported tooling."
+        }
+        _ => {
+            "The operation could not complete; preserve the draft and report this diagnostic code for runtime repair."
+        }
+    }
+}
+
+pub(crate) fn field_requirement(field: &str) -> &'static str {
+    match field {
+        "schema_version" => "Provide the required integer schema_version: 1.",
+        "kind" => {
+            "Provide kind as one of goal, decision, evidence, invariant, unknown, assumption."
+        }
+        "scope" => {
+            "Use scope: project (the default) or scope: user with explicit user authorization."
+        }
+        "statement"
+        | "proof.summary"
+        | "oracle.human_fallback.question"
+        | "oracle.human_fallback.valid_when"
+        | "oracle.outcomes.valid"
+        | "oracle.outcomes.invalidated"
+        | "proof.sources.locator"
+        | "transition.reason" => {
+            "Provide the required string value; mappings, sequences and null are not accepted."
+        }
+        "retrieval_terms" => {
+            "Provide a nonempty sequence of string retrieval terms (1 to 20 items, each 1 to 100 Unicode scalar values)."
+        }
+        "proof" => "Provide a proof mapping containing summary and sources.",
+        "proof.sources" => {
+            "Provide a sequence of 1 to 20 source mappings, each containing kind and locator."
+        }
+        "proof.sources.kind" => {
+            "Provide source kind as git-file, local-file, official-url, or user-decision."
+        }
+        "oracle" => {
+            "Provide an oracle mapping containing human_fallback and outcomes, and automated when required by the sources."
+        }
+        "oracle.automated" | "oracle.automated.kind" => {
+            "Use an automated oracle mapping with kind: source-fingerprint and expected: all-proof-sources-unchanged."
+        }
+        "oracle.automated.expected" => {
+            "Set the required string expected to all-proof-sources-unchanged."
+        }
+        "oracle.human_fallback" => {
+            "Provide a human_fallback mapping containing question and valid_when strings."
+        }
+        "oracle.outcomes" => {
+            "Provide an outcomes mapping containing valid and invalidated strings."
+        }
+        "id" => "Use mem_ followed by exactly 24 lowercase hexadecimal digits.",
+        "scope.key" => "Use project_ followed by exactly 64 lowercase hexadecimal digits.",
+        "proof.sources.fingerprint" => {
+            "Use sha256: followed by exactly 64 lowercase hexadecimal digits."
+        }
+        "timestamp" => {
+            "Use a real UTC calendar timestamp YYYY-MM-DDTHH:MM:SS[.fraction]Z, year 0001 or later, without leap seconds."
+        }
+        _ => {
+            "Provide one YAML mapping matching the complete entry contract, with required fields, closed enum values and no additional fields."
+        }
+    }
+}

--- a/tooling/agent-memory/src/lib.rs
+++ b/tooling/agent-memory/src/lib.rs
@@ -1,5 +1,7 @@
 mod admission;
 mod cli;
+mod diagnostic;
+pub use diagnostic::Diagnostic;
 mod hook;
 mod memory;
 pub use admission::{AdmissionContext, admit, prepare_admission};

--- a/tooling/agent-memory/src/memory/error.rs
+++ b/tooling/agent-memory/src/memory/error.rs
@@ -12,6 +12,7 @@ pub struct MemoryError {
     class: MemoryErrorClass,
     code: &'static str,
     field: &'static str,
+    diagnostic: Option<Box<crate::Diagnostic>>,
 }
 
 impl MemoryError {
@@ -20,6 +21,7 @@ impl MemoryError {
             class: MemoryErrorClass::Rejection,
             code,
             field,
+            diagnostic: None,
         }
     }
 
@@ -28,6 +30,7 @@ impl MemoryError {
             class: MemoryErrorClass::Conflict,
             code,
             field,
+            diagnostic: None,
         }
     }
 
@@ -36,6 +39,7 @@ impl MemoryError {
             class: MemoryErrorClass::Unavailable,
             code,
             field,
+            diagnostic: None,
         }
     }
 
@@ -49,6 +53,34 @@ impl MemoryError {
 
     pub const fn field(&self) -> &'static str {
         self.field
+    }
+
+    pub fn diagnostic(&self) -> crate::Diagnostic {
+        self.diagnostic
+            .as_deref()
+            .copied()
+            .unwrap_or_else(|| crate::Diagnostic::for_code(self.code, self.field))
+    }
+
+    pub(crate) fn with_diagnostic(mut self, diagnostic: crate::Diagnostic) -> Self {
+        self.diagnostic = Some(Box::new(diagnostic));
+        self
+    }
+
+    pub(crate) fn with_message(self, message: &'static str) -> Self {
+        let diagnostic = crate::Diagnostic {
+            message,
+            ..self.diagnostic()
+        };
+        self.with_diagnostic(diagnostic)
+    }
+
+    pub(crate) fn at_item(self, index: usize) -> Self {
+        let diagnostic = crate::Diagnostic {
+            item_index: Some(index),
+            ..self.diagnostic()
+        };
+        self.with_diagnostic(diagnostic)
     }
 }
 

--- a/tooling/agent-memory/src/memory/retrieval/transition.rs
+++ b/tooling/agent-memory/src/memory/retrieval/transition.rs
@@ -13,9 +13,10 @@ pub fn confirm(
     if entry.status() != Status::Active {
         return Err(MemoryError::conflict("entry_not_active", "status"));
     }
-    let status = conclusion
-        .status_for(entry.kind())
-        .ok_or_else(|| MemoryError::new("invalid_human_conclusion", "conclusion"))?;
+    let status = conclusion.status_for(entry.kind()).ok_or_else(|| {
+        MemoryError::new("invalid_human_conclusion", "conclusion")
+            .with_message(human_status_requirement(entry.kind()))
+    })?;
     let terminal = entry.into_transition(
         status,
         context.clock.now(),
@@ -27,4 +28,22 @@ pub fn confirm(
         status,
         index_rebuild_required: commit.index_rebuild_required(),
     })
+}
+
+fn human_status_requirement(kind: crate::MemoryKind) -> &'static str {
+    match kind {
+        crate::MemoryKind::Goal => {
+            "For a goal, the human terminal statuses are achieved and abandoned."
+        }
+        crate::MemoryKind::Decision => {
+            "For a decision, the only human terminal status is superseded."
+        }
+        crate::MemoryKind::Unknown => "For an unknown, the only human terminal status is resolved.",
+        crate::MemoryKind::Assumption => {
+            "For an assumption, the only human terminal status is confirmed."
+        }
+        crate::MemoryKind::Evidence | crate::MemoryKind::Invariant => {
+            "Evidence and invariant entries have no human terminal status; do not confirm them."
+        }
+    }
 }

--- a/tooling/agent-memory/src/memory/sensitive.rs
+++ b/tooling/agent-memory/src/memory/sensitive.rs
@@ -1,12 +1,39 @@
-pub(crate) fn contains_sensitive(value: &str) -> bool {
+pub(crate) fn rejection_reason(value: &str) -> Option<&'static str> {
     let lowercase = value.to_ascii_lowercase();
-    has_private_pem(&lowercase)
-        || has_url_userinfo(&lowercase)
-        || has_authorization_header(&lowercase)
-        || has_secret_assignment(&lowercase)
-        || has_credential_prefix(&lowercase)
-        || has_system_prompt_marker(&lowercase)
-        || has_transcript_block(&lowercase)
+    if has_private_pem(&lowercase) {
+        return Some("Remove the private-key PEM material; retain only a safe durable summary.");
+    }
+    if has_url_userinfo(&lowercase) {
+        return Some(
+            "Remove URL userinfo credentials; retain a safe reference without authentication data.",
+        );
+    }
+    if has_authorization_header(&lowercase) {
+        return Some(
+            "Remove the authorization header; authentication material cannot be persisted.",
+        );
+    }
+    if has_secret_assignment(&lowercase) {
+        return Some(
+            "Remove the secret assignment (password, secret, token, or API key); retain only a safe durable summary.",
+        );
+    }
+    if has_credential_prefix(&lowercase) {
+        return Some(
+            "Remove the credential with a recognized token prefix; do not encode it to evade detection.",
+        );
+    }
+    if has_system_prompt_marker(&lowercase) {
+        return Some(
+            "Remove the private prompt identified by a system-prompt marker; retain only a safe durable summary.",
+        );
+    }
+    if has_transcript_block(&lowercase) {
+        return Some(
+            "Replace the role-prefixed transcript with a safe durable summary; raw conversations cannot be persisted.",
+        );
+    }
+    None
 }
 
 fn has_private_pem(value: &str) -> bool {

--- a/tooling/agent-memory/src/memory/source.rs
+++ b/tooling/agent-memory/src/memory/source.rs
@@ -75,16 +75,16 @@ impl ResolvedDraft {
     }
 
     pub fn recheck_sources(&self, context: &SourceContext<'_>) -> Result<(), MemoryError> {
-        for expected in &self.sources {
+        for (index, expected) in self.sources.iter().enumerate() {
             let actual = match resolve_source(expected.kind, &expected.locator, context) {
                 Ok(actual) => actual,
                 Err(error) if error.class() == super::MemoryErrorClass::Rejection => {
-                    return Err(source_changed());
+                    return Err(source_changed().at_item(index));
                 }
-                Err(error) => return Err(error),
+                Err(error) => return Err(error.at_item(index)),
             };
             if actual.fingerprint != expected.fingerprint {
-                return Err(source_changed());
+                return Err(source_changed().at_item(index));
             }
         }
         Ok(())
@@ -107,13 +107,17 @@ pub fn resolve_sources(
         .iter()
         .any(|source| source.kind() == SourceKind::UserDecision);
     if has_official_url && !has_user_decision {
-        return Err(source_invalid());
+        return Err(source_invalid().with_message("An official-url requires a user-decision source recording the user-approved primary domain; do not infer officiality from a successful fetch."));
     }
     let sources = draft
         .proof()
         .sources()
         .iter()
-        .map(|source| resolve_draft_source(source.kind(), source.locator(), context))
+        .enumerate()
+        .map(|(index, source)| {
+            resolve_draft_source(source.kind(), source.locator(), context)
+                .map_err(|error| error.at_item(index))
+        })
         .collect::<Result<Vec<_>, _>>()?;
     Ok(ResolvedDraft { draft, sources })
 }
@@ -165,9 +169,13 @@ fn resolve_draft_git_file(
     let path = resolved_regular_path(&cwd.join(relative))?;
     let worktree = git_worktree(context)?;
     if !cwd.starts_with(&worktree) || !path.starts_with(&worktree) {
-        return Err(source_invalid());
+        return Err(source_invalid()
+            .with_message("The resolved Git source must remain inside the current worktree."));
     }
-    let relative = path.strip_prefix(&worktree).map_err(|_| source_invalid())?;
+    let relative = path.strip_prefix(&worktree).map_err(|_| {
+        source_invalid()
+            .with_message("The resolved Git source must remain inside the current worktree.")
+    })?;
     validate_relative_git_path(relative)?;
     validate_tracked(relative, &worktree, context)?;
     let locator = relative.to_str().ok_or_else(source_unavailable)?.to_owned();
@@ -180,7 +188,8 @@ fn resolve_git_file(locator: &str, context: &SourceContext<'_>) -> Result<Vec<u8
     let worktree = git_worktree(context)?;
     let path = resolved_regular_path(&worktree.join(relative))?;
     if !path.starts_with(&worktree) {
-        return Err(source_invalid());
+        return Err(source_invalid()
+            .with_message("The resolved Git source must remain inside the current worktree."));
     }
     validate_tracked(relative, &worktree, context)?;
     read_bounded_regular_file(&path)
@@ -193,7 +202,7 @@ fn validate_relative_git_path(relative: &Path) -> Result<(), MemoryError> {
             .components()
             .all(|component| matches!(component, Component::Normal(_)))
     {
-        return Err(source_invalid());
+        return Err(source_invalid().with_message("Use a nonempty relative Git file path with normal components, without parent traversal or a leading dot component."));
     }
     Ok(())
 }
@@ -223,7 +232,7 @@ fn validate_tracked(
         .map_err(|_| source_unavailable())?;
     if !output.success() {
         return if output.code() == Some(1) {
-            Err(source_invalid())
+            Err(source_invalid().with_message("The Git proof file must be tracked in the current worktree; choose a tracked primary source."))
         } else {
             Err(source_unavailable())
         };
@@ -239,20 +248,28 @@ fn validate_tracked(
 fn resolve_local_file(locator: &str) -> Result<Vec<u8>, MemoryError> {
     let path = Path::new(locator);
     if !path.is_absolute() {
-        return Err(source_invalid());
+        return Err(source_invalid().with_message("Use an absolute path for a local-file source."));
     }
     let path = resolved_regular_path(path)?;
     read_bounded_regular_file(&path)
 }
 
 fn resolved_regular_path(path: &Path) -> Result<PathBuf, MemoryError> {
-    let parent = path.parent().ok_or_else(source_invalid)?;
-    let name = path.file_name().ok_or_else(source_invalid)?;
+    let parent = path.parent().ok_or_else(|| {
+        source_invalid()
+            .with_message("Provide a file path with a parent directory and a file name.")
+    })?;
+    let name = path.file_name().ok_or_else(|| {
+        source_invalid()
+            .with_message("Provide a file path with a parent directory and a file name.")
+    })?;
     let parent = parent.canonicalize().map_err(classify_local_error)?;
     let resolved = parent.join(name);
     let metadata = fs::symlink_metadata(&resolved).map_err(classify_local_error)?;
     if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
-        return Err(source_invalid());
+        return Err(source_invalid().with_message(
+            "The final source path must be a regular file, not a symlink or directory.",
+        ));
     }
     Ok(resolved)
 }
@@ -267,10 +284,10 @@ fn read_bounded_regular_file(path: &Path) -> Result<Vec<u8>, MemoryError> {
     let mut file = File::from(descriptor);
     let metadata = file.metadata().map_err(|_| source_unavailable())?;
     if !metadata.file_type().is_file() {
-        return Err(source_invalid());
+        return Err(source_invalid().with_message("The opened source must be a regular file."));
     }
     if metadata.len() > MAX_SOURCE_BYTES {
-        return Err(source_unavailable());
+        return Err(source_unavailable().with_message("The source body must be at most 1048576 bytes (1 MiB); select a bounded primary source."));
     }
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
     file.by_ref()
@@ -278,7 +295,7 @@ fn read_bounded_regular_file(path: &Path) -> Result<Vec<u8>, MemoryError> {
         .read_to_end(&mut bytes)
         .map_err(|_| source_unavailable())?;
     if bytes.len() as u64 > MAX_SOURCE_BYTES {
-        return Err(source_unavailable());
+        return Err(source_unavailable().with_message("The source body must be at most 1048576 bytes (1 MiB); select a bounded primary source."));
     }
     Ok(bytes)
 }
@@ -287,7 +304,7 @@ fn resolve_official_url(
     locator: &str,
     context: &SourceContext<'_>,
 ) -> Result<Vec<u8>, MemoryError> {
-    let url = validated_https_url(locator).map_err(|_| source_invalid())?;
+    let url = validated_https_url(locator).map_err(|_| source_invalid().with_message("Use an HTTPS URL with a domain name, without credentials, literal IP addresses or fragments."))?;
     let temporary = create_private_temporary(context)?;
     let max_time = curl_max_time(context.curl)?;
     let arguments = curl_arguments(temporary.path(), url.as_str(), &max_time);
@@ -391,13 +408,13 @@ fn validate_curl_result(
     metadata: &CurlMetadata,
 ) -> Result<(), MemoryError> {
     if !allowed_https_url(&metadata.final_url) {
-        return Err(source_invalid());
+        return Err(source_invalid().with_message("The final redirected URL must be HTTPS with a domain name, without credentials, literal IP addresses or fragments."));
     }
     if matches!(metadata.status, 404 | 410) && output.code() == Some(22) {
-        return Err(source_invalid());
+        return Err(source_invalid().with_message("The official URL returned HTTP 404 or 410; revalidate the primary reference before replacing it."));
     }
     if !output.success() || !matches!(metadata.status, 200..=299) {
-        return Err(source_unavailable());
+        return Err(source_unavailable().with_message("The HTTPS fetch did not complete with HTTP 2xx within 5 redirects, 5 seconds to connect, 15 seconds total, and 1048576 body bytes; restore access to the primary source."));
     }
     Ok(())
 }
@@ -421,7 +438,7 @@ fn classify_local_error(error: io::Error) -> MemoryError {
 
 fn classify_local_io_kind(kind: io::ErrorKind) -> MemoryError {
     if kind == io::ErrorKind::NotFound {
-        source_invalid()
+        source_invalid().with_message("The proof file or its parent directory does not exist; provide an existing primary source.")
     } else {
         source_unavailable()
     }

--- a/tooling/agent-memory/src/memory/validation.rs
+++ b/tooling/agent-memory/src/memory/validation.rs
@@ -1,3 +1,5 @@
+mod diagnostics;
+
 use super::error::MemoryError;
 use super::model::{
     AdmissionAuthorization, AdmissionDraft, EntryData, EntryProof, EntryScope, EntrySource,
@@ -18,7 +20,8 @@ pub fn parse_draft(bytes: &[u8]) -> Result<AdmissionDraft, MemoryError> {
     let value = parse_value(input)?;
     validate_schema_version(&value)?;
     validate_source_kinds(&value)?;
-    let raw: RawDraftKind = deserialize(input)?;
+    let raw: RawDraftKind =
+        deserialize(input).map_err(|error| diagnostics::draft_error(value, error))?;
     let (kind, data) = raw.split();
     Ok(AdmissionDraft { kind, data })
 }
@@ -47,9 +50,11 @@ pub fn validate_draft(
         .proof
         .sources
         .into_iter()
-        .map(|source| {
+        .enumerate()
+        .map(|(index, source)| {
             let (kind, locator) = source.split();
-            reject_persisted_text(&locator, "proof.sources.locator")?;
+            reject_persisted_text(&locator, "proof.sources.locator")
+                .map_err(|error| error.at_item(index))?;
             Ok(ValidatedDraftSource::new(kind, locator))
         })
         .collect::<Result<Vec<_>, MemoryError>>()?;
@@ -138,9 +143,11 @@ fn validated_entry_proof(proof: super::model::RawEntryProof) -> Result<EntryProo
     let sources = proof
         .sources
         .into_iter()
-        .map(|source| {
+        .enumerate()
+        .map(|(index, source)| {
             let (kind, locator, fingerprint_value) = source.split();
-            reject_persisted_text(&locator, "proof.sources.locator")?;
+            reject_persisted_text(&locator, "proof.sources.locator")
+                .map_err(|error| error.at_item(index))?;
             Ok(EntrySource::new(
                 kind,
                 locator,
@@ -213,25 +220,16 @@ fn checked_input(bytes: &[u8]) -> Result<&str, MemoryError> {
 fn parse_value(input: &str) -> Result<Value, MemoryError> {
     serde_yaml_ng::from_str(input).map_err(|error| {
         if error.to_string().to_ascii_lowercase().contains("duplicate") {
-            MemoryError::new("duplicate_field", "document")
+            diagnostics::yaml_error("duplicate_field", &error)
         } else {
-            MemoryError::new("malformed_yaml", "document")
+            diagnostics::yaml_error("malformed_yaml", &error)
         }
     })
 }
 
 fn deserialize<T: DeserializeOwned>(input: &str) -> Result<T, MemoryError> {
     let deserializer = serde_yaml_ng::Deserializer::from_str(input);
-    serde_path_to_error::deserialize(deserializer).map_err(|error| {
-        let message = error.inner().to_string().to_ascii_lowercase();
-        if message.contains("unknown field") {
-            MemoryError::new("unknown_field", "document")
-        } else if message.contains("unknown variant") && error.path().to_string().contains("kind") {
-            MemoryError::new("invalid_source_kind", "proof.sources.kind")
-        } else {
-            MemoryError::new("invalid_field", "document")
-        }
-    })
+    serde_path_to_error::deserialize(deserializer).map_err(diagnostics::deserialize_error)
 }
 
 fn validate_schema_version(value: &Value) -> Result<(), MemoryError> {
@@ -258,20 +256,21 @@ fn validate_source_kinds(value: &Value) -> Result<(), MemoryError> {
     else {
         return Ok(());
     };
-    for source in sources {
+    for (index, source) in sources.iter().enumerate() {
         let kind = source
             .as_mapping()
             .and_then(|source| nested(source, "kind"))
             .and_then(Value::as_str)
-            .ok_or_else(|| MemoryError::new("invalid_field", "proof.sources.kind"))?;
+            .ok_or_else(|| {
+                MemoryError::new("invalid_field", "proof.sources.kind").at_item(index)
+            })?;
         if !matches!(
             kind,
             "git-file" | "local-file" | "official-url" | "user-decision"
         ) {
-            return Err(MemoryError::new(
-                "invalid_source_kind",
-                "proof.sources.kind",
-            ));
+            return Err(
+                MemoryError::new("invalid_source_kind", "proof.sources.kind").at_item(index),
+            );
         }
     }
     Ok(())
@@ -339,9 +338,12 @@ fn retrieval_terms(values: Vec<String>) -> Result<Vec<RetrievalTerm>, MemoryErro
     }
     values
         .into_iter()
-        .map(|value| {
-            validate_text(&value, 1, 100, "retrieval_terms")?;
-            reject_persisted_text(&value, "retrieval_terms")?;
+        .enumerate()
+        .map(|(index, value)| {
+            validate_text(&value, 1, 100, "retrieval_terms")
+                .map_err(|error| error.at_item(index))?;
+            reject_persisted_text(&value, "retrieval_terms")
+                .map_err(|error| error.at_item(index))?;
             Ok(RetrievalTerm::from_validated(value))
         })
         .collect()
@@ -469,7 +471,10 @@ fn validate_text(
     if (minimum..=maximum).contains(&length) {
         Ok(())
     } else {
-        Err(MemoryError::new("invalid_field", field))
+        Err(MemoryError::new("invalid_field", field).with_diagnostic(
+            crate::Diagnostic::new("Adjust the string length to the inclusive bounds; length counts Unicode scalar values, not bytes, graphemes or tokens.")
+                .bounds(minimum, maximum, "unicode_scalars"),
+        ))
     }
 }
 
@@ -477,7 +482,10 @@ fn validate_count(count: usize, maximum: usize, field: &'static str) -> Result<(
     if count <= maximum {
         Ok(())
     } else {
-        Err(MemoryError::new("too_many_items", field))
+        Err(MemoryError::new("too_many_items", field).with_diagnostic(
+            crate::Diagnostic::new("Reduce the number of items to the inclusive maximum.")
+                .bounds(1, maximum, "items"),
+        ))
     }
 }
 
@@ -497,15 +505,15 @@ fn validate_scope_source_kinds(
     mut source_kinds: impl Iterator<Item = SourceKind>,
 ) -> Result<(), MemoryError> {
     if user_scope && source_kinds.any(|kind| kind == SourceKind::GitFile) {
-        Err(MemoryError::new("source_invalid", "proof.sources"))
+        Err(MemoryError::new("source_invalid", "proof.sources").with_message("A git-file source requires project scope; user scope cannot contain Git sources. Do not broaden scope without authorization."))
     } else {
         Ok(())
     }
 }
 
 fn reject_sensitive(value: &str, field: &'static str) -> Result<(), MemoryError> {
-    if sensitive::contains_sensitive(value) {
-        Err(MemoryError::new("sensitive_content", field))
+    if let Some(message) = sensitive::rejection_reason(value) {
+        Err(MemoryError::new("sensitive_content", field).with_message(message))
     } else {
         Ok(())
     }

--- a/tooling/agent-memory/src/memory/validation/diagnostics.rs
+++ b/tooling/agent-memory/src/memory/validation/diagnostics.rs
@@ -1,0 +1,183 @@
+use crate::{Diagnostic, MemoryError};
+use serde_path_to_error::Segment;
+use serde_yaml_ng::Value;
+
+const FIELDS: &[&str] = &[
+    "schema_version",
+    "kind",
+    "statement",
+    "scope",
+    "retrieval_terms",
+    "proof",
+    "proof.summary",
+    "proof.sources",
+    "proof.sources.kind",
+    "proof.sources.locator",
+    "oracle",
+    "oracle.automated",
+    "oracle.automated.kind",
+    "oracle.automated.expected",
+    "oracle.human_fallback",
+    "oracle.human_fallback.question",
+    "oracle.human_fallback.valid_when",
+    "oracle.outcomes",
+    "oracle.outcomes.valid",
+    "oracle.outcomes.invalidated",
+    "id",
+    "status",
+    "scope.key",
+    "proof.sources.fingerprint",
+    "proof.established_at",
+    "created_at",
+    "transition",
+    "transition.from",
+    "transition.to",
+    "transition.at",
+    "transition.verdict",
+    "transition.reason",
+];
+
+pub(super) fn yaml_error(code: &'static str, error: &serde_yaml_ng::Error) -> MemoryError {
+    located(MemoryError::new(code, "document"), error)
+}
+
+pub(super) fn draft_error(mut value: Value, fallback: MemoryError) -> MemoryError {
+    let Some(root) = value.as_mapping_mut() else {
+        return fallback;
+    };
+    let mut kind = root
+        .remove(Value::String("kind".to_owned()))
+        .unwrap_or(Value::Null);
+    while let Value::Tagged(tagged) = kind {
+        kind = tagged.value;
+    }
+    if serde_yaml_ng::from_value::<crate::MemoryKind>(kind).is_err() {
+        return MemoryError::new("invalid_field", "kind");
+    }
+    if let Some(error) = tagged_field(&value, "") {
+        return error;
+    }
+    serde_path_to_error::deserialize::<_, crate::memory::model::RawDraftData>(value)
+        .err()
+        .map(deserialize_error)
+        .unwrap_or(fallback)
+}
+
+pub(super) fn deserialize_error(
+    error: serde_path_to_error::Error<serde_yaml_ng::Error>,
+) -> MemoryError {
+    let mut path = String::new();
+    let mut index = None;
+    for segment in error.path() {
+        match segment {
+            Segment::Map { key } => {
+                let Some(field) = child_field(&path, key) else {
+                    break;
+                };
+                path = field.to_owned();
+            }
+            Segment::Seq { index: position } => index = Some(*position),
+            _ => {}
+        }
+    }
+    let message = error.inner().to_string();
+    let (code, field) = classify(&path, &message);
+    let mut failure = MemoryError::new(code, field);
+    if code == "unknown_field" {
+        failure = failure.with_message(allowed_fields(field));
+    }
+    if let Some(index) = index {
+        failure = failure.at_item(index);
+    }
+    located(failure, error.inner())
+}
+
+fn child_field(parent: &str, key: &str) -> Option<&'static str> {
+    FIELDS.iter().copied().find(|field| {
+        let (prefix, name) = field.rsplit_once('.').unwrap_or(("", field));
+        prefix == parent && name == key
+    })
+}
+
+fn tagged_field(value: &Value, field: &'static str) -> Option<MemoryError> {
+    match value {
+        Value::Tagged(_) => Some(MemoryError::new("invalid_field", field).with_message(
+            "Remove custom YAML tags from this field; use the plain type required by the entry contract.",
+        )),
+        Value::Mapping(mapping) => mapping.iter().find_map(|(key, value)| {
+            let child = child_field(field, key.as_str()?)?;
+            tagged_field(value, child)
+        }),
+        Value::Sequence(values) => values.iter().enumerate().find_map(|(index, value)| {
+            tagged_field(value, field).map(|error| error.at_item(index))
+        }),
+        _ => None,
+    }
+}
+
+fn classify(path: &str, message: &str) -> (&'static str, &'static str) {
+    let field = FIELDS
+        .iter()
+        .copied()
+        .filter(|field| {
+            *field == path
+                || path
+                    .strip_prefix(field)
+                    .is_some_and(|suffix| suffix.starts_with('.'))
+        })
+        .max_by_key(|field| field.len())
+        .unwrap_or("document");
+    if message.starts_with("unknown field") || message.contains(": unknown field") {
+        return ("unknown_field", field);
+    }
+    for candidate in FIELDS {
+        let key = candidate.rsplit('.').next().unwrap();
+        let parent = candidate.rsplit_once('.').map_or("", |(parent, _)| parent);
+        if parent == path && message.contains(&format!("missing field `{key}`")) {
+            return ("invalid_field", candidate);
+        }
+    }
+    if field == "oracle.automated" && message.contains("all-proof-sources-unchanged") {
+        return ("invalid_field", "oracle.automated.expected");
+    }
+    if field == "proof.sources" && message.contains("expected a string") {
+        return ("invalid_field", "proof.sources.locator");
+    }
+    ("invalid_field", field)
+}
+
+fn located(error: MemoryError, yaml: &serde_yaml_ng::Error) -> MemoryError {
+    let Some(location) = yaml.location() else {
+        return error;
+    };
+    let diagnostic = Diagnostic {
+        line: Some(location.line()),
+        column: Some(location.column()),
+        ..error.diagnostic()
+    };
+    error.with_diagnostic(diagnostic)
+}
+
+fn allowed_fields(field: &str) -> &'static str {
+    match field {
+        "proof" => {
+            "Remove extra proof keys; allowed keys are summary and sources (plus established_at only in stored entries)."
+        }
+        "proof.sources" => {
+            "Remove extra source keys; allowed keys are kind and locator (plus fingerprint only in stored entries)."
+        }
+        "oracle" => {
+            "Remove extra oracle keys; allowed keys are automated, human_fallback, outcomes."
+        }
+        "oracle.automated" => {
+            "Remove extra automated oracle keys; allowed keys are kind and expected."
+        }
+        "oracle.human_fallback" => {
+            "Remove extra human_fallback keys; allowed keys are question and valid_when."
+        }
+        "oracle.outcomes" => "Remove extra outcomes keys; allowed keys are valid and invalidated.",
+        _ => {
+            "Remove extra draft keys; allowed top-level keys are schema_version, kind, statement, scope, retrieval_terms, proof, oracle. Runtime-assigned fields must be omitted."
+        }
+    }
+}

--- a/tooling/agent-memory/tests/memory_cli.rs
+++ b/tooling/agent-memory/tests/memory_cli.rs
@@ -4,10 +4,18 @@ mod admission_order;
 mod argument_redaction;
 #[path = "memory_cli/canonical_reads.rs"]
 mod canonical_reads;
+#[path = "memory_cli/diagnostics.rs"]
+mod diagnostics;
 #[path = "memory_cli/error_classes.rs"]
 mod error_classes;
+#[path = "memory_cli/schema_diagnostics.rs"]
+mod schema_diagnostics;
+#[path = "memory_cli/source_diagnostics.rs"]
+mod source_diagnostics;
 #[path = "memory_cli/support.rs"]
 mod support;
+#[path = "memory_cli/text_diagnostics.rs"]
+mod text_diagnostics;
 
 use serde_json::Value;
 use support::*;

--- a/tooling/agent-memory/tests/memory_cli/diagnostics.rs
+++ b/tooling/agent-memory/tests/memory_cli/diagnostics.rs
@@ -1,0 +1,218 @@
+use super::support::*;
+use serde_json::{Value, json};
+
+fn rejection(output: &std::process::Output, code: &str, field: &str) -> Value {
+    assert_error(output, 2, code);
+    let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+    let error = error["error"].clone();
+    assert_eq!(error["field"], field);
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|text| text.len() > 20)
+    );
+    error
+}
+
+#[test]
+fn statement_rejection_supplies_the_boundary_for_a_single_repair() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("invariant", &"é".repeat(558), "diagnostic");
+    let error = rejection(
+        &fixture.run(["admit", "--format", "json"], &draft),
+        "invalid_field",
+        "statement",
+    );
+    assert_eq!(error["minimum"], 1);
+    assert_eq!(error["maximum"], 500);
+    assert_eq!(error["unit"], "unicode_scalars");
+    assert!(!fixture.root().exists());
+    let repaired = fixture.git_draft(
+        "invariant",
+        &"é".repeat(error["maximum"].as_u64().unwrap() as usize),
+        "diagnostic",
+    );
+    assert_exit(&fixture.run(["admit", "--format", "json"], &repaired), 0);
+}
+
+#[test]
+fn nested_schema_errors_name_a_safe_field_and_expected_shape() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("invariant", "Diagnostic memory.", "diagnostic");
+    let mut valid: Value = serde_yaml_ng::from_slice(&draft).unwrap();
+    valid["scope"] = json!("project");
+    let cases = [
+        ("/statement", json!([]), "statement", "string"),
+        ("/scope", json!("private-canary"), "scope", "project"),
+        ("/kind", json!("private-canary"), "kind", "invariant"),
+        (
+            "/proof/summary",
+            json!({"private-canary": "secret"}),
+            "proof.summary",
+            "string",
+        ),
+        (
+            "/oracle/human_fallback/question",
+            json!([]),
+            "oracle.human_fallback.question",
+            "string",
+        ),
+        (
+            "/oracle/automated/expected",
+            json!("private-canary"),
+            "oracle.automated.expected",
+            "all-proof-sources-unchanged",
+        ),
+        (
+            "/proof/sources/0/locator",
+            json!([]),
+            "proof.sources.locator",
+            "string",
+        ),
+    ];
+    for (pointer, value, field, expected) in cases {
+        let mut draft = valid.clone();
+        *draft.pointer_mut(pointer).unwrap() = value;
+        let output = fixture.run(
+            ["admit", "--format", "json"],
+            &serde_json::to_vec(&draft).unwrap(),
+        );
+        let error = rejection(&output, "invalid_field", field);
+        assert!(
+            error["message"].as_str().unwrap().contains(expected),
+            "{error}"
+        );
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("private-canary"));
+    }
+}
+
+#[test]
+fn admission_rejection_classes_explain_the_required_correction() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("invariant", "Diagnostic memory.", "diagnostic");
+    let mut valid: Value = serde_yaml_ng::from_slice(&draft).unwrap();
+    valid["scope"] = json!("project");
+    let cases = [
+        (
+            "/schema_version",
+            json!(2),
+            "unsupported_schema",
+            "schema_version",
+            "1",
+        ),
+        (
+            "/proof/sources",
+            json!([]),
+            "missing_proof",
+            "proof.sources",
+            "source",
+        ),
+        (
+            "/oracle/automated",
+            Value::Null,
+            "missing_oracle",
+            "oracle.automated",
+            "source-fingerprint",
+        ),
+        (
+            "/proof/sources/0/kind",
+            json!("private-canary"),
+            "invalid_source_kind",
+            "proof.sources.kind",
+            "git-file",
+        ),
+        (
+            "/statement",
+            json!("secret=private-canary"),
+            "sensitive_content",
+            "statement",
+            "secret",
+        ),
+        (
+            "/retrieval_terms",
+            json!(vec!["term"; 21]),
+            "too_many_items",
+            "retrieval_terms",
+            "items",
+        ),
+    ];
+    for (pointer, value, code, field, expected) in cases {
+        let mut draft = valid.clone();
+        *draft.pointer_mut(pointer).unwrap() = value;
+        let output = fixture.run(
+            ["admit", "--format", "json"],
+            &serde_json::to_vec(&draft).unwrap(),
+        );
+        let error = rejection(&output, code, field);
+        assert!(
+            error["message"].as_str().unwrap().contains(expected),
+            "{error}"
+        );
+        if code == "too_many_items" {
+            assert_eq!(error["maximum"], 20);
+        }
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("private-canary"));
+    }
+}
+
+#[test]
+fn yaml_errors_provide_locations_without_echoing_keys_or_values() {
+    let fixture = CliFixture::new();
+    for (input, code) in [
+        ("private-canary: [broken", "malformed_yaml"),
+        ("private-canary: 1\nprivate-canary: 2\n", "duplicate_field"),
+    ] {
+        let output = fixture.run(["admit", "--format", "json"], input.as_bytes());
+        let error = rejection(&output, code, "document");
+        assert!(error["line"].as_u64().is_some_and(|line| line > 0));
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("private-canary"));
+    }
+}
+
+#[test]
+fn retrieve_confirm_and_hook_explain_rejections_without_echoing_input() {
+    let fixture = CliFixture::new();
+    rejection(
+        &fixture.run(["retrieve", "--query-stdin", "--format", "json"], b" \n"),
+        "empty_query",
+        "query",
+    );
+    rejection(
+        &fixture.run(["retrieve", "--query-stdin", "--format", "json"], &[255]),
+        "invalid_utf8",
+        "query",
+    );
+    let error = rejection(
+        &fixture.run(
+            [
+                "confirm",
+                "--id",
+                "private-canary",
+                "--status",
+                "confirmed",
+                "--reason-stdin",
+            ],
+            "é".repeat(501).as_bytes(),
+        ),
+        "invalid_field",
+        "transition.reason",
+    );
+    assert_eq!(error["maximum"], 500);
+    for agent in ["claude", "codex"] {
+        let payload = json!({"hook_event_name": "UserPromptSubmit", "prompt": "private-canary", "cwd": "relative"});
+        let output = fixture.run(
+            ["hook", "--agent", agent],
+            &serde_json::to_vec(&payload).unwrap(),
+        );
+        let error = rejection(&output, "invalid_hook_cwd", "cwd");
+        assert!(error["message"].as_str().unwrap().contains("absolute"));
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("private-canary"));
+    }
+    let error = rejection(
+        &fixture.run(["admit", "--format", "json"], &vec![b'a'; 1_048_577]),
+        "input_too_large",
+        "stdin",
+    );
+    assert_eq!(error["maximum"], 1_048_576);
+    assert_eq!(error["unit"], "bytes");
+}

--- a/tooling/agent-memory/tests/memory_cli/schema_diagnostics.rs
+++ b/tooling/agent-memory/tests/memory_cli/schema_diagnostics.rs
@@ -1,0 +1,136 @@
+use super::support::*;
+use serde_json::{Value, json};
+
+#[test]
+fn unknown_keys_identify_the_containing_mapping_without_echoing_the_key() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("invariant", "Schema diagnostics.", "schema");
+    let valid: Value = serde_yaml_ng::from_slice(&draft).unwrap();
+    for (pointer, field, allowed) in [
+        ("/proof", "proof", "summary and sources"),
+        ("/proof/sources/0", "proof.sources", "kind and locator"),
+        (
+            "/oracle/human_fallback",
+            "oracle.human_fallback",
+            "question and valid_when",
+        ),
+    ] {
+        let mut draft = valid.clone();
+        draft.pointer_mut(pointer).unwrap()["private-canary"] = json!("private-value");
+        let output = fixture.run(
+            ["admit", "--format", "json"],
+            &serde_json::to_vec(&draft).unwrap(),
+        );
+        assert_error(&output, 2, "unknown_field");
+        let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error"]["field"], field);
+        assert!(
+            error["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains(allowed)
+        );
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("private-"));
+    }
+}
+
+#[test]
+fn numeric_scalars_remain_rejected_in_persisted_text_fields() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("invariant", "Schema diagnostics.", "schema");
+    let valid: Value = serde_yaml_ng::from_slice(&draft).unwrap();
+    for pointer in [
+        "/statement",
+        "/retrieval_terms/0",
+        "/proof/summary",
+        "/proof/sources/0/locator",
+        "/oracle/human_fallback/question",
+        "/oracle/outcomes/valid",
+    ] {
+        for scalar in [json!(123), json!(true), json!(null), json!(1.2)] {
+            let mut draft = valid.clone();
+            *draft.pointer_mut(pointer).unwrap() = scalar;
+            let output = fixture.run(
+                ["admit", "--format", "json"],
+                &serde_json::to_vec(&draft).unwrap(),
+            );
+            assert_error(&output, 2, "invalid_field");
+        }
+    }
+}
+
+#[test]
+fn custom_yaml_tags_are_rejected_with_a_safe_repair() {
+    let fixture = CliFixture::new();
+    let draft =
+        String::from_utf8(fixture.git_draft("invariant", "Schema diagnostics.", "schema")).unwrap();
+    for (from, to, field) in [
+        ("statement:", "statement: !private-canary", "statement"),
+        ("summary:", "summary: !private-canary", "proof.summary"),
+        ("proof:", "proof: !private-canary", "proof"),
+    ] {
+        let output = fixture.run(
+            ["admit", "--format", "json"],
+            draft.replace(from, to).as_bytes(),
+        );
+        assert_error(&output, 2, "invalid_field");
+        let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error"]["field"], field);
+        assert!(error["error"]["message"].as_str().unwrap().contains("tag"));
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("private-canary"));
+    }
+    let output = fixture.run(
+        ["admit", "--format", "json"],
+        draft
+            .replace("kind: invariant", "kind: !custom invariant")
+            .as_bytes(),
+    );
+    assert_exit(&output, 0);
+}
+
+#[test]
+fn an_accepted_kind_tag_does_not_hide_the_actual_rejected_field() {
+    let fixture = CliFixture::new();
+    let draft =
+        String::from_utf8(fixture.git_draft("invariant", "Schema diagnostics.", "schema")).unwrap();
+    let draft = draft
+        .replace("kind: invariant", "kind: !custom invariant")
+        .replace("statement: \"Schema diagnostics.\"", "statement: []");
+    let output = fixture.run(["admit", "--format", "json"], draft.as_bytes());
+    assert_error(&output, 2, "invalid_field");
+    let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(error["error"]["field"], "statement");
+}
+
+#[test]
+fn missing_nested_fields_identify_the_required_field() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("invariant", "Schema diagnostics.", "schema");
+    let valid: Value = serde_yaml_ng::from_slice(&draft).unwrap();
+    for (pointer, key, field) in [
+        ("", "statement", "statement"),
+        ("/proof", "summary", "proof.summary"),
+        ("/proof/sources/0", "locator", "proof.sources.locator"),
+        (
+            "/oracle/human_fallback",
+            "question",
+            "oracle.human_fallback.question",
+        ),
+        ("/oracle/automated", "expected", "oracle.automated.expected"),
+    ] {
+        let mut draft = valid.clone();
+        draft
+            .pointer_mut(pointer)
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove(key);
+        let output = fixture.run(
+            ["admit", "--format", "json"],
+            &serde_json::to_vec(&draft).unwrap(),
+        );
+        assert_error(&output, 2, "invalid_field");
+        let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error"]["field"], field);
+    }
+}

--- a/tooling/agent-memory/tests/memory_cli/source_diagnostics.rs
+++ b/tooling/agent-memory/tests/memory_cli/source_diagnostics.rs
@@ -1,0 +1,120 @@
+use super::support::*;
+use serde_json::{Value, json};
+
+#[test]
+fn source_rejections_identify_the_criterion_and_source_without_its_locator() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("invariant", "Source diagnostics.", "source diagnostics");
+    let valid: Value = serde_yaml_ng::from_slice(&draft).unwrap();
+    std::fs::write(fixture.repository().join("private-canary"), "proof").unwrap();
+    let cases = [
+        ("git-file", "../private-canary", "relative"),
+        ("git-file", "missing-private-canary", "does not exist"),
+        ("git-file", "private-canary", "tracked"),
+        ("local-file", "private-canary", "absolute"),
+        ("official-url", "http://private-canary.example", "HTTPS"),
+    ];
+    for (kind, locator, expected) in cases {
+        let mut draft = valid.clone();
+        draft["proof"]["sources"] = json!([
+            {"kind": "user-decision", "locator": "The user approved the primary domain."},
+            {"kind": kind, "locator": locator},
+        ]);
+        let output = fixture.run(
+            ["admit", "--format", "json"],
+            &serde_json::to_vec(&draft).unwrap(),
+        );
+        assert_error(&output, 2, "source_invalid");
+        let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error"]["item_index"], 1);
+        assert!(
+            error["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains(expected),
+            "{error}"
+        );
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("private-canary"));
+    }
+}
+
+#[test]
+fn official_url_requires_an_explicit_user_decision_before_fetching() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("invariant", "Source diagnostics.", "source diagnostics");
+    let mut draft: Value = serde_yaml_ng::from_slice(&draft).unwrap();
+    draft["proof"]["sources"][0] =
+        json!({"kind": "official-url", "locator": "https://unused.invalid"});
+    let output = fixture.run(
+        ["admit", "--format", "json"],
+        &serde_json::to_vec(&draft).unwrap(),
+    );
+    assert_error(&output, 2, "source_invalid");
+    let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("user-decision")
+    );
+}
+
+#[test]
+fn oversized_source_keeps_unavailable_exit_and_names_the_size_limit() {
+    let fixture = CliFixture::new();
+    std::fs::write(
+        fixture.repository().join("proof.txt"),
+        vec![b'a'; 1_048_577],
+    )
+    .unwrap();
+    let draft = fixture.git_draft("invariant", "Source diagnostics.", "source diagnostics");
+    let output = fixture.run(["admit", "--format", "json"], &draft);
+    assert_error(&output, 4, "source_unavailable");
+    let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("1048576")
+    );
+}
+
+#[test]
+fn incompatible_confirmation_names_the_actual_kinds_allowed_statuses() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("decision", "Source diagnostics.", "source diagnostics");
+    let stored = fixture.run(["admit", "--format", "json"], &draft);
+    let stored = stdout_json(&stored);
+    let id = stored["id"].as_str().unwrap();
+    let output = fixture.run(
+        [
+            "confirm",
+            "--id",
+            id,
+            "--status",
+            "achieved",
+            "--reason-stdin",
+        ],
+        b"A human concluded the decision.",
+    );
+    assert_error(&output, 2, "invalid_human_conclusion");
+    let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(
+        error["error"]["message"],
+        "For a decision, the only human terminal status is superseded."
+    );
+    assert_exit(
+        &fixture.run(
+            [
+                "confirm",
+                "--id",
+                id,
+                "--status",
+                "superseded",
+                "--reason-stdin",
+            ],
+            b"A human concluded the decision.",
+        ),
+        0,
+    );
+}

--- a/tooling/agent-memory/tests/memory_cli/text_diagnostics.rs
+++ b/tooling/agent-memory/tests/memory_cli/text_diagnostics.rs
@@ -1,0 +1,123 @@
+use super::support::*;
+use serde_json::{Value, json};
+
+#[test]
+fn every_bounded_text_field_returns_a_usable_unicode_limit() {
+    for (pointer, field, maximum) in [
+        ("/statement", "statement", 500),
+        ("/retrieval_terms/0", "retrieval_terms", 100),
+        ("/proof/summary", "proof.summary", 1000),
+        (
+            "/oracle/human_fallback/question",
+            "oracle.human_fallback.question",
+            500,
+        ),
+        (
+            "/oracle/human_fallback/valid_when",
+            "oracle.human_fallback.valid_when",
+            500,
+        ),
+        ("/oracle/outcomes/valid", "oracle.outcomes.valid", 500),
+        (
+            "/oracle/outcomes/invalidated",
+            "oracle.outcomes.invalidated",
+            500,
+        ),
+    ] {
+        let fixture = CliFixture::new();
+        let draft = fixture.git_draft("invariant", "Text diagnostics.", "text");
+        let mut draft: Value = serde_yaml_ng::from_slice(&draft).unwrap();
+        for text in [String::new(), "é".repeat(maximum + 1)] {
+            *draft.pointer_mut(pointer).unwrap() = json!(text);
+            let output = fixture.run(
+                ["admit", "--format", "json"],
+                &serde_json::to_vec(&draft).unwrap(),
+            );
+            assert_error(&output, 2, "invalid_field");
+            let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+            assert_eq!(error["error"]["field"], field);
+            assert_eq!(error["error"]["maximum"], maximum);
+            assert_eq!(error["error"]["minimum"], 1);
+            assert_eq!(error["error"]["unit"], "unicode_scalars");
+        }
+        *draft.pointer_mut(pointer).unwrap() = json!("é".repeat(maximum));
+        assert_exit(
+            &fixture.run(
+                ["admit", "--format", "json"],
+                &serde_json::to_vec(&draft).unwrap(),
+            ),
+            0,
+        );
+    }
+}
+
+#[test]
+fn sensitive_rejections_name_the_pattern_without_echoing_the_content() {
+    let fixture = CliFixture::new();
+    for (text, criterion) in [
+        ("-----BEGIN PRIVATE KEY----- private-canary", "PEM"),
+        ("https://private-canary@example.invalid", "userinfo"),
+        ("Authorization: private-canary", "header"),
+        ("password=private-canary", "assignment"),
+        ("ghp_private-canary", "prefix"),
+        ("system prompt: private-canary", "marker"),
+        ("user: private-canary\nassistant: private-canary", "role"),
+    ] {
+        let draft = fixture.git_draft("invariant", text, "text");
+        let output = fixture.run(["admit", "--format", "json"], &draft);
+        assert_error(&output, 2, "sensitive_content");
+        let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert!(
+            error["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains(criterion),
+            "{error}"
+        );
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("private-canary"));
+    }
+}
+
+#[test]
+fn list_member_rejections_locate_the_offending_item() {
+    let fixture = CliFixture::new();
+    let draft = fixture.git_draft("invariant", "Text diagnostics.", "text");
+    let valid: Value = serde_yaml_ng::from_slice(&draft).unwrap();
+    for (field, items, code) in [
+        (
+            "retrieval_terms",
+            json!(["text", "é".repeat(101)]),
+            "invalid_field",
+        ),
+        (
+            "retrieval_terms",
+            json!(["text", "secret=private-canary"]),
+            "sensitive_content",
+        ),
+        (
+            "sources",
+            json!([{"kind": "git-file", "locator": "proof.txt"}, {"kind": "private-canary", "locator": "unused"}]),
+            "invalid_source_kind",
+        ),
+        (
+            "sources",
+            json!([{"kind": "git-file", "locator": "proof.txt"}, {"kind": "user-decision", "locator": "secret=private-canary"}]),
+            "sensitive_content",
+        ),
+    ] {
+        let mut draft = valid.clone();
+        if field == "sources" {
+            draft["proof"][field] = items;
+        } else {
+            draft[field] = items;
+        }
+        let output = fixture.run(
+            ["admit", "--format", "json"],
+            &serde_json::to_vec(&draft).unwrap(),
+        );
+        assert_error(&output, 2, code);
+        let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error"]["item_index"], 1);
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("private-canary"));
+    }
+}


### PR DESCRIPTION
## Description

An otherwise valid admission with an overlong statement returned only `invalid_field` and `statement`, leaving callers unable to identify the violated constraint. Other validation, source, confirmation, and hook failures similarly discarded useful diagnostic context.

Return redacted criterion messages, inclusive bounds with explicit units, known schema field paths, and safe list indices or parser locations. Distinguish source prerequisites and sensitive-content patterns, and report the compatible human status for the actual entry kind. Diagnostic text never incorporates rejected values, arbitrary keys, paths, URLs, prompts, or transcripts.

Keep the existing admission parser authoritative and run richer schema diagnosis only after rejection, preserving scalar and YAML-tag acceptance. The statement cap remains 500 Unicode scalar values. The canonical entry contract now documents field bounds, source requirements, content exclusions, command inputs, and recovery guidance. Exit statuses remain `0` success/duplicate, `2` rejection/usage, `3` conflict, and `4` unavailable; diagnostic fields are added and inaccurate field paths are corrected.

Existing validation and source modules remain cohesive to preserve control ordering; new diagnostic responsibilities are separate. No comments were added. The shared memory store and installed binary were not modified.

## Useful Links

- Accepted authority: [ADR-042 — Mémoire durable locale partagée](https://github.com/SebastienElet/dotfiles/blob/main/docs/adr/042-memoire-durable-locale-partagee.md)
- Canonical contract: `harness/skills/memory-governance/references/entry-contract.md`

## How to Test

- `moon run tooling/agent-memory:fmt tooling/agent-memory:clippy tooling/agent-memory:test`
- `cargo test --manifest-path tooling/agent-memory/Cargo.toml --test memory_cli diagnostics`
- Run Prettier on `harness/skills/memory-governance/references/entry-contract.md`.

Local macOS arm64 validation: all 260 tests pass, including 17 new CLI tests, plus Rust formatting, Clippy and contract formatting. The tests use temporary repositories and stores and exercise the real executable. Red/green witnesses cover actionable bounds, one-step repair with multibyte text, nested schema errors, sensitive-content redaction, source causes, confirmation compatibility, and unchanged scalar/tag acceptance. Independent review findings were corrected and verified.

Linux validation is left to the existing macOS/Ubuntu CI matrix; remote CI is required before merge.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
