### PR TITLE
fix(handoff): remove duplicate Claude Stop hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,14 +156,6 @@ ${LOCAL_BIN}/agent-handoff: ${DOTFILES_PATH}/tooling/agent-handoff/target/releas
 .PHONY: agent-handoff
 agent-handoff: ${LOCAL_BIN}/agent-handoff
 
-~/.claude/hooks: | ~/.claude
-	mkdir -p $@
-~/.claude/hooks/agent_handoff: ${DOTFILES_PATH}/tooling/agent-handoff/target/release/agent-handoff FORCE | ~/.claude/hooks
-	@if [ -L "$@" ] && [ "$$(readlink "$@")" = "$<" ]; then exit 0; fi; \
-	if [ -L "$@" ] && [ "$$(readlink "$@")" = "${DOTFILES_PATH}/tooling/agent-handoff" ]; then ln -sfn "$<" "$@"; exit 0; fi; \
-	if [ -e "$@" ] || [ -L "$@" ]; then echo "Error: $@ exists and is not the expected symbolic link" >&2; exit 1; fi; \
-	echo "ln -s $< $@"; ln -s "$<" "$@"
-
 ${DOTFILES_PATH}/tooling/agent-memory/target/release/agent-memory: \
 	${DOTFILES_PATH}/tooling/agent-memory/Cargo.lock \
 	${DOTFILES_PATH}/tooling/agent-memory/Cargo.toml \
@@ -291,7 +283,7 @@ ${LOCAL_BIN}/claude:
 	@${CREATE_SYMLINK}
 
 .PHONY: claude-code-hooks
-claude-code-hooks: arnes agent-memory agent-handoff ~/.claude/hooks/agent_handoff
+claude-code-hooks: arnes agent-memory agent-handoff
 	@"${LOCAL_BIN}/arnes" doctor hooks --agent claude --color never >/dev/null 2>&1 || "${LOCAL_BIN}/arnes" setup hooks --agent claude
 
 .PHONY: hunspell

