### PR TITLE
feat(moon): bootstrap workstation installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,4 +12,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-      - run: make smoke-minimal
+        with:
+          fetch-depth: 0
+      - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095
+      - run: make smoke-minimal MOON_EXEC="moon exec --quiet --ignore-ci-checks"

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -5,5 +5,7 @@ projects:
   tooling/agent-memory: tooling/agent-memory
   tooling/arnes: tooling/arnes
 
+defaultProject: repository
+
 vcs:
   defaultBranch: main

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ DOCKER_UNAVAILABLE_POLICY?=require-docker
 DOTFILES_PATH:=$(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 CREATE_SYMLINK=if [ -L "$@" ] && [ "$$(readlink "$@")" = "$<" ]; then exit 0; fi; if [ -e "$@" ] || [ -L "$@" ]; then echo "Error: $@ exists and is not the expected symbolic link" >&2; exit 1; fi; echo "ln -s $< $@"; ln -s "$<" "$@"
 SKIP_PAID_APPS?=0
+MOON_EXEC?=moon exec --quiet
 export HOMEBREW_NO_ASK:=1
+export PATH:=$(PATH):$(HOME)/.moon/bin:$(BREW_BIN)
 
 .PHONY: usage
 usage:
@@ -27,14 +29,12 @@ bootstrap:
 	@xcode-select --print-path >/dev/null || { echo "Error: Apple Command Line Tools are required" >&2; exit 1; }
 
 .PHONY: minimal
-minimal: bootstrap brew
-	@$(MAKE) --no-print-directory bundle-minimal </dev/null
+minimal: bootstrap
+	@$(MOON_EXEC) install
 	@$(MAKE) --no-print-directory minimal-artifacts </dev/null
 
 .PHONY: optional
-optional: bootstrap
-	@$(MAKE) --no-print-directory brew
-	@$(MAKE) --no-print-directory minimal </dev/null
+optional: minimal
 	@$(MAKE) --no-print-directory bundle-optional </dev/null
 	@$(MAKE) --no-print-directory optional-artifacts </dev/null
 
@@ -55,7 +55,7 @@ smoke-minimal:
 
 .PHONY: bundle-minimal
 bundle-minimal:
-	@brew bundle check --quiet --no-upgrade --file "${DOTFILES_PATH}/Brewfile" || { echo "brew bundle --no-upgrade --file ${DOTFILES_PATH}/Brewfile"; brew bundle --no-upgrade --file "${DOTFILES_PATH}/Brewfile" </dev/null; }
+	@$(MOON_EXEC) applications-install
 
 .PHONY: bundle-optional
 bundle-optional:
@@ -465,11 +465,8 @@ tmux: ~/.config/tmux/tmux.conf ~/.tmux/plugins/tpm/tpm
 	git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 
 .PHONY: brew
-brew: ${BREW_BIN}/brew
-${BREW_BIN}/brew:
-	curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > /tmp/brew-installer.sh
-	chmod +x /tmp/brew-installer.sh
-	/tmp/brew-installer.sh
+brew:
+	@$(MOON_EXEC) homebrew-install
 
 .PHONY: daisydisk
 daisydisk:
@@ -490,7 +487,9 @@ ${VOLTA_BIN}/pnpm: ${VOLTA_BIN}/node
 
 .PHONY: moon
 moon:
-	curl -fsSL https://moonrepo.dev/install/moon.sh | bash
+	@set -e; \
+	moon_installer=$$(curl -fsSL --connect-timeout 10 --max-time 60 https://moonrepo.dev/install/moon.sh); \
+	/bin/bash -c "$$moon_installer"
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -19,10 +19,18 @@ dialog, then rerun the command above after the installation finishes.
 cd && \
   git clone --depth 1 https://github.com/SebastienElet/dotfiles.git .dotfiles && \
   cd .dotfiles && \
+  make moon && \
   make minimal
 ```
 
 Install the separately maintained optional profile with `make optional`.
+
+Installation is moving to Moon, one dependency at a time. With Moon available:
+
+```bash
+moon exec install
+moon action-graph repository:install
+```
 
 ## Architecture decisions
 

--- a/docs/adr/001-makefile-installateur.md
+++ b/docs/adr/001-makefile-installateur.md
@@ -1,7 +1,8 @@
-# ADR-001 — Profils hybrides comme installateur de poste
+# ADR-001 — Moon comme orchestrateur du poste
 
 - **Statut** : accepté
 - **Date** : 2026-08
+- **Révision** : 2026-09-03
 - **Issue** : [#257](https://github.com/SebastienElet/dotfiles/issues/257)
 
 ## Contexte
@@ -12,15 +13,30 @@ payants et composants dépendants de Docker. La CI devait reconstruire sa porté
 
 ## Décision
 
-Le `Makefile` reste l’orchestrateur public avec deux profils :
+Moon est l'orchestrateur cible unique pour l'installation et les tâches de développement.
+La migration avance par dépendances validées, jusqu'à la suppression du `Makefile`.
+Une tâche migrée appelle directement sa commande d'installation, jamais une cible Make.
+Les tâches d'installation simples résident dans le `moon.yml` racine ; aucun répertoire projet
+n'est créé uniquement pour donner un préfixe à une commande.
+
+La première étape porte `homebrew-install` et `applications-install`, cette dernière dépendant de
+la première. Les `checks` natifs de Moon vérifient l'état installé avant les commandes ; le cache
+de tâches est désactivé, car l'état Homebrew n'est pas un artefact de build du dépôt.
+
+`Brewfile` et `Brewfile.optional` restent les sources canoniques des formules, casks, taps et
+applications Mac App Store. Installer les paquets n'implique pas déployer leurs configurations.
+
+## Transition
+
+Les chemins non encore migrés conservent provisoirement les profils Make historiques :
 
 - `minimal` installe le poste de développement de référence ;
 - `optional` converge d’abord `minimal`, puis installe les composants utilisés hors de ce socle.
 
-`Brewfile` et `Brewfile.optional` sont les sources canoniques des formules, casks, taps et
-applications Mac App Store. Le `Makefile` conserve l’amorçage Homebrew, les installations
-non-Homebrew et les artefacts possédés par le dépôt. `install.sh` et `tooling/upgrade` appellent
-`make minimal` ; aucun alias `all` n’est conservé.
+`install.sh` amorce Moon avant d'appeler `make minimal`. Le profil Make délègue les opérations
+migrées à Moon et conserve les artefacts non encore migrés. L'installation de Moon lui-même reste
+hors de son graphe, car elle doit fonctionner avant que son exécutable soit disponible.
+`tooling/upgrade` utilise encore ce profil de transition.
 
 Les profils ferment leur entrée standard après l’amorçage. Ils exécutent
 `brew bundle check --quiet --no-upgrade` avant toute installation, afin qu’un passage convergé
@@ -30,11 +46,14 @@ reste silencieux sans demander de mise à niveau globale.
 
 - Le socle et les optionnels sont lisibles dans deux manifestes déclaratifs.
 - Les installations spécifiques restent locales au processus ou à l’artefact qu’elles possèdent.
-- Seul le profil minimal reçoit une garantie end-to-end en CI.
-- L’ajout d’un composant Homebrew modifie le Brewfile de son profil, pas une recette Make.
+- Le smoke test macOS existant passe par Moon pour les opérations migrées, puis par les recettes
+  Make restantes ; il vérifie l'état installé et le second passage du profil de transition.
+- L’ajout d’un composant Homebrew modifie le Brewfile de son profil, pas le graphe d'orchestration.
 
 ## Alternatives écartées
 
 - Conserver `all` : sa portée ambiguë est précisément le défaut corrigé.
-- Un script shell impératif : il dupliquerait l’orchestration et les probes de Make et Bundle.
+- Conserver Make derrière Moon : maintient deux graphes pour les mêmes tâches.
+- Créer un projet Moon par commande : ajoute des répertoires sans responsabilité propre.
+- Un script shell orchestrateur : dupliquerait le graphe de Moon.
 - Ansible ou un gestionnaire de dotfiles : disproportionné pour un poste unique.

--- a/docs/adr/041-frontiere-automatisation-typescript-rust.md
+++ b/docs/adr/041-frontiere-automatisation-typescript-rust.md
@@ -20,10 +20,11 @@ plutôt que comme infrastructure vide.
 
 ## Décision
 
-- Le `Makefile` reste l'installateur idempotent défini par l'ADR-001.
+- Moon devient l'orchestrateur unique selon l'ADR-001 ; les parcours Make non migrés sont transitoires.
 - Bash se limite à l'amorçage, à l'environnement et à une courte séquence linéaire de commandes.
-- Moon porte les tâches de développement nommées progressivement migrées, leur graphe de dépendances
-  et leur sélection affectée; chaque migration conserve une frontière de projet précise.
+- Moon porte les tâches d'installation et de développement, leur graphe de dépendances
+  et leur sélection affectée. Les tâches simples restent dans le projet racine ; un projet séparé
+  correspond à une responsabilité existante, pas à un simple préfixe de commande.
 - Bun et TypeScript sont le choix par défaut pour un petit utilitaire cohésif qui dépasse la frontière
   Shell, y compris l'analyse et la validation de données ou une politique bornée.
 - Rust est retenu pour une CLI substantielle, un état durable, une concurrence complexe, une

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,7 +37,7 @@ ici sont les dates d'auteur.
 
 | #                                                      | Titre                                                            | Date    |
 | ------------------------------------------------------ | ---------------------------------------------------------------- | ------- |
-| [001](001-makefile-installateur.md)                    | Profils hybrides comme installateur de poste                     | 2026-08 |
+| [001](001-makefile-installateur.md)                    | Moon comme orchestrateur du poste                                | 2026-08 |
 | [002](002-homebrew-source-unique.md)                   | Brewfiles comme source unique des paquets                        | 2026-08 |
 | [003](003-deploiement-par-symlinks.md)                 | Déploiement depuis un état propre                                | 2026-08 |
 | [004](004-script-upgrade-unique.md)                    | Script `upgrade` unique pour toutes les mises à jour             | 2017-09 |

--- a/install.sh
+++ b/install.sh
@@ -27,8 +27,10 @@ then
   exit 1
 fi
 
-cd 
+set -e
+
+cd "$HOME"
 git clone --depth 1 https://github.com/SebastienElet/dotfiles.git .dotfiles
 cd .dotfiles
-make brew
-make minimal </dev/null
+make moon
+make minimal

--- a/moon.yml
+++ b/moon.yml
@@ -36,6 +36,49 @@ fileGroups:
     - bun.lock
 
 tasks:
+  install:
+    description: Install the workstation
+    command: noop
+    deps:
+      - applications-install
+    toolchains: system
+    options:
+      cache: false
+      os: macos
+      runInCI: false
+  homebrew-install:
+    description: Install Homebrew
+    script: |
+      set -e
+      homebrew_installer=$(curl -fsSL --connect-timeout 10 --max-time 60 https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)
+      /bin/bash -c "$homebrew_installer"
+    checks:
+      - check: condition
+        script: command -v brew
+    env:
+      PATH: /opt/homebrew/bin:/usr/local/bin:${PATH}
+    toolchains: system
+    options:
+      cache: false
+      interactive: true
+      os: macos
+      runInCI: false
+  applications-install:
+    description: Install the minimal Brewfile
+    command: brew bundle install --no-upgrade --file Brewfile
+    deps:
+      - homebrew-install
+    checks:
+      - check: condition
+        script: brew bundle check --quiet --no-upgrade --file Brewfile
+    env:
+      PATH: /opt/homebrew/bin:/usr/local/bin:${PATH}
+      HOMEBREW_NO_ASK: "1"
+    toolchains: system
+    options:
+      cache: false
+      os: macos
+      runInCI: false
   typescript-lint:
     command: bun --config=/dev/null --no-env-file tooling/lint-typescript.ts
     inputs:

--- a/tooling/install.test.ts
+++ b/tooling/install.test.ts
@@ -55,7 +55,11 @@ function createFixture(gitState: GitState): Fixture {
     "xcode-select",
     `printf 'xcode-select %s\n' "$*" >> "$INSTALL_TEST_TRACE"${gitState === "system-shim" || gitState === "working-without-clt" ? "\nexit 1" : ""}`,
   );
-  installTracedCommand(bin, "make");
+  installCommand(
+    bin,
+    "make",
+    'printf "make %s\\n" "$*" >> "$INSTALL_TEST_TRACE"\nif [ "$1" = moon ]; then exit "$INSTALL_TEST_MOON_STATUS"; fi',
+  );
   if (gitState !== "missing") {
     installCommand(
       bin,
@@ -75,6 +79,7 @@ function createFixture(gitState: GitState): Fixture {
     environment: {
       HOME: home,
       INSTALL_TEST_TRACE: tracePath,
+      INSTALL_TEST_MOON_STATUS: "0",
       PATH: bin,
       ...(gitState === "system-shim" ? { BASH_ENV: bashEnvironment } : {}),
     },
@@ -88,14 +93,6 @@ function installCommand(bin: string, name: string, body: string): void {
   const path = join(bin, name);
   writeFileSync(path, `#!/bin/sh\n${body}\n`);
   chmodSync(path, executableMode);
-}
-
-function installTracedCommand(bin: string, name: string): void {
-  installCommand(
-    bin,
-    name,
-    `printf '${name} %s\n' "$*" >> "$INSTALL_TEST_TRACE"`,
-  );
 }
 
 async function runInstaller(
@@ -178,12 +175,56 @@ test("rejects a third-party Git when developer tools are absent", async () => {
   expect(readTrace(fixture)).toBe("xcode-select --print-path\n");
 });
 
-test("clones and runs make through the shipped entry point when Git works", async () => {
+test("bootstraps Moon before installing the workstation", async () => {
   const fixture = createFixture("working");
   const result = await runInstaller(fixture);
 
   expect(result).toEqual({ exitCode: 0, stderr: "", stdout: "" });
   expect(readTrace(fixture)).toBe(
-    "xcode-select --print-path\ngit --version\ngit clone --depth 1 https://github.com/SebastienElet/dotfiles.git .dotfiles\nmake brew\nmake minimal\n",
+    "xcode-select --print-path\ngit --version\ngit clone --depth 1 https://github.com/SebastienElet/dotfiles.git .dotfiles\nmake moon\nmake minimal\n",
   );
+});
+
+test("stops before workstation installation when Moon bootstrap fails", async () => {
+  const fixture = createFixture("working");
+  const bootstrapFailureExitCode = 42;
+  const result = await runInstaller({
+    ...fixture,
+    environment: {
+      ...fixture.environment,
+      INSTALL_TEST_MOON_STATUS: String(bootstrapFailureExitCode),
+    },
+  });
+
+  expect(result.exitCode).toBe(bootstrapFailureExitCode);
+  expect(readTrace(fixture)).toEndWith("make moon\n");
+  expect(readTrace(fixture)).not.toContain("make minimal");
+});
+
+test("stops before Moon bootstrap when cloning fails", async () => {
+  const fixture = createFixture("working");
+  installCommand(
+    fixture.bin,
+    "git",
+    'printf "git %s\\n" "$*" >> "$INSTALL_TEST_TRACE"\nif [ "$1" = clone ]; then exit 1; fi',
+  );
+
+  const result = await runInstaller(fixture);
+
+  expect(result.exitCode).not.toBe(0);
+  expect(readTrace(fixture)).not.toContain("make ");
+});
+
+test("preserves stdin for the Homebrew bootstrap delegated through Moon", async () => {
+  const fixture = createFixture("working");
+  installCommand(
+    fixture.bin,
+    "make",
+    String.raw`if [ "$1" = minimal ]; then IFS= read -r answer || exit 1; printf "answer %s\n" "$answer" >> "$INSTALL_TEST_TRACE"; fi`,
+  );
+
+  const result = await runInstaller(fixture, "y\n");
+
+  expect(result.exitCode).toBe(0);
+  expect(readTrace(fixture)).toEndWith("answer y\n");
 });

--- a/tooling/moon/bootstrap.test.ts
+++ b/tooling/moon/bootstrap.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const makefile = fileURLToPath(new URL("../../Makefile", import.meta.url));
+const downloadFailureExitCode = 22;
+
+function bootstrapMoon(
+  installer: string,
+  downloadStatus: number,
+): Readonly<{ exitCode: number; stdout: string }> {
+  const directory = mkdtempSync(join(tmpdir(), "moon-bootstrap-test-"));
+
+  try {
+    writeFileSync(
+      join(directory, "curl"),
+      '#!/bin/sh\nprintf "%s" "$MOON_TEST_INSTALLER"\nexit "$MOON_TEST_DOWNLOAD_STATUS"\n',
+      { mode: 0o755 },
+    );
+    const result = Bun.spawnSync(
+      ["/usr/bin/make", "--no-print-directory", "-f", makefile, "moon"],
+      {
+        env: {
+          HOME: directory,
+          PATH: `${directory}:/usr/bin:/bin`,
+          MOON_TEST_INSTALLER: installer,
+          MOON_TEST_DOWNLOAD_STATUS: String(downloadStatus),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    return { exitCode: result.exitCode, stdout: result.stdout.toString() };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("runs the downloaded Moon installer", () => {
+  const result = bootstrapMoon('printf "installer executed"', 0);
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("installer executed");
+});
+
+test("does not execute partial Moon installer content after download failure", () => {
+  const result = bootstrapMoon(
+    'printf "installer executed"',
+    downloadFailureExitCode,
+  );
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stdout).not.toContain("installer executed");
+});
+
+test("propagates a Moon installer failure", () => {
+  expect(bootstrapMoon("exit 1", 0).exitCode).not.toBe(0);
+});

--- a/tooling/moon/homebrew-install.test.ts
+++ b/tooling/moon/homebrew-install.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { z } from "zod";
+
+const configuration = z
+  .object({ tasks: z.record(z.string(), z.unknown()) })
+  .parse(
+    Bun.YAML.parse(
+      await Bun.file(new URL("../../moon.yml", import.meta.url)).text(),
+    ),
+  );
+
+const downloadFailureExitCode = 22;
+const installerFailureExitCode = 42;
+
+function runInstaller(
+  installer: string,
+  downloadStatus: number,
+): Readonly<{ exitCode: number; stdout: string }> {
+  const task = configuration.tasks["homebrew-install"];
+  expect(task).toBeDefined();
+  const { script } = z.object({ script: z.string() }).parse(task);
+  const directory = mkdtempSync(join(tmpdir(), "homebrew-install-test-"));
+
+  try {
+    writeFileSync(
+      join(directory, "curl"),
+      '#!/bin/sh\nprintf "%s" "$HOMEBREW_TEST_INSTALLER"\nexit "$HOMEBREW_TEST_DOWNLOAD_STATUS"\n',
+      { mode: 0o755 },
+    );
+
+    const result = Bun.spawnSync(["/bin/bash", "-c", script], {
+      env: {
+        PATH: directory,
+        HOMEBREW_TEST_INSTALLER: installer,
+        HOMEBREW_TEST_DOWNLOAD_STATUS: String(downloadStatus),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    return { exitCode: result.exitCode, stdout: result.stdout.toString() };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("executes the downloaded Homebrew installer", () => {
+  expect(runInstaller('printf "installer executed"', 0)).toEqual({
+    exitCode: 0,
+    stdout: "installer executed",
+  });
+});
+
+test("does not execute partial installer content when the download fails", () => {
+  expect(
+    runInstaller('printf "installer executed"', downloadFailureExitCode),
+  ).toEqual({
+    exitCode: downloadFailureExitCode,
+    stdout: "",
+  });
+});
+
+test("propagates a Homebrew installer failure", () => {
+  expect(runInstaller(`exit ${installerFailureExitCode}`, 0).exitCode).toBe(
+    installerFailureExitCode,
+  );
+});


### PR DESCRIPTION
## Description

Start the incremental migration to a single Moon dependency graph for workstation installation.
`moon exec install` runs the minimal Brewfile through a separate Homebrew prerequisite; both actions execute directly from the root Moon configuration.

The entry script bootstraps Moon before installation. Existing Make entry points delegate migrated operations to Moon and retain the remaining artifact recipes until their migration. Bootstrap failures stop installation, and stdin remains available for Homebrew prompts.

The existing disposable macOS smoke test now exercises Moon through the transitional Make profile. The large Makefile remains cohesive during this incremental migration; no parallel project directories or new orchestration layer are introduced.

## Useful Links

- Earlier draft approach: #299

## How to Test

Validated locally on macOS:

- 99 Bun tests covering bootstrap failures, installation, deployment, Docker adapters, and Node installation.
- Moon TypeScript lint, typecheck, and format tasks; repository Prettier check.
- Native `moon query tasks` and installation action-graph validation.
- `bash -n`, ShellCheck for `install.sh`, and Make installation dry-runs.

No real workstation installation was executed locally. The full installation smoke test must pass on the disposable macOS CI runner; actionlint was unavailable locally.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)

Comments added: none.
