### PR TITLE
fix(arnes): support Codex skill name selectors

### DIFF
--- a/tooling/arnes/src/skills/external/codex.rs
+++ b/tooling/arnes/src/skills/external/codex.rs
@@ -1,48 +1,21 @@
 use super::model::{Exposure, Plugin, Topology, plugin_diagnostics};
 use crate::Roots;
 use crate::diagnostic::{Diagnostic, State};
-use crate::files::paths::{ancestor_within, canonical_within};
 use crate::manifest::{Agent, Manifest, Scope};
-use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 mod command;
+mod config;
 mod resolution;
 mod state;
-
-#[derive(Default, Deserialize)]
-struct Config {
-    #[serde(default)]
-    plugins: BTreeMap<String, PluginConfig>,
-    #[serde(default)]
-    skills: SkillsConfig,
-}
-
-#[derive(Deserialize)]
-struct PluginConfig {
-    enabled: Option<bool>,
-}
-
-#[derive(Default, Deserialize)]
-struct SkillsConfig {
-    #[serde(default)]
-    config: Vec<SkillConfig>,
-}
-
-#[derive(Deserialize)]
-struct SkillConfig {
-    path: PathBuf,
-    enabled: bool,
-}
 
 pub(super) fn diagnose(roots: &Roots, policy: &Manifest, scope: Scope) -> Vec<Diagnostic> {
     if scope == Scope::Project {
         return Vec::new();
     }
     let path = roots.home().join(".codex/config.toml");
-    let config = match load(&path, roots.home()) {
+    let config = match config::load(&path, roots.home()) {
         Ok(config) => config,
         Err(detail) => {
             return vec![Diagnostic::new(
@@ -79,7 +52,7 @@ pub(super) fn diagnose(roots: &Roots, policy: &Manifest, scope: Scope) -> Vec<Di
 }
 
 fn configured_and_resolved_ids(
-    configured: &BTreeMap<String, PluginConfig>,
+    configured: &BTreeMap<String, config::PluginConfig>,
     resolved: Option<&state::ResolverState>,
 ) -> BTreeSet<String> {
     configured
@@ -122,46 +95,8 @@ fn resolver_failure_diagnostic(detail: &str) -> Diagnostic {
 }
 
 pub(super) fn skill_exposure(roots: &Roots, skill_file: &Path) -> Exposure {
-    let Ok(config) = load(&roots.home().join(".codex/config.toml"), roots.home()) else {
+    let Ok(config) = config::load(&roots.home().join(".codex/config.toml"), roots.home()) else {
         return Exposure::Unknown;
     };
-    let matching = config
-        .skills
-        .config
-        .iter()
-        .filter(|entry| same_path(&entry.path, skill_file))
-        .map(|entry| entry.enabled)
-        .collect::<Vec<_>>();
-    match matching.as_slice() {
-        [] | [true] => Exposure::Enabled,
-        [false] => Exposure::Disabled,
-        _ => Exposure::Unknown,
-    }
-}
-
-fn load(path: &Path, root: &Path) -> Result<Config, &'static str> {
-    match fs::symlink_metadata(path) {
-        Ok(_) if canonical_within(path, root).is_none() => {
-            return Err("config resolves outside HOME");
-        }
-        Ok(_) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return if ancestor_within(path, root) {
-                Ok(Config::default())
-            } else {
-                Err("config parent resolves outside HOME")
-            };
-        }
-        Err(_) => return Err("config metadata could not be read"),
-    }
-    let contents = fs::read_to_string(path).map_err(|_| "config could not be read")?;
-    toml::from_str(&contents).map_err(|_| "config is invalid TOML")
-}
-
-fn same_path(left: &Path, right: &Path) -> bool {
-    left == right
-        || fs::canonicalize(left)
-            .ok()
-            .zip(fs::canonicalize(right).ok())
-            .is_some_and(|(left, right)| left == right)
+    config.skill_exposure(skill_file)
 }

--- a/tooling/arnes/src/skills/external/codex/config.rs
+++ b/tooling/arnes/src/skills/external/codex/config.rs
@@ -1,0 +1,138 @@
+use super::Exposure;
+use crate::files::paths::{ancestor_within, canonical_within};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Default, Deserialize)]
+pub(super) struct Config {
+    #[serde(default)]
+    pub plugins: BTreeMap<String, PluginConfig>,
+    #[serde(default)]
+    skills: SkillsConfig,
+}
+
+#[derive(Deserialize)]
+pub(super) struct PluginConfig {
+    pub enabled: Option<bool>,
+}
+
+#[derive(Default, Deserialize)]
+struct SkillsConfig {
+    #[serde(default)]
+    config: Vec<SkillConfig>,
+}
+
+#[derive(Deserialize)]
+struct SkillConfig {
+    path: Option<PathBuf>,
+    name: Option<String>,
+    enabled: bool,
+}
+
+impl Config {
+    pub(super) fn skill_exposure(&self, skill_file: &Path) -> Exposure {
+        let name = self
+            .skills
+            .config
+            .iter()
+            .any(|entry| entry.name.is_some())
+            .then(|| skill_name(skill_file))
+            .flatten();
+        self.skills
+            .config
+            .iter()
+            .rev()
+            .find_map(|entry| entry.matching_exposure(skill_file, name.as_deref()))
+            .unwrap_or(Exposure::Enabled)
+    }
+}
+
+impl SkillConfig {
+    fn matching_exposure(&self, skill_file: &Path, skill_name: Option<&str>) -> Option<Exposure> {
+        let matches = match (self.path.as_deref(), self.name.as_deref()) {
+            (Some(path), None) => same_path(path, skill_file),
+            (None, Some(name)) if !name.trim().is_empty() => {
+                let Some(skill_name) = skill_name else {
+                    return Some(Exposure::Unknown);
+                };
+                name.trim() == skill_name
+            }
+            _ => false,
+        };
+        matches.then_some(if self.enabled {
+            Exposure::Enabled
+        } else {
+            Exposure::Disabled
+        })
+    }
+}
+
+pub(super) fn load(path: &Path, root: &Path) -> Result<Config, &'static str> {
+    match fs::symlink_metadata(path) {
+        Ok(_) if canonical_within(path, root).is_none() => {
+            return Err("config resolves outside HOME");
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return if ancestor_within(path, root) {
+                Ok(Config::default())
+            } else {
+                Err("config parent resolves outside HOME")
+            };
+        }
+        Err(_) => return Err("config metadata could not be read"),
+    }
+    let contents = fs::read_to_string(path).map_err(|_| "config could not be read")?;
+    let value: toml::Value = toml::from_str(&contents).map_err(|_| "config is invalid TOML")?;
+    value
+        .try_into()
+        .map_err(|_| "config has invalid plugin or skill settings")
+}
+
+fn skill_name(skill_file: &Path) -> Option<String> {
+    #[derive(Deserialize)]
+    struct Metadata {
+        name: Option<String>,
+    }
+
+    let root = skill_file.parent()?.parent()?;
+    let path = canonical_within(skill_file, root)?;
+    if !fs::metadata(&path).ok()?.is_file() {
+        return None;
+    }
+    let contents = fs::read_to_string(&path).ok()?;
+    let mut lines = contents.lines();
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+    let mut frontmatter = Vec::new();
+    for line in lines {
+        if line.trim() == "---" {
+            let metadata: Metadata = serde_yaml_ng::from_str(&frontmatter.join("\n")).ok()?;
+            let name = metadata.name.unwrap_or_default();
+            let name = if name.trim().is_empty() {
+                path.parent()?.file_name()?.to_str().unwrap_or("skill")
+            } else {
+                &name
+            };
+            let name = name.split_whitespace().collect::<Vec<_>>().join(" ");
+            return Some(if name.is_empty() {
+                "skill".to_owned()
+            } else {
+                name
+            });
+        }
+        frontmatter.push(line);
+    }
+    None
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    left == right
+        || fs::canonicalize(left)
+            .ok()
+            .zip(fs::canonicalize(right).ok())
+            .is_some_and(|(left, right)| left == right)
+}

--- a/tooling/arnes/tests/external_codex_plugins.rs
+++ b/tooling/arnes/tests/external_codex_plugins.rs
@@ -34,7 +34,7 @@ fn active_plugin_uses_codex_selection_and_inventories_skills() {
     fixture.write_home(".arnes.yaml", &manifest(true, true));
     fixture.write_home(
         ".codex/config.toml",
-        "[plugins.\"demo@marketplace\"]\nenabled = true\n",
+        "[plugins.\"demo@marketplace\"]\nenabled = true\n[[skills.config]]\nname = 'review'\nenabled = false\n",
     );
     fixture.write_home(
         ".codex/plugins/cache/marketplace/demo/11c74d6b/.codex-plugin/plugin.json",

--- a/tooling/arnes/tests/external_codex_skill_config.rs
+++ b/tooling/arnes/tests/external_codex_skill_config.rs
@@ -1,0 +1,245 @@
+#[path = "support/codex.rs"]
+pub mod codex_support;
+#[path = "support/skills.rs"]
+pub mod skill_support;
+pub mod support;
+
+use serde_json::json;
+use skill_support::run;
+use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+use support::Fixture;
+
+fn fixture(config: &str) -> Fixture {
+    let fixture = Fixture::new();
+    fixture.write_home(
+        ".arnes.yaml",
+        "version: 1\nagents:\n  - { id: codex, scopes: [user] }\nskills: []\nresources: []\nexternal:\n  roots:\n    - { agent: codex, scope: user, origin: system, location: { root: home, path: .codex/skills/.system } }\n  plugins: []\n  skills:\n    - { agent: codex, scope: user, origin: system, slug: folder }\n",
+    );
+    fixture.write_home(
+        ".codex/skills/.system/folder/SKILL.md",
+        "---\nname: actual-name\ndescription: Example\n---\nSkill\n",
+    );
+    let path = fixture.home().join(".codex/skills/.system/folder/SKILL.md");
+    fixture.write_home(
+        ".codex/config.toml",
+        &config.replace("SKILL_PATH", path.to_str().unwrap()),
+    );
+    codex_support::install(
+        &fixture,
+        json!({"marketplaces": []}),
+        json!({"installed": [], "available": []}),
+    );
+    fixture
+}
+
+fn doctor(fixture: &Fixture) -> (i32, String, String) {
+    run(
+        fixture,
+        &[
+            "doctor", "skills", "--agent", "codex", "--scope", "user", "-v",
+        ],
+    )
+}
+
+#[test]
+fn name_only_override_preserves_unrelated_path_overrides() {
+    let fixture = fixture(
+        "[[skills.config]]\nname = 'review'\nenabled = false\n[[skills.config]]\npath = 'SKILL_PATH'\nenabled = false\n",
+    );
+    let (code, stdout, _) = doctor(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("folder · disabled · healthy · allowed"));
+    assert!(!stdout.contains("plugin configuration"), "{stdout}");
+}
+
+#[test]
+fn name_override_matches_metadata_instead_of_directory_name() {
+    for (name, expected) in [(" actual-name ", "disabled"), ("folder", "enabled")] {
+        let fixture = fixture(&format!(
+            "[[skills.config]]\nname = '{name}'\nenabled = false\n"
+        ));
+        let (code, stdout, _) = doctor(&fixture);
+
+        assert_eq!(code, 0, "{stdout}");
+        assert!(stdout.contains(&format!("folder · {expected} · healthy · allowed")));
+    }
+}
+
+#[test]
+fn name_matching_accepts_crlf_and_whitespace_around_delimiters() {
+    let fixture = fixture("[[skills.config]]\nname = 'actual-name'\nenabled = false\n");
+    fixture.write_home(
+        ".codex/skills/.system/folder/SKILL.md",
+        " --- \r\nname: actual-name\r\ndescription: Example\r\n --- \r\nSkill\r\n",
+    );
+    let (code, stdout, _) = doctor(&fixture);
+
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("folder · disabled · healthy · allowed"));
+}
+
+#[test]
+fn name_matching_uses_normalized_metadata_or_the_folder_fallback() {
+    for (metadata, name, folder) in [
+        ("name: ' actual   name '", "actual name", "folder"),
+        ("name: ' '", "folder", "folder"),
+        ("", "folder", "folder"),
+        ("", "actual name", "actual   name"),
+        ("", "skill", " "),
+    ] {
+        let fixture = fixture(&format!(
+            "[[skills.config]]\nname = '{name}'\nenabled = false\n"
+        ));
+        fixture.write_home(
+            ".codex/skills/.system/folder/SKILL.md",
+            &format!("---\n{metadata}\ndescription: Example\n---\n"),
+        );
+        let path = fixture.home().join(".codex/skills/.system/folder");
+        fs::rename(&path, path.with_file_name(folder)).unwrap();
+        let (code, stdout, _) = doctor(&fixture);
+
+        assert_eq!(code, 0, "{stdout}");
+        assert!(stdout.contains(&format!("{folder} · disabled · healthy")));
+    }
+}
+
+#[test]
+fn later_matching_name_or_path_override_wins() {
+    for (first, second) in [
+        ("name = 'actual-name'", "path = 'SKILL_PATH'"),
+        ("path = 'SKILL_PATH'", "name = 'actual-name'"),
+        ("name = 'actual-name'", "name = 'actual-name'"),
+        ("path = 'SKILL_PATH'", "path = 'SKILL_PATH'"),
+    ] {
+        for (enabled, expected) in [(true, "enabled"), (false, "disabled")] {
+            let fixture = fixture(&format!(
+                "[[skills.config]]\n{first}\nenabled = {}\n[[skills.config]]\n{second}\nenabled = {enabled}\n",
+                !enabled
+            ));
+            let (code, stdout, _) = doctor(&fixture);
+
+            assert_eq!(code, 0, "{stdout}");
+            assert!(stdout.contains(&format!("folder · {expected} · healthy · allowed")));
+        }
+    }
+}
+
+#[test]
+fn ambiguous_or_empty_selectors_do_not_disable_skills() {
+    for selector in [
+        "",
+        "name = ' '",
+        "name = 'actual-name'\npath = 'SKILL_PATH'",
+    ] {
+        let fixture = fixture(&format!("[[skills.config]]\n{selector}\nenabled = false\n"));
+        let (code, stdout, _) = doctor(&fixture);
+
+        assert_eq!(code, 0, "{stdout}");
+        assert!(stdout.contains("folder · enabled · healthy · allowed"));
+    }
+}
+
+#[test]
+fn syntax_and_schema_failures_are_distinct_and_redacted() {
+    for (config, detail) in [
+        ("[[skills.config]", "config is invalid TOML"),
+        (
+            "[[skills.config]]\nname = 'private-sentinel'\nenabled = 'invalid'\n",
+            "config has invalid plugin or skill settings",
+        ),
+        (
+            "[[skills.config]]\nname = 42\nenabled = false\n",
+            "config has invalid plugin or skill settings",
+        ),
+        (
+            "[[skills.config]]\nname = 'private-sentinel'\n",
+            "config has invalid plugin or skill settings",
+        ),
+    ] {
+        let fixture = fixture(config);
+        let (code, stdout, stderr) = doctor(&fixture);
+
+        assert_eq!(code, 2, "{stdout}");
+        assert!(stdout.contains(detail), "{stdout}");
+        assert!(stdout.contains("folder · unknown · healthy · allowed"));
+        assert!(!stdout.contains("private-sentinel"));
+        assert!(!stderr.contains("private-sentinel"));
+    }
+}
+
+#[test]
+fn unreadable_or_invalid_metadata_keeps_name_exposure_unknown() {
+    for contents in [
+        "no metadata",
+        "---\nname: [invalid]\n---\n",
+        "---\nname: actual-name\n---not-a-delimiter\n",
+    ] {
+        let fixture = fixture("[[skills.config]]\nname = 'actual-name'\nenabled = false\n");
+        fixture.write_home(".codex/skills/.system/folder/SKILL.md", contents);
+        let (code, stdout, _) = doctor(&fixture);
+
+        assert_eq!(code, 0, "{stdout}");
+        assert!(stdout.contains("UNSUPPORTED folder · unknown · healthy · allowed"));
+    }
+
+    let fixture = fixture("[[skills.config]]\nname = 'actual-name'\nenabled = false\n");
+    let path = fixture.home().join(".codex/skills/.system/folder/SKILL.md");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+    let output = fixture.command(["doctor", "skills", "--agent", "codex", "-v"]);
+    fs::set_permissions(path, fs::Permissions::from_mode(0o644)).unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert!(stdout.contains("UNSUPPORTED folder · unknown · healthy · allowed"));
+}
+
+#[test]
+fn non_regular_metadata_does_not_block_name_matching() {
+    let fixture = fixture("[[skills.config]]\nname = 'actual-name'\nenabled = false\n");
+    let path = fixture.home().join(".codex/skills/.system/folder/SKILL.md");
+    fs::remove_file(&path).unwrap();
+    assert!(Command::new("mkfifo").arg(path).status().unwrap().success());
+    let mut child = Command::new(env!("CARGO_BIN_EXE_arnes"))
+        .args(["doctor", "skills", "--agent", "codex", "-v"])
+        .current_dir(fixture.repository())
+        .env_clear()
+        .env("HOME", fixture.home())
+        .env("PATH", fixture.home().join("bin"))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let start = Instant::now();
+    while child.try_wait().unwrap().is_none() {
+        if start.elapsed() > Duration::from_secs(2) {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            panic!("skill doctor blocked on non-regular metadata");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let output = child.wait_with_output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stdout.contains("folder · unknown · broken · allowed"));
+}
+
+#[test]
+fn name_matching_does_not_read_a_skill_outside_the_declared_root() {
+    let fixture = fixture("[[skills.config]]\nname = 'actual-name'\nenabled = false\n");
+    fixture.write_home("outside/SKILL.md", "---\nname: actual-name\n---\n");
+    symlink(
+        fixture.home().join("outside"),
+        fixture.home().join(".codex/skills/.system/escape"),
+    )
+    .unwrap();
+    let (code, stdout, _) = doctor(&fixture);
+
+    assert_eq!(code, 2, "{stdout}");
+    assert!(stdout.contains("folder · disabled · healthy · allowed"));
+    assert!(stdout.contains("escape · unknown · broken · unexpected"));
+}


### PR DESCRIPTION
## Description

`arnes doctor skills --agent codex` rejects valid Codex configuration containing `[[skills.config]]` with `name = "review"` and no `path`. It reports an invalid TOML error, skips the plugin inventory, and marks system skill exposure as unknown.

Support name and path selectors with Codex's matching and override order, including normalized metadata names and folder-name fallback. Distinguish TOML syntax errors from incompatible settings, preserve redacted diagnostics, and keep metadata reads within the skill root without blocking on special files.

## Useful Links

- [Codex configuration schema](https://developers.openai.com/codex/config-schema.json)
- [Upstream skill selector behavior](https://github.com/openai/codex/blob/main/codex-rs/config/src/skills_config.rs)

## How to Test

- Run `moon run --force tooling/arnes:fmt tooling/arnes:clippy tooling/arnes:check tooling/arnes:test` (passed on macOS).
- Regression tests exercise the real CLI: name/path overrides, ordering, metadata normalization, malformed settings, unreadable metadata, escaping symlinks, and FIFO files.
- A live macOS doctor run cleared the original error and six unsupported system skills; three existing Sites allowlist drifts remain visible.
- Linux validation is delegated to the existing CI workflow.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)