--- a/tooling/arnes/src/hooks.rs
+++ b/tooling/arnes/src/hooks.rs
@@ -47,7 +47,7 @@ pub fn setup(args: SetupHooksArgs) -> Result<(), HooksError> {
     let handoff_path = handoff_path(roots.home());
     let memory_path = memory_path(roots.home());
     let measurement = measurement_command(&measurement_path, args.agent)?;
-    let handoff_aliases = handoff_aliases(&handoff_path, roots.repository())?;
+    let handoff_aliases = handoff_aliases(&handoff_path, roots.repository(), args.agent)?;
     let memory = memory_command(&memory_path, args.agent)?;
     let memory_event = policy.memory_event;
     if desired.contains(&HookKind::Memory) && (memory.is_none() || memory_event.is_none()) {
@@ -117,12 +117,18 @@ fn memory_path(home: &Path) -> PathBuf {
     home.join(".local/bin/agent-memory")
 }
 
-fn handoff_aliases(command: &Path, repository: &Path) -> Result<Vec<String>, HooksError> {
-    let mut aliases = vec![
-        path_string(command)?,
+fn handoff_aliases(
+    command: &Path,
+    repository: &Path,
+    agent: Agent,
+) -> Result<Vec<String>, HooksError> {
+    let mut aliases = vec![path_string(command)?];
+    aliases
+        .extend((agent == Agent::Claude).then_some("$HOME/.claude/hooks/agent_handoff".to_owned()));
+    aliases.extend([
         path_string(&repository.join("tooling/agent-handoff"))?,
         path_string(&repository.join("scripts/agent_handoff"))?,
-    ];
+    ]);
     let metadata = match fs::symlink_metadata(command) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(aliases),
@@ -234,6 +240,7 @@ mod tests {
         let aliases = handoff_aliases(
             Path::new("/tmp/home/.local/bin/agent-handoff"),
             Path::new("/tmp/repository"),
+            crate::manifest::Agent::Claude,
         )
         .unwrap();
 

--- a/tooling/arnes/src/hooks/inspect/expectation.rs
+++ b/tooling/arnes/src/hooks/inspect/expectation.rs
@@ -43,7 +43,7 @@ pub fn expectation(
         }
         HookKind::Handoff => {
             let path = handoff_path(roots.home());
-            let mut aliases = handoff_aliases(&path, roots.repository())?.into_iter();
+            let mut aliases = handoff_aliases(&path, roots.repository(), agent)?.into_iter();
             let command = aliases
                 .next()
                 .ok_or_else(|| HooksError::new("handoff hook command is required"))?;

--- a/tooling/deployment-agent-handoff.test.ts
+++ b/tooling/deployment-agent-handoff.test.ts
@@ -135,52 +135,6 @@ describe("agent-handoff historical migration", () => {
   });
 });
 
-describe("Claude agent-handoff compatibility link", () => {
-  test("migrates the historical crate link to the release binary", () => {
-    const fixture = createDeploymentFixture("handoff-claude-compatibility");
-    const prepared = prepareAgentHandoff(fixture);
-    mkdirSync(dirname(prepared.claudeDestination), { recursive: true });
-    symlinkSync(prepared.crate, prepared.claudeDestination);
-
-    expectSuccess(runAgentHandoffMake(fixture, prepared.claudeDestination));
-
-    expect(linkTarget(prepared.claudeDestination)).toBe(prepared.release);
-  });
-
-  test.each([
-    ["file", false],
-    ["link", true],
-  ] as const)(
-    "refuses an unexpected %s without changing it",
-    (name, linked) => {
-      const fixture = createDeploymentFixture(
-        `handoff-claude-unexpected-${name}`,
-      );
-      const prepared = prepareAgentHandoff(fixture);
-      const unexpected = join(fixture.root, "unexpected");
-      mkdirSync(dirname(prepared.claudeDestination), { recursive: true });
-      writeFileSync(unexpected, "keep\n");
-      if (linked) {
-        symlinkSync(unexpected, prepared.claudeDestination);
-      } else {
-        writeFileSync(prepared.claudeDestination, "keep\n");
-      }
-      const before = linked
-        ? linkTarget(prepared.claudeDestination)
-        : fileIdentity(prepared.claudeDestination);
-
-      const result = runAgentHandoffMake(fixture, prepared.claudeDestination);
-
-      expect(result.exitCode).not.toBe(0);
-      expect(
-        linked
-          ? linkTarget(prepared.claudeDestination)
-          : fileIdentity(prepared.claudeDestination),
-      ).toEqual(before);
-    },
-  );
-});
-
 describe("agent-handoff up-to-date unexpected destination", () => {
   test("leaves an up-to-date unexpected file untouched", () => {
     const fixture = createDeploymentFixture("handoff-current-file");
@@ -240,7 +194,6 @@ describe("agent-handoff stale unexpected destination", () => {
 });
 
 type PreparedAgentHandoff = Readonly<{
-  claudeDestination: string;
   crate: string;
   destination: string;
   release: string;
@@ -266,7 +219,6 @@ function prepareAgentHandoff(fixture: DeploymentFixture): PreparedAgentHandoff {
   symlinkSync(noOperation, join(fixture.bin, "brew"));
   symlinkSync(noOperation, join(fixture.bin, "cargo"));
   return {
-    claudeDestination: join(fixture.home, ".claude", "hooks", "agent_handoff"),
     crate,
     destination: join(fixture.home, ".local", "bin", "agent-handoff"),
     release,


### PR DESCRIPTION
## Description

Remove the redundant Claude Code handoff wiring so one Stop event invokes the canonical ~/.local/bin/agent-handoff entry point once.

- remove the obsolete ~/.claude/hooks/agent_handoff Make deployment
- let the existing Arnes reconciliation retire that exact Claude-only legacy command
- preserve the agent-handoff runtime, threshold, and Codex hook configuration
- add no gate or configuration-mirroring test

## Useful Links

- Audit baseline: 61df900e598f3702eea5cc636d67625c4e4220b6

## How to Test

- cargo test --manifest-path tooling/arnes/Cargo.toml --locked
- cargo test --manifest-path tooling/agent-handoff/Cargo.toml
- bun test tooling/deployment-*.test.ts
- bun run typecheck
- bun tooling/lint-typescript.ts
- bun run format:typescript:check
- run make claude-code-hooks in a temporary HOME seeded with both Claude Stop commands; verify the doctor changes from drift to healthy and the resulting configuration contains one canonical agent-handoff command

Local validation ran on macOS 26.6.2 arm64. GitHub macos-latest and Ubuntu remain covered by required remote CI before merge.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes (or documented if necessary)