### PR TITLE
Migrate workstation orchestration from Make to Moon

### DIFF
--- a/.github/workflows/check-typescript.yml
+++ b/.github/workflows/check-typescript.yml
@@ -16,6 +16,8 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095
+      - name: Validate Moon workspace
+        run: moon query tasks >/dev/null
       - run: >-
           moon ci repository:typescript-lint repository:typescript-typecheck
           repository:typescript-format-check repository:prettier-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,18 @@ on:
   pull_request:
 
 jobs:
-  minimal:
-    name: Minimal macOS profile
+  moon-install:
+    name: Disposable macOS Moon install
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-      - run: make smoke-minimal
+        with:
+          fetch-depth: 0
+      - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095
+        with:
+          auto-setup: true
+      - name: Install repository dependencies through Moon
+        run: moon exec --ignore-ci-checks repository:dependencies
+      - name: Install workstation through Moon
+        run: moon exec --ignore-ci-checks workstation:install

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -4,6 +4,7 @@ projects:
   tooling/agent-handoff: tooling/agent-handoff
   tooling/agent-memory: tooling/agent-memory
   tooling/arnes: tooling/arnes
+  workstation: workstation
 
 vcs:
   defaultBranch: main

--- a/harness/moon.yml
+++ b/harness/moon.yml
@@ -12,9 +12,17 @@ tasks:
     command: noop
     deps:
       - ~:semctx-install
+  install-hosts:
+    description: Install supported agent hosts through existing leaf recipes
+    command: make claude-code codex
+    options:
+      mutex: harness-mutation
+      os: macos
   semctx-install:
     description: Install or update Semctx plugins for detected agent hosts
     command: bun run semctx install --host auto --skip-setup --json
+    deps:
+      - ~:install-hosts
     options:
       mutex: harness-mutation
       outputStyle: stream
@@ -27,3 +35,11 @@ tasks:
   semctx-status:
     description: Inspect local Semctx plugin delivery without network attestation
     command: bun run semctx plugin-status --host auto --json
+  install-cursor:
+    description: Install Cursor harness through its existing leaf recipe
+    command: make cursor
+    deps:
+      - ~:install
+    options:
+      mutex: harness-mutation
+      os: macos

--- a/moon.yml
+++ b/moon.yml
@@ -36,6 +36,13 @@ fileGroups:
     - bun.lock
 
 tasks:
+  dependencies:
+    command: bun install --frozen-lockfile
+    inputs:
+      - package.json
+      - bun.lock
+    options:
+      cache: false
   typescript-lint:
     command: bun --config=/dev/null --no-env-file tooling/lint-typescript.ts
     inputs:
@@ -54,6 +61,14 @@ tasks:
     inputs:
       - "@group(trackedTypeScript)"
       - "@group(typescriptToolchain)"
+  typescript-test:
+    command: bun --config=/dev/null --no-env-file test --timeout 15000
+    inputs:
+      - "@group(trackedTypeScript)"
+      - package.json
+      - bun.lock
+    options:
+      cache: false
   prettier-check:
     command: >-
       bun run prettier --check "**/*.{yml,yaml,md,json}"

--- a/workstation/moon.yml
+++ b/workstation/moon.yml
@@ -1,0 +1,160 @@
+language: typescript
+layer: configuration
+
+taskOptions:
+  cache: false
+  os: macos
+  runFromWorkspaceRoot: true
+  runInCI: false
+
+tasks:
+  install:
+    description: Install the development workstation
+    command: noop
+    deps:
+      - ~:artifacts-minimal
+      - harness:install
+    options:
+      runDepsInParallel: false
+  install-optional:
+    description: Install the workstation and optional capabilities
+    command: noop
+    deps:
+      - ~:install
+      - ~:optional-artifacts
+    options:
+      runDepsInParallel: false
+  verify:
+    description: Run every repository verification task
+    command: noop
+    deps:
+      - repository:typescript-lint
+      - repository:typescript-typecheck
+      - repository:typescript-format-check
+      - repository:typescript-test
+      - repository:prettier-check
+      - repository:fish-syntax
+      - repository:fish-format
+      - repository:fish-test
+      - tooling/arnes:fmt
+      - tooling/arnes:clippy
+      - tooling/arnes:check
+      - tooling/arnes:test
+      - tooling/agent-memory:fmt
+      - tooling/agent-memory:clippy
+      - tooling/agent-memory:test
+      - tooling/agent-handoff:fmt
+      - tooling/agent-handoff:clippy
+      - tooling/agent-handoff:test
+  bootstrap:
+    command: make bootstrap
+  homebrew:
+    command: make brew
+    deps:
+      - ~:bootstrap
+    options:
+      mutex: homebrew
+  packages-minimal:
+    command: make bundle-minimal
+    deps:
+      - ~:homebrew
+    options:
+      mutex: homebrew
+  artifacts-minimal:
+    command: noop
+    deps:
+      - ~:bat
+      - ~:fish
+      - ~:nvim
+      - ~:wezterm
+      - ~:git-delta
+      - ~:tmux
+      - ~:pnpm
+      - ~:hunspell
+      - ~:colgrep-search
+    options:
+      internal: true
+      runDepsInParallel: false
+  bat:
+    command: make bat
+    deps: [~:packages-minimal]
+  fish:
+    command: make fish
+    deps: [~:packages-minimal]
+  nvim:
+    command: make nvim
+    deps: [~:packages-minimal]
+  wezterm:
+    command: make wezterm
+    deps: [~:packages-minimal]
+  git-delta:
+    command: make git-delta
+    deps: [~:packages-minimal]
+  tmux:
+    command: make tmux
+    deps: [~:packages-minimal]
+  node:
+    command: make node
+    deps: [~:packages-minimal]
+    options:
+      mutex: volta
+  pnpm:
+    command: make pnpm
+    deps: [~:node]
+    options:
+      mutex: volta
+  hunspell:
+    command: make hunspell
+    deps: [~:packages-minimal]
+  colgrep-search:
+    command: make "$HOME/.local/bin/colgrep-search"
+    deps: [~:packages-minimal]
+  packages-optional:
+    command: make bundle-optional
+    deps: [~:packages-minimal]
+    options:
+      mutex: homebrew
+  optional-artifacts:
+    command: noop
+    deps:
+      - ~:packages-optional
+      - ~:cspell
+      - harness:install-cursor
+      - ~:cloakbrowser
+      - ~:scrapling
+      - ~:postgresql
+      - ~:daisydisk
+      - ~:things-3
+    options:
+      internal: true
+      runDepsInParallel: false
+  cspell:
+    command: make cspell
+    deps:
+      - ~:packages-optional
+      - ~:node
+    options:
+      mutex: volta
+  cloakbrowser:
+    command: make cloakbrowser
+    deps: [~:packages-optional]
+    options:
+      mutex: docker
+  scrapling:
+    command: make scrapling
+    deps: [~:packages-optional]
+    options:
+      mutex: docker
+  postgresql:
+    command: make postgresql
+    deps: [~:packages-optional]
+  daisydisk:
+    command: make daisydisk
+    deps: [~:packages-optional]
+  things-3:
+    command: make things-3
+    deps:
+      - ~:packages-optional
+      - ~:node
+    options:
+      mutex: volta


### PR DESCRIPTION
## Objet

Faire de Moon le graphe d’orchestration du poste, avec deux entrées publiques :

- `moon run workstation:install`
- `moon run workstation:install-optional`

Le harnais fait partie du profil minimal et `harness:install` installe d’abord les hôtes supportés, puis Semctx directement avec sa CLI.

## Validation

- `moon query tasks` charge et valide nativement le workspace en CI
- un runner macOS jetable exécute les dépendances puis `workstation:install` via Moon
- Prettier et actionlint passent localement

## Périmètre

La PR contient 206 ajouts et 4 suppressions dans six fichiers. Elle n’ajoute aucun utilitaire TypeScript ni test qui reparcourt les déclarations Moon.

Les recettes Make existantes restent provisoirement les implémentations feuilles ; Moon porte désormais leur ordre et leurs dépendances. Leur migration pourra donc être faite composant par composant sans réécrire tout l’installateur dans cette PR.
