### PR TITLE
feat(moon): migrate Hunspell and agent runtimes

### DIFF
--- a/.github/workflows/test-agent-handoff.yml
+++ b/.github/workflows/test-agent-handoff.yml
@@ -19,5 +19,4 @@ jobs:
           filter: blob:none
       - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095
       - run: >-
-          moon ci tooling/agent-handoff:fmt tooling/agent-handoff:clippy
-          tooling/agent-handoff:test
+          moon ci agent-handoff:fmt agent-handoff:clippy agent-handoff:test

--- a/.github/workflows/test-agent-memory.yml
+++ b/.github/workflows/test-agent-memory.yml
@@ -19,5 +19,4 @@ jobs:
           filter: blob:none
       - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095
       - run: >-
-          moon ci tooling/agent-memory:fmt tooling/agent-memory:clippy
-          tooling/agent-memory:test
+          moon ci agent-memory:fmt agent-memory:clippy agent-memory:test

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -10,6 +10,7 @@ on:
       - harness/**
       - tooling/deployment-*.ts
       - tooling/install-hunspell-dictionary*
+      - tooling/agent-handoff/**
       - tooling/agent-memory/**
       - tooling/apple-notes*.ts
       - tooling/pr-feedback-skill-test
@@ -28,6 +29,7 @@ on:
       - harness/**
       - tooling/deployment-*.ts
       - tooling/install-hunspell-dictionary*
+      - tooling/agent-handoff/**
       - tooling/agent-memory/**
       - tooling/apple-notes*.ts
       - tooling/pr-feedback-skill-test
@@ -56,10 +58,10 @@ jobs:
           bun-version-file: package.json
       - run: bun install --frozen-lockfile
       - run: >-
-          bun test tooling/deployment-agent-handoff.test.ts
-          tooling/deployment-fish.test.ts tooling/deployment-links.test.ts
+          bun test tooling/deployment-fish.test.ts tooling/deployment-links.test.ts
           tooling/deployment-xdg.test.ts
       - run: moon ci agent-memory:deployment-test
+      - run: moon ci agent-handoff:deployment-test
       - run: moon ci repository:hunspell-test
       - run: bun test tooling/apple-notes*.test.ts
       - run: tooling/pr-feedback-skill-test

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -3,12 +3,14 @@ name: Deployment tests
 on:
   push:
     paths:
+      - .cargo/**
       - .moon/**
       - .agents/skills/apple-notes/scripts/**
       - home/**
       - harness/**
       - tooling/deployment-*.ts
       - tooling/install-hunspell-dictionary*
+      - tooling/agent-memory/**
       - tooling/apple-notes*.ts
       - tooling/pr-feedback-skill-test
       - package.json
@@ -19,12 +21,14 @@ on:
       - .github/workflows/test-deployment.yml
   pull_request:
     paths:
+      - .cargo/**
       - .moon/**
       - .agents/skills/apple-notes/scripts/**
       - home/**
       - harness/**
       - tooling/deployment-*.ts
       - tooling/install-hunspell-dictionary*
+      - tooling/agent-memory/**
       - tooling/apple-notes*.ts
       - tooling/pr-feedback-skill-test
       - package.json
@@ -51,7 +55,11 @@ jobs:
         with:
           bun-version-file: package.json
       - run: bun install --frozen-lockfile
-      - run: bun test tooling/deployment-*.test.ts
+      - run: >-
+          bun test tooling/deployment-agent-handoff.test.ts
+          tooling/deployment-fish.test.ts tooling/deployment-links.test.ts
+          tooling/deployment-xdg.test.ts
+      - run: moon ci agent-memory:deployment-test
       - run: moon ci repository:hunspell-test
       - run: bun test tooling/apple-notes*.test.ts
       - run: tooling/pr-feedback-skill-test

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -3,6 +3,7 @@ name: Deployment tests
 on:
   push:
     paths:
+      - .moon/**
       - .agents/skills/apple-notes/scripts/**
       - home/**
       - harness/**
@@ -14,9 +15,11 @@ on:
       - bun.lock
       - tsconfig.json
       - Makefile
+      - moon.yml
       - .github/workflows/test-deployment.yml
   pull_request:
     paths:
+      - .moon/**
       - .agents/skills/apple-notes/scripts/**
       - home/**
       - harness/**
@@ -28,6 +31,7 @@ on:
       - bun.lock
       - tsconfig.json
       - Makefile
+      - moon.yml
       - .github/workflows/test-deployment.yml
 
 jobs:
@@ -39,12 +43,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: package.json
       - run: bun install --frozen-lockfile
       - run: bun test tooling/deployment-*.test.ts
-      - run: bun test tooling/install-hunspell-dictionary.test.ts tooling/install-hunspell-dictionary-failures.test.ts
+      - run: moon ci repository:hunspell-test
       - run: bun test tooling/apple-notes*.test.ts
       - run: tooling/pr-feedback-skill-test
       - run: bun run typecheck

--- a/.github/workflows/test-typescript.yml
+++ b/.github/workflows/test-typescript.yml
@@ -18,7 +18,7 @@ jobs:
           bun-version-file: package.json
       - run: bun --config=/dev/null --no-env-file install --frozen-lockfile --ignore-scripts
       - run: bun --config=/dev/null --no-env-file tooling/node-version-contract.ts verify-runtime
-      - run: moon run tooling/agent-memory:build-release
+      - run: moon run agent-memory:build
       - run: bun --config=/dev/null --no-env-file test --timeout 15000
         env:
           SCRAPLING_DOCKER_SMOKE: "1"

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,7 +1,7 @@
 projects:
   repository: .
   harness: harness
-  tooling/agent-handoff: tooling/agent-handoff
+  agent-handoff: tooling/agent-handoff
   agent-memory: tooling/agent-memory
   arnes: tooling/arnes
 

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -2,7 +2,7 @@ projects:
   repository: .
   harness: harness
   tooling/agent-handoff: tooling/agent-handoff
-  tooling/agent-memory: tooling/agent-memory
+  agent-memory: tooling/agent-memory
   arnes: tooling/arnes
 
 defaultProject: repository

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VOLTA_BIN:=$(HOME)/.volta/bin
 PNPM_BIN:=$(HOME)/Library/pnpm
 LOCAL_BIN:=$(HOME)/.local/bin
 APP_BIN:=/Applications
-MINIMAL_SNAPSHOT_PATHS:=.agents/skills .arnes.yaml .claude .claude.json .codex/AGENTS.md .codex/agents .config/bat .config/cspell .config/fish .config/git/config.delta .config/git/ignore .config/nvim .config/starship.toml .config/tmux .config/wezterm .gitconfig .local/bin/agent-handoff .local/bin/arnes .local/bin/claude .local/bin/colgrep-search .tmux/plugins/tpm .volta/bin/codex .volta/bin/node .volta/bin/pnpm Library/Spelling cspell.json
+MINIMAL_SNAPSHOT_PATHS:=.agents/skills .arnes.yaml .claude .claude.json .codex/AGENTS.md .codex/agents .config/bat .config/cspell .config/fish .config/git/config.delta .config/git/ignore .config/nvim .config/starship.toml .config/tmux .config/wezterm .gitconfig .local/bin/agent-handoff .local/bin/agent-memory .local/bin/arnes .local/bin/claude .local/bin/colgrep-search .tmux/plugins/tpm .volta/bin/codex .volta/bin/node .volta/bin/pnpm Library/Spelling cspell.json
 SCRAPLING_IMAGE?=pyd4vinci/scrapling
 CLOAKBROWSER_IMAGE?=cloakhq/cloakbrowser:0.5.3
 DOCKER_UNAVAILABLE_POLICY?=require-docker
@@ -43,7 +43,7 @@ smoke-minimal:
 	@set -eu; \
 	$(MAKE) --no-print-directory minimal </dev/null; \
 	brew bundle check --quiet --no-upgrade --file "${DOTFILES_PATH}/Brewfile"; \
-	for executable in "${BREW_BIN}/colgrep" "${LOCAL_BIN}/agent-handoff" "${LOCAL_BIN}/arnes" "${LOCAL_BIN}/claude" "${LOCAL_BIN}/colgrep-search" "${VOLTA_BIN}/codex" "${VOLTA_BIN}/node" "${VOLTA_BIN}/pnpm"; do test -x "$$executable"; done; \
+	for executable in "${BREW_BIN}/colgrep" "${LOCAL_BIN}/agent-handoff" "${LOCAL_BIN}/agent-memory" "${LOCAL_BIN}/arnes" "${LOCAL_BIN}/claude" "${LOCAL_BIN}/colgrep-search" "${VOLTA_BIN}/codex" "${VOLTA_BIN}/node" "${VOLTA_BIN}/pnpm"; do test -x "$$executable"; done; \
 	stdout=$$(mktemp); stderr=$$(mktemp); trap 'rm -f "$$stdout" "$$stderr"' EXIT; \
 	before=$$(cd "$(HOME)" && tar -cf - ${MINIMAL_SNAPSHOT_PATHS} | shasum -a 256); \
 	if ! $(MAKE) --no-print-directory minimal </dev/null >"$$stdout" 2>"$$stderr"; then cat "$$stdout"; cat "$$stderr" >&2; exit 1; fi; \
@@ -159,20 +159,9 @@ ${LOCAL_BIN}/agent-handoff: ${DOTFILES_PATH}/tooling/agent-handoff/target/releas
 .PHONY: agent-handoff
 agent-handoff: ${LOCAL_BIN}/agent-handoff
 
-${DOTFILES_PATH}/tooling/agent-memory/target/release/agent-memory: \
-	${DOTFILES_PATH}/tooling/agent-memory/Cargo.lock \
-	${DOTFILES_PATH}/tooling/agent-memory/Cargo.toml \
-	$(shell find ${DOTFILES_PATH}/tooling/agent-memory/src ${DOTFILES_PATH}/tooling/agent-memory/tests -type f -name '*.rs') \
-	| ${BREW_BIN}/cargo
-	cd ${DOTFILES_PATH}/tooling/agent-memory && ${BREW_BIN}/cargo build --release
-	test -x "$@"
-	touch "$@"
-${LOCAL_BIN}/agent-memory: ${DOTFILES_PATH}/tooling/agent-memory/target/release/agent-memory | ${LOCAL_BIN}
-	test ! -L "$@" || test "$$(readlink "$@")" != "${DOTFILES_PATH}/tooling/agent-memory" || ln -sfn "$<" "$@"
-	test -e "$@" || test -L "$@" || ln -s "$<" "$@"
-	test "$$(readlink "$@")" = "$<"
 .PHONY: agent-memory
-agent-memory: ${LOCAL_BIN}/agent-memory
+agent-memory:
+	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) agent-memory:install
 
 .PHONY: docker
 docker:
@@ -485,6 +474,7 @@ moon:
 
 .PHONY: clean
 clean:
+	rm -rf ~/.local/bin/agent-memory
 	rm -rf ~/.config/nvim
 	rm -rf ~/.local/share/nvim
 	rm -rf ~/.cache/nvim

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ bundle-optional:
 	@skip_mas=; if [ "$(SKIP_PAID_APPS)" = "1" ]; then skip_mas="411643860 904280696"; fi; HOMEBREW_BUNDLE_MAS_SKIP="$$skip_mas" brew bundle check --quiet --no-upgrade --file "${DOTFILES_PATH}/Brewfile.optional" || { echo "brew bundle --no-upgrade --file ${DOTFILES_PATH}/Brewfile.optional"; HOMEBREW_BUNDLE_MAS_SKIP="$$skip_mas" brew bundle --no-upgrade --file "${DOTFILES_PATH}/Brewfile.optional" </dev/null; }
 
 .PHONY: minimal-artifacts
-minimal-artifacts: bat fish nvim wezterm git-delta starship tmux node pnpm arnes claude-code codex hunspell ${LOCAL_BIN}/colgrep-search
+minimal-artifacts: bat fish nvim wezterm git-delta starship tmux node pnpm arnes claude-code codex ${LOCAL_BIN}/colgrep-search
 
 .PHONY: optional-artifacts
 optional-artifacts: cspell cursor cloakbrowser scrapling postgresql daisydisk things-3
@@ -294,10 +294,7 @@ hunspell: hunspell-dictionaries
 
 .PHONY: hunspell-dictionaries
 hunspell-dictionaries:
-	@"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/fr_FR/dictionaries/fr.aff" "c176610cd5dc4846806a65ddd029f422d87978bf58f224aa44222662a16a2de5" "$(HOME)/Library/Spelling/fr.aff"
-	@"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/fr_FR/dictionaries/fr.dic" "b78a868e31dd6e373b6c3217969afb898a9acde828a5e7ef97308da42218c88c" "$(HOME)/Library/Spelling/fr.dic"
-	@"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.aff" "e746c882dd6f303c2c46e7452804b9201115a6942cfeb15f18f8edf774d2e24e" "$(HOME)/Library/Spelling/en_US.aff"
-	@"${DOTFILES_PATH}/tooling/install-hunspell-dictionary" "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.dic" "f0b1a234bd178bdd01875b2a392a9647f888b8fe879f79c52aae62c2759b3647" "$(HOME)/Library/Spelling/en_US.dic"
+	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) repository:hunspell-dictionaries
 
 .PHONY: codex
 codex: ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.codex/agents/design-claim-auditor.toml ~/.agents/skills/agent-instructions ~/.agents/skills/claude-developer ~/.agents/skills/code-search ~/.agents/skills/design-claim-audit ~/.agents/skills/handoff ~/.agents/skills/enforcement-code ~/.agents/skills/harness-reflection ~/.agents/skills/issue-creation ~/.agents/skills/linear-issue-spec ~/.agents/skills/linear-start ~/.agents/skills/linear-sync ~/.agents/skills/linear-workflow ~/.agents/skills/memory-governance ~/.agents/skills/obsidian-retrieval ~/.agents/skills/pr-fix ~/.agents/skills/pr-feedback ~/.agents/skills/pr-verdict ~/.agents/skills/requirements-clarification ~/.agents/skills/skill-manager ~/.agents/skills/workflow-automation codex-hooks

--- a/Makefile
+++ b/Makefile
@@ -129,35 +129,9 @@ ${LOCAL_BIN}/arnes: FORCE
 ${BREW_BIN}/cargo:
 	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) rust
 
-${DOTFILES_PATH}/tooling/agent-handoff/target/release/agent-handoff: \
-	${DOTFILES_PATH}/tooling/agent-handoff/Cargo.lock \
-	${DOTFILES_PATH}/tooling/agent-handoff/Cargo.toml \
-	${DOTFILES_PATH}/tooling/agent-handoff/src/decision.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/src/environment.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/src/error.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/src/event.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/src/lib.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/src/main.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/src/run.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/src/state.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/src/transcript.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/tests/cli.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/tests/cli/runtime_parity.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/tests/concurrency.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/tests/decision.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/tests/event.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/tests/transcript.rs \
-	${DOTFILES_PATH}/tooling/agent-handoff/tests/transcript/numeric.rs \
-	| ${BREW_BIN}/cargo
-	cd ${DOTFILES_PATH}/tooling/agent-handoff && ${BREW_BIN}/cargo build --release
-	test -x "$@"
-	touch "$@"
-${LOCAL_BIN}/agent-handoff: ${DOTFILES_PATH}/tooling/agent-handoff/target/release/agent-handoff | ${LOCAL_BIN}
-	test ! -L "$@" || test "$$(readlink "$@")" != "${DOTFILES_PATH}/tooling/agent-handoff" || ln -sfn "$<" "$@"
-	test -e "$@" || test -L "$@" || ln -s "$<" "$@"
-	test "$$(readlink "$@")" = "$<"
 .PHONY: agent-handoff
-agent-handoff: ${LOCAL_BIN}/agent-handoff
+agent-handoff:
+	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) agent-handoff:install
 
 .PHONY: agent-memory
 agent-memory:
@@ -474,6 +448,7 @@ moon:
 
 .PHONY: clean
 clean:
+	rm -rf ~/.local/bin/agent-handoff
 	rm -rf ~/.local/bin/agent-memory
 	rm -rf ~/.config/nvim
 	rm -rf ~/.local/share/nvim

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,8 @@ l'[ADR-038](adr/038-frontieres-home-harness-tooling.md).
 
 Les points d'entrée restent à la racine :
 
-- `Makefile` orchestre les profils `minimal` et `optional` et décrit les destinations déployées ;
+- `moon.yml` orchestre les tâches migrées ; le `Makefile` conserve temporairement les profils
+  `minimal` et `optional` ainsi que les points d'entrée de compatibilité ;
 - `Brewfile` et `Brewfile.optional` sont les inventaires canoniques des paquets de leurs profils ;
 - `install.sh` amorce une nouvelle machine en clonant le dépôt puis en lançant
   `make minimal` ;
@@ -43,9 +44,9 @@ Les points d'entrée restent à la racine :
 | `home/.config/wezterm/wezterm.lua` | `~/.config/wezterm/wezterm.lua` |
 | `home/cspell.json`                 | `~/cspell.json`                 |
 
-Le `Makefile` déploie les artefacts statiques et lie les exécutables générés après leur build. À
-chaque passage du profil, il conserve silencieusement un lien exact, crée une destination absente et
-refuse toute divergence sans la modifier.
+Moon déploie les capacités migrées, tandis que le `Makefile` conserve les artefacts encore en
+transition. Chaque installateur part d'une destination possédée absente ; ses probes permettent un
+second passage silencieux sans transformer l'installation en diagnostic.
 
 ## Intégrations d'agents
 
@@ -74,14 +75,15 @@ deux occurrences.
   `upgrade`, `agent-handoff` et `git-main-branch` ;
 - les applications structurées dans leur propre répertoire, comme le projet Rust `arnes/`.
 
-Les exécutables destinés au `PATH` sont liés depuis le `Makefile`, généralement
-sous `~/.local/bin`. `tooling/upgrade` met à jour le dépôt puis relance
+Les exécutables destinés au `PATH` sont liés par leur projet Moon ou, pour les composants encore en
+transition, par le `Makefile`, généralement sous `~/.local/bin`. `tooling/upgrade` met à jour le dépôt puis relance
 `make minimal`, ce qui déploie les nouveaux chemins du socle.
 
 ## Flux de changement
 
 1. Placer la source dans la zone qui porte sa responsabilité.
-2. Mettre à jour le `Makefile` lorsqu'un artefact est installé ou déployé.
+2. Mettre à jour le projet Moon propriétaire lorsqu'un artefact est installé ou déployé, puis le
+   point d'entrée Make de compatibilité tant que la transition l'exige.
 3. Mettre à jour tous les consommateurs du chemin source dans le même changement.
 4. Ajouter ou adapter la barrière CI qui couvre le type de fichier concerné.
 5. Enregistrer une ADR seulement si le changement introduit ou remplace une

--- a/docs/adr/038-frontieres-home-harness-tooling.md
+++ b/docs/adr/038-frontieres-home-harness-tooling.md
@@ -2,6 +2,7 @@
 
 - **Statut** : accepté
 - **Date** : 2026-08
+- **Révision** : 2026-09-04
 
 ## Contexte
 
@@ -30,10 +31,10 @@ Les chemins imposés par un outil (`.agents/`, `.claude/`, `.codex/`,
 `.cursor/`, `.github/`) et les points d'entrée du dépôt (`AGENTS.md`,
 `CLAUDE.md`, `Makefile`, `README.md`, `install.sh`) restent à la racine.
 
-Conformément à l'[ADR-003](003-deploiement-par-symlinks.md), le déploiement part
-d'un état propre et laisse Make créer chaque destination absente. Les recettes
-n'inspectent ni ne migrent une destination préexistante. Aucun lien de
-compatibilité n'est conservé dans le dépôt.
+Conformément à l'[ADR-003](003-deploiement-par-symlinks.md), le déploiement par
+Moon ou, pendant la transition, par Make part d'un état propre et crée chaque
+destination absente. Les tâches n'inspectent ni ne migrent une destination
+préexistante. Aucun lien de compatibilité n'est conservé dans le dépôt.
 
 ## Conséquences
 

--- a/docs/software-source-exceptions.md
+++ b/docs/software-source-exceptions.md
@@ -14,4 +14,4 @@ référencé par [ADR-002](adr/002-homebrew-source-unique.md).
 | Thèmes Bat                    | Branche Catppuccin par défaut      | HTTPS GitHub                                 | Changement explicite de source         | Fichier de thème existant                           |
 | Dictionnaires Hunspell        | Commit LibreOffice déclaré         | SHA-256 déclaré                              | Changement du commit et du checksum    | Destination identique conservée, divergence refusée |
 
-Les sources internes à un outil local appelé par le `Makefile` relèvent des tests de cet outil.
+Les sources internes à un outil local appelé par Moon ou le `Makefile` relèvent des tests de cet outil.

--- a/harness/moon.yml
+++ b/harness/moon.yml
@@ -11,6 +11,7 @@ tasks:
     description: Install migrated harness capabilities
     command: noop
     deps:
+      - agent-memory:install
       - arnes:install
     toolchains: system
   semctx:

--- a/harness/moon.yml
+++ b/harness/moon.yml
@@ -11,6 +11,7 @@ tasks:
     description: Install migrated harness capabilities
     command: noop
     deps:
+      - agent-handoff:install
       - agent-memory:install
       - arnes:install
     toolchains: system

--- a/home/.config/cspell/user.txt
+++ b/home/.config/cspell/user.txt
@@ -22,6 +22,8 @@ pathspecs
 pullrequests
 renameat
 renamex
+rustc
+rustup
 scrapling
 unmatch
 wezterm

--- a/moon.yml
+++ b/moon.yml
@@ -34,6 +34,13 @@ fileGroups:
     - tooling/git-main-branch-*.ts
     - package.json
     - bun.lock
+  hunspellTests:
+    - tooling/install-hunspell-dictionary
+    - tooling/install-hunspell-dictionary*.ts
+    - package.json
+    - bun.lock
+    - tsconfig.json
+    - .github/workflows/test-deployment.yml
 
 tasks:
   install:
@@ -42,6 +49,7 @@ tasks:
     deps:
       - applications-install
       - harness:install
+      - hunspell-dictionaries
     toolchains: system
     options:
       cache: false
@@ -99,6 +107,31 @@ tasks:
       mutex: homebrew
       os: macos
       runInCI: false
+  hunspell-dictionaries:
+    description: Install Hunspell dictionaries
+    script: |
+      set -e
+      tooling/install-hunspell-dictionary "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/fr_FR/dictionaries/fr.aff" "c176610cd5dc4846806a65ddd029f422d87978bf58f224aa44222662a16a2de5" "$HOME/Library/Spelling/fr.aff"
+      tooling/install-hunspell-dictionary "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/fr_FR/dictionaries/fr.dic" "b78a868e31dd6e373b6c3217969afb898a9acde828a5e7ef97308da42218c88c" "$HOME/Library/Spelling/fr.dic"
+      tooling/install-hunspell-dictionary "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.aff" "e746c882dd6f303c2c46e7452804b9201115a6942cfeb15f18f8edf774d2e24e" "$HOME/Library/Spelling/en_US.aff"
+      tooling/install-hunspell-dictionary "https://raw.githubusercontent.com/LibreOffice/dictionaries/f2ff99058268502bdcf4cad25c1ca2935ad8aa7d/en/en_US.dic" "f0b1a234bd178bdd01875b2a392a9647f888b8fe879f79c52aae62c2759b3647" "$HOME/Library/Spelling/en_US.dic"
+    inputs:
+      - tooling/install-hunspell-dictionary
+      - tooling/install-hunspell-dictionary-error.ts
+      - tooling/install-hunspell-dictionary-files.ts
+      - tooling/install-hunspell-dictionary.ts
+    toolchains: bun
+    options:
+      cache: false
+      os: macos
+      runInCI: false
+  hunspell-test:
+    command: >-
+      bun --config=/dev/null --no-env-file test
+      tooling/install-hunspell-dictionary.test.ts
+      tooling/install-hunspell-dictionary-failures.test.ts
+    inputs:
+      - "@group(hunspellTests)"
   typescript-lint:
     command: bun --config=/dev/null --no-env-file tooling/lint-typescript.ts
     inputs:

--- a/moon.yml
+++ b/moon.yml
@@ -106,7 +106,7 @@ tasks:
       cache: false
       mutex: homebrew
       os: macos
-      runInCI: false
+      runInCI: skip
   hunspell-dictionaries:
     description: Install Hunspell dictionaries
     script: |

--- a/tooling/agent-handoff/moon.yml
+++ b/tooling/agent-handoff/moon.yml
@@ -8,11 +8,47 @@ fileGroups:
     - benches/**/*
     - /.cargo/**/*
     - /.github/workflows/test-agent-handoff.yml
+  deployment:
+    - moon.yml
+    - /.github/workflows/test-deployment.yml
+    - /Makefile
+    - /.moon/workspace.yml
+    - /harness/moon.yml
+    - /moon.yml
+    - /tooling/deployment-agent-handoff.test.ts
+    - /tooling/deployment-moon-test-support.ts
+    - /tooling/deployment-test-support.ts
+    - /package.json
+    - /bun.lock
+    - /tsconfig.json
 
 env:
   RUSTFLAGS: -Funsafe-code
 
 tasks:
+  install:
+    description: Install the Agent Handoff executable
+    command: noop
+    deps:
+      - binary
+    toolchains: system
+    options:
+      cache: false
+      runInCI: false
+  binary:
+    script: |
+      set -e
+      mkdir -p "$HOME/.local/bin"
+      ln -s "$projectRoot/target/release/agent-handoff" "$HOME/.local/bin/agent-handoff"
+    deps:
+      - build
+    checks:
+      - check: condition
+        script: test -e "$HOME/.local/bin/agent-handoff" || test -L "$HOME/.local/bin/agent-handoff"
+    toolchains: system
+    options:
+      cache: false
+      runInCI: false
   fmt:
     command: cargo fmt --check
     inputs:
@@ -29,11 +65,28 @@ tasks:
       - "@group(rust)"
     options:
       mutex: agent-handoff-cargo-target
-  build-release:
-    command: cargo build --release
+  build:
+    script: |
+      set -e
+      cargo build --quiet --release --locked
+      test -x "$projectRoot/target/release/agent-handoff" || { printf 'Agent Handoff build produced no executable at %s\n' "$projectRoot/target/release/agent-handoff" >&2; exit 1; }
+    deps:
+      - repository:rust
+    env:
+      PATH: /opt/homebrew/bin:/usr/local/bin:${PATH}
     inputs:
       - "@group(rust)"
     outputs:
       - target/release/agent-handoff
     options:
       mutex: agent-handoff-cargo-target
+  deployment-test:
+    command: >-
+      bun --config=/dev/null --no-env-file test
+      tooling/deployment-agent-handoff.test.ts
+    inputs:
+      - "@group(deployment)"
+      - "@group(rust)"
+    toolchains: bun
+    options:
+      runFromWorkspaceRoot: true

--- a/tooling/agent-memory/moon.yml
+++ b/tooling/agent-memory/moon.yml
@@ -8,8 +8,44 @@ fileGroups:
     - benches/**/*
     - /.cargo/**/*
     - /.github/workflows/test-agent-memory.yml
+  deployment:
+    - moon.yml
+    - /.github/workflows/test-deployment.yml
+    - /Makefile
+    - /.moon/workspace.yml
+    - /harness/moon.yml
+    - /moon.yml
+    - /tooling/deployment-agent-memory.test.ts
+    - /tooling/deployment-moon-test-support.ts
+    - /tooling/deployment-test-support.ts
+    - /package.json
+    - /bun.lock
+    - /tsconfig.json
 
 tasks:
+  install:
+    description: Install the Agent Memory executable
+    command: noop
+    deps:
+      - binary
+    toolchains: system
+    options:
+      cache: false
+      runInCI: false
+  binary:
+    script: |
+      set -e
+      mkdir -p "$HOME/.local/bin"
+      ln -s "$projectRoot/target/release/agent-memory" "$HOME/.local/bin/agent-memory"
+    deps:
+      - build
+    checks:
+      - check: condition
+        script: test -e "$HOME/.local/bin/agent-memory" || test -L "$HOME/.local/bin/agent-memory"
+    toolchains: system
+    options:
+      cache: false
+      runInCI: false
   fmt:
     command: cargo fmt --check
     env:
@@ -32,11 +68,28 @@ tasks:
       - "@group(rust)"
     options:
       mutex: agent-memory-cargo-target
-  build-release:
-    command: cargo build --release
+  build:
+    script: |
+      set -e
+      cargo build --quiet --release --locked
+      test -x "$projectRoot/target/release/agent-memory" || { printf 'Agent Memory build produced no executable at %s\n' "$projectRoot/target/release/agent-memory" >&2; exit 1; }
+    deps:
+      - repository:rust
+    env:
+      PATH: /opt/homebrew/bin:/usr/local/bin:${PATH}
     inputs:
       - "@group(rust)"
     outputs:
       - target/release/agent-memory
     options:
       mutex: agent-memory-cargo-target
+  deployment-test:
+    command: >-
+      bun --config=/dev/null --no-env-file test
+      tooling/deployment-agent-memory.test.ts
+    inputs:
+      - "@group(deployment)"
+      - "@group(rust)"
+    toolchains: bun
+    options:
+      runFromWorkspaceRoot: true

--- a/tooling/deployment-agent-handoff.test.ts
+++ b/tooling/deployment-agent-handoff.test.ts
@@ -1,240 +1,152 @@
-import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import {
-  chmodSync,
-  copyFileSync,
-  mkdirSync,
-  symlinkSync,
-  unlinkSync,
-  utimesSync,
-  writeFileSync,
-} from "node:fs";
+import { afterEach, expect, setDefaultTimeout, test } from "bun:test";
 import {
   cleanupDeploymentFixtures,
   createDeploymentFixture,
   expectSuccess,
-  fileIdentity,
   linkTarget,
   pathExists,
   project,
   requireCommand,
   runMake,
 } from "./deployment-test-support.ts";
-import { dirname, join } from "node:path";
+import {
+  cleanupMoonDeploymentFixtures,
+  createMoonDeploymentFixture,
+  runMoon,
+} from "./deployment-moon-test-support.ts";
+import {
+  mkdirSync,
+  realpathSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
 
-afterEach(cleanupDeploymentFixtures);
-const deploymentTimeoutMilliseconds = 15_000;
+afterEach(() => {
+  cleanupDeploymentFixtures();
+  cleanupMoonDeploymentFixtures();
+});
+
+const deploymentTimeoutMilliseconds = 120_000;
+const executableFileMode = 0o755;
 setDefaultTimeout(deploymentTimeoutMilliseconds);
 
-const prerequisites = [
-  "Cargo.lock",
-  "Cargo.toml",
-  "src/decision.rs",
-  "src/environment.rs",
-  "src/error.rs",
-  "src/event.rs",
-  "src/lib.rs",
-  "src/main.rs",
-  "src/run.rs",
-  "src/state.rs",
-  "src/transcript.rs",
-  "tests/cli.rs",
-  "tests/cli/runtime_parity.rs",
-  "tests/concurrency.rs",
-  "tests/decision.rs",
-  "tests/event.rs",
-  "tests/transcript.rs",
-  "tests/transcript/numeric.rs",
-] as const;
-const oldTime = new Date("2020-01-01T00:00:00Z");
-const releaseTime = new Date("2021-01-01T00:00:00Z");
-const newTime = new Date("2022-01-01T00:00:00Z");
-const executableFileMode = 0o755;
-type CommandResult = ReturnType<typeof runMake>;
-type DeploymentFixture = ReturnType<typeof createDeploymentFixture>;
+test("installs an executable handoff runtime through Moon", () => {
+  const fixture = createMoonDeploymentFixture("agent-handoff");
+  const result = runMoon(fixture, "agent-handoff:install");
+  const destination = join(fixture.home, ".local/bin/agent-handoff");
 
-describe("agent-handoff release target", () => {
-  test.each([...prerequisites])(
-    "rebuilds once after %s changes",
-    (relativePath) => {
-      const fixture = createDeploymentFixture(
-        `handoff-build-${relativePath.replaceAll("/", "-")}`,
-      );
-      const prepared = prepareAgentHandoff(fixture);
-      utimesSync(join(prepared.crate, relativePath), newTime, newTime);
-
-      const rebuilt = runAgentHandoffMake(fixture, prepared.release);
-      expectSuccess(rebuilt);
-      expect(rebuilt.stdout).toContain(`${fixture.bin}/cargo build --release`);
-
-      const replayed = runAgentHandoffMake(fixture, prepared.release);
-      expectSuccess(replayed);
-      expect(replayed.stdout).not.toContain("cargo build --release");
-    },
+  expectSuccess(result);
+  expect(linkTarget(destination)).toBe(
+    join(
+      realpathSync(fixture.repository),
+      "tooling/agent-handoff/target/release/agent-handoff",
+    ),
   );
-
-  test("refuses a successful build that produces no release binary", () => {
-    const fixture = createDeploymentFixture("handoff-missing-release");
-    const prepared = prepareAgentHandoff(fixture);
-    unlinkSync(prepared.release);
-
-    const result = runAgentHandoffMake(fixture, prepared.release);
-
-    expect(result.exitCode).not.toBe(0);
-    expect(pathExists(prepared.release)).toBeFalse();
-  });
+  expect(statSync(destination).mode & executableFileMode).not.toBe(0);
 });
 
-describe("agent-handoff deployed link", () => {
-  test("does not rebuild or revalidate an up-to-date deployed link", () => {
-    const fixture = createDeploymentFixture("handoff-current");
-    const prepared = prepareAgentHandoff(fixture);
-    mkdirSync(dirname(prepared.destination), { recursive: true });
-    symlinkSync(prepared.release, prepared.destination);
-
-    const result = runAgentHandoffMake(fixture, prepared.destination);
-
-    expectSuccess(result);
-    expect(result.stdout).not.toContain("cargo build --release");
-    expect(result.stdout).not.toContain(`readlink ${prepared.destination}`);
-    expect(linkTarget(prepared.destination)).toBe(prepared.release);
+test("propagates a handoff build failure", () => {
+  const fixture = createMoonDeploymentFixture("agent-handoff");
+  const result = runMoon(fixture, "agent-handoff:install", {
+    cache: "off",
+    environment: { RUSTC: join(fixture.root, "missing-rustc") },
+    force: true,
   });
 
-  test("creates an absent deployed link", () => {
-    const fixture = createDeploymentFixture("handoff-absent");
-    const prepared = prepareAgentHandoff(fixture);
-
-    expectSuccess(runAgentHandoffMake(fixture, prepared.destination));
-
-    expect(linkTarget(prepared.destination)).toBe(prepared.release);
-  });
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain("missing-rustc");
 });
 
-describe("agent-handoff historical migration", () => {
-  test("migrates the exact historical link when the release is newer", () => {
-    const fixture = createDeploymentFixture("handoff-historical-stale");
-    const prepared = prepareAgentHandoff(fixture);
-    installHistoricalLink(prepared);
-    utimesSync(prepared.crate, oldTime, oldTime);
-
-    expectSuccess(runAgentHandoffMake(fixture, prepared.destination));
-
-    expect(linkTarget(prepared.destination)).toBe(prepared.release);
+test("refuses a handoff build that produces no canonical binary", () => {
+  const fixture = createMoonDeploymentFixture("agent-handoff");
+  const alternateTarget = join(fixture.root, "alternate-target");
+  const result = runMoon(fixture, "agent-handoff:install", {
+    cache: "off",
+    environment: { CARGO_TARGET_DIR: alternateTarget },
+    force: true,
   });
 
-  test("leaves an up-to-date historical link untouched", () => {
-    const fixture = createDeploymentFixture("handoff-historical-current");
-    const prepared = prepareAgentHandoff(fixture);
-    installHistoricalLink(prepared);
-    utimesSync(prepared.crate, newTime, newTime);
-
-    const result = runAgentHandoffMake(fixture, prepared.destination);
-
-    expectSuccess(result);
-    expect(result.stdout).not.toContain(`readlink ${prepared.destination}`);
-    expect(linkTarget(prepared.destination)).toBe(prepared.crate);
-  });
-});
-
-describe("agent-handoff up-to-date unexpected destination", () => {
-  test("leaves an up-to-date unexpected file untouched", () => {
-    const fixture = createDeploymentFixture("handoff-current-file");
-    const prepared = prepareAgentHandoff(fixture);
-    mkdirSync(dirname(prepared.destination), { recursive: true });
-    writeFileSync(prepared.destination, "keep\n");
-    utimesSync(prepared.destination, newTime, newTime);
-    const before = fileIdentity(prepared.destination);
-
-    const result = runAgentHandoffMake(fixture, prepared.destination);
-
-    expectSuccess(result);
-    expect(result.stdout).not.toContain(`readlink ${prepared.destination}`);
-    expect(fileIdentity(prepared.destination)).toEqual(before);
-  });
-});
-
-describe("agent-handoff stale unexpected destination", () => {
-  test.each([
-    ["file", false, false],
-    ["link", true, false],
-    ["dangling link", true, true],
-  ] as const)(
-    "refuses a stale unexpected %s without changing it",
-    (name, linked, dangling) => {
-      const fixture = createDeploymentFixture(
-        `handoff-stale-${name.replaceAll(" ", "-")}`,
-      );
-      const prepared = prepareAgentHandoff(fixture);
-      const unexpected = join(fixture.root, "unexpected");
-      mkdirSync(dirname(prepared.destination), { recursive: true });
-      if (!dangling) {
-        writeFileSync(unexpected, "keep\n");
-        utimesSync(unexpected, oldTime, oldTime);
-      }
-      if (linked) {
-        symlinkSync(unexpected, prepared.destination);
-      } else {
-        writeFileSync(prepared.destination, "keep\n");
-        utimesSync(prepared.destination, oldTime, oldTime);
-      }
-      const before = linked
-        ? linkTarget(prepared.destination)
-        : fileIdentity(prepared.destination);
-
-      const result = runAgentHandoffMake(fixture, prepared.destination);
-
-      expect(result.exitCode).not.toBe(0);
-      expect(result.stderr).not.toBe("");
-      expect(
-        linked
-          ? linkTarget(prepared.destination)
-          : fileIdentity(prepared.destination),
-      ).toEqual(before);
-    },
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain(
+    "tooling/agent-handoff/target/release/agent-handoff",
   );
 });
 
-type PreparedAgentHandoff = Readonly<{
-  crate: string;
-  destination: string;
-  release: string;
-}>;
+test("propagates a handoff deployment failure", () => {
+  const fixture = createMoonDeploymentFixture("agent-handoff");
+  writeFileSync(join(fixture.home, ".local"), "occupied\n");
+  const result = runMoon(fixture, "agent-handoff:install");
 
-function prepareAgentHandoff(fixture: DeploymentFixture): PreparedAgentHandoff {
-  const crate = join(fixture.repository, "tooling", "agent-handoff");
-  for (const relativePath of prerequisites) {
-    const destination = join(crate, relativePath);
-    mkdirSync(dirname(destination), { recursive: true });
-    copyFileSync(
-      join(project, "tooling", "agent-handoff", relativePath),
-      destination,
-    );
-    utimesSync(destination, oldTime, oldTime);
-  }
-  const release = join(crate, "target", "release", "agent-handoff");
-  mkdirSync(dirname(release), { recursive: true });
-  writeFileSync(release, "binary");
-  chmodSync(release, executableFileMode);
-  utimesSync(release, releaseTime, releaseTime);
-  const noOperation = requireCommand("true");
-  symlinkSync(noOperation, join(fixture.bin, "brew"));
-  symlinkSync(noOperation, join(fixture.bin, "cargo"));
-  return {
-    crate,
-    destination: join(fixture.home, ".local", "bin", "agent-handoff"),
-    release,
-  };
-}
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain(".local");
+  expect(result.stderr).toContain("Not a directory");
+});
 
-function installHistoricalLink(prepared: PreparedAgentHandoff): void {
-  mkdirSync(dirname(prepared.destination), { recursive: true });
-  symlinkSync(prepared.crate, prepared.destination);
-}
-
-function runAgentHandoffMake(
-  fixture: DeploymentFixture,
-  target: string,
-): CommandResult {
-  return runMake(fixture, [target], {
+test.each([
+  ["codex", true],
+  ["claude-code", true],
+  ["cursor", false],
+] as const)("%s preserves its handoff dependency", (target, deploysHandoff) => {
+  const fixture = createDeploymentFixture(`handoff-wiring-${target}`);
+  installBuildProviders(fixture);
+  const result = runMake(fixture, [target], {
+    dryRun: true,
+    repository: project,
     variables: { BREW_BIN: fixture.bin },
   });
+
+  expectSuccess(result);
+  expect(
+    result.stdout.includes("moon exec --quiet agent-handoff:install"),
+  ).toBe(deploysHandoff);
+});
+
+test("keeps the handoff runtime independent from memory", () => {
+  const fixture = createDeploymentFixture("handoff-runtime-independence");
+  const result = runMake(fixture, ["agent-handoff"], {
+    dryRun: true,
+    repository: project,
+  });
+
+  expectSuccess(result);
+  expect(result.stdout).toContain("moon exec --quiet agent-handoff:install");
+  expect(result.stdout).not.toContain("agent-memory");
+});
+
+test.each(["file", "directory", "symlink"] as const)(
+  "clean removes the owned handoff %s destination only",
+  (destinationType) => {
+    const fixture = createDeploymentFixture("handoff-clean");
+    const destination = join(fixture.home, ".local/bin/agent-handoff");
+    const neighbor = join(fixture.home, ".local/bin/keep");
+    const external = join(fixture.root, "external");
+    mkdirSync(join(fixture.home, ".local/bin"), { recursive: true });
+    if (destinationType === "directory") {
+      mkdirSync(destination);
+    } else if (destinationType === "symlink") {
+      mkdirSync(external);
+      symlinkSync(external, destination);
+    } else {
+      writeFileSync(destination, "handoff\n");
+    }
+    writeFileSync(neighbor, "keep\n");
+
+    expectSuccess(runMake(fixture, ["clean"], { repository: project }));
+    expect(pathExists(destination)).toBeFalse();
+    expect(pathExists(neighbor)).toBeTrue();
+    if (destinationType === "symlink") {
+      expect(pathExists(external)).toBeTrue();
+    }
+  },
+);
+
+function installBuildProviders(
+  fixture: ReturnType<typeof createDeploymentFixture>,
+): void {
+  const provider = requireCommand("true");
+  for (const command of ["bun", "cargo", "volta"]) {
+    symlinkSync(provider, join(fixture.bin, command));
+  }
 }

--- a/tooling/deployment-agent-memory.test.ts
+++ b/tooling/deployment-agent-memory.test.ts
@@ -4,17 +4,86 @@ import {
   createDeploymentFixture,
   expectSuccess,
   linkTarget,
+  pathExists,
   project,
   requireCommand,
   runMake,
 } from "./deployment-test-support.ts";
-import { readFileSync, symlinkSync } from "node:fs";
+import {
+  cleanupMoonDeploymentFixtures,
+  createMoonDeploymentFixture,
+  runMoon,
+} from "./deployment-moon-test-support.ts";
+import {
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
-afterEach(cleanupDeploymentFixtures);
+afterEach(() => {
+  cleanupDeploymentFixtures();
+  cleanupMoonDeploymentFixtures();
+});
 
-const deploymentTimeoutMilliseconds = 15_000;
+const deploymentTimeoutMilliseconds = 120_000;
 setDefaultTimeout(deploymentTimeoutMilliseconds);
+const executableFileMode = 0o755;
+
+test("installs an executable memory runtime through Moon", () => {
+  const fixture = createMoonDeploymentFixture("agent-memory");
+  const result = runMoon(fixture, "agent-memory:install");
+  const destination = join(fixture.home, ".local/bin/agent-memory");
+
+  expectSuccess(result);
+  expect(linkTarget(destination)).toBe(
+    join(
+      realpathSync(fixture.repository),
+      "tooling/agent-memory/target/release/agent-memory",
+    ),
+  );
+  expect(statSync(destination).mode & executableFileMode).not.toBe(0);
+});
+
+test("propagates a memory build failure", () => {
+  const fixture = createMoonDeploymentFixture("agent-memory");
+  const result = runMoon(fixture, "agent-memory:install", {
+    cache: "off",
+    environment: { RUSTC: join(fixture.root, "missing-rustc") },
+    force: true,
+  });
+
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain("missing-rustc");
+});
+
+test("refuses a memory build that produces no canonical binary", () => {
+  const fixture = createMoonDeploymentFixture("agent-memory");
+  const alternateTarget = join(fixture.root, "alternate-target");
+  const result = runMoon(fixture, "agent-memory:install", {
+    cache: "off",
+    environment: { CARGO_TARGET_DIR: alternateTarget },
+    force: true,
+  });
+
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain(
+    "tooling/agent-memory/target/release/agent-memory",
+  );
+});
+
+test("propagates a memory deployment failure", () => {
+  const fixture = createMoonDeploymentFixture("agent-memory");
+  writeFileSync(join(fixture.home, ".local"), "occupied\n");
+  const result = runMoon(fixture, "agent-memory:install");
+
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain(".local");
+  expect(result.stderr).toContain("Not a directory");
+});
 
 test.each([
   ["codex", "codex", true],
@@ -24,7 +93,6 @@ test.each([
   "%s entry point deploys its memory runtime",
   (target, agent, deploysHandoff) => {
     const fixture = createDeploymentFixture(`memory-wiring-${target}`);
-    const memory = join(fixture.home, ".local", "bin", "agent-memory");
     const handoff = join(fixture.home, ".local", "bin", "agent-handoff");
     const expected = `"${fixture.home}/.local/bin/arnes" setup hooks --agent ${agent}`;
 
@@ -36,7 +104,7 @@ test.each([
     });
 
     expectSuccess(result);
-    expect(result.stdout).toContain(memory);
+    expect(result.stdout).toContain("moon exec --quiet agent-memory:install");
     expect(result.stdout.includes(handoff)).toBe(deploysHandoff);
     expect(result.stdout).toContain(expected);
   },
@@ -84,11 +152,40 @@ test("keeps memory and handoff runtime targets independent", () => {
   const handoffResult = result("agent-handoff");
   expectSuccess(memoryResult);
   expectSuccess(handoffResult);
-  expect(memoryResult.stdout).toContain(memory);
+  expect(memoryResult.stdout).toContain(
+    "moon exec --quiet agent-memory:install",
+  );
   expect(memoryResult.stdout).not.toContain(handoff);
   expect(handoffResult.stdout).toContain(handoff);
   expect(handoffResult.stdout).not.toContain(memory);
 });
+
+test.each(["file", "directory", "symlink"] as const)(
+  "clean removes the owned memory %s destination only",
+  (destinationType) => {
+    const fixture = createDeploymentFixture("memory-clean");
+    const destination = join(fixture.home, ".local/bin/agent-memory");
+    const neighbor = join(fixture.home, ".local/bin/keep");
+    const external = join(fixture.root, "external");
+    mkdirSync(join(fixture.home, ".local/bin"), { recursive: true });
+    if (destinationType === "directory") {
+      mkdirSync(destination);
+    } else if (destinationType === "symlink") {
+      mkdirSync(external);
+      symlinkSync(external, destination);
+    } else {
+      writeFileSync(destination, "memory\n");
+    }
+    writeFileSync(neighbor, "keep\n");
+
+    expectSuccess(runMake(fixture, ["clean"], { repository: project }));
+    expect(pathExists(destination)).toBeFalse();
+    expect(pathExists(neighbor)).toBeTrue();
+    if (destinationType === "symlink") {
+      expect(pathExists(external)).toBeTrue();
+    }
+  },
+);
 
 function installBuildProviders(
   fixture: ReturnType<typeof createDeploymentFixture>,

--- a/tooling/deployment-agent-memory.test.ts
+++ b/tooling/deployment-agent-memory.test.ts
@@ -93,7 +93,7 @@ test.each([
   "%s entry point deploys its memory runtime",
   (target, agent, deploysHandoff) => {
     const fixture = createDeploymentFixture(`memory-wiring-${target}`);
-    const handoff = join(fixture.home, ".local", "bin", "agent-handoff");
+    const handoffTarget = "moon exec --quiet agent-handoff:install";
     const expected = `"${fixture.home}/.local/bin/arnes" setup hooks --agent ${agent}`;
 
     installBuildProviders(fixture);
@@ -105,7 +105,7 @@ test.each([
 
     expectSuccess(result);
     expect(result.stdout).toContain("moon exec --quiet agent-memory:install");
-    expect(result.stdout.includes(handoff)).toBe(deploysHandoff);
+    expect(result.stdout.includes(handoffTarget)).toBe(deploysHandoff);
     expect(result.stdout).toContain(expected);
   },
 );
@@ -139,7 +139,7 @@ test("deploys the Cursor memory rule from its canonical source", () => {
 test("keeps memory and handoff runtime targets independent", () => {
   const fixture = createDeploymentFixture("memory-runtime-binaries");
   const memory = join(fixture.home, ".local", "bin", "agent-memory");
-  const handoff = join(fixture.home, ".local", "bin", "agent-handoff");
+  const handoffTarget = "moon exec --quiet agent-handoff:install";
   const result = (target: string): ReturnType<typeof runMake> =>
     runMake(fixture, [target], {
       dryRun: true,
@@ -155,8 +155,8 @@ test("keeps memory and handoff runtime targets independent", () => {
   expect(memoryResult.stdout).toContain(
     "moon exec --quiet agent-memory:install",
   );
-  expect(memoryResult.stdout).not.toContain(handoff);
-  expect(handoffResult.stdout).toContain(handoff);
+  expect(memoryResult.stdout).not.toContain(handoffTarget);
+  expect(handoffResult.stdout).toContain(handoffTarget);
   expect(handoffResult.stdout).not.toContain(memory);
 });
 

--- a/tooling/deployment-moon-test-support.ts
+++ b/tooling/deployment-moon-test-support.ts
@@ -1,0 +1,180 @@
+import {
+  type CommandResult,
+  expectSuccess,
+  project,
+  requireCommand,
+} from "./deployment-test-support.ts";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+type MoonDeploymentFixture = Readonly<{
+  home: string;
+  repository: string;
+  root: string;
+}>;
+
+type RunMoonOptions = Readonly<{
+  cache?: "off" | "read-write";
+  environment?: Readonly<NodeJS.ProcessEnv>;
+  force?: boolean;
+}>;
+
+type MoonProjectFixturePaths = Readonly<{
+  destination: string;
+  home: string;
+  projectId: "agent-memory" | "agent-handoff";
+  repository: string;
+  source: string;
+}>;
+
+const fixtures: string[] = [];
+
+function createMoonDeploymentFixture(
+  projectId: "agent-memory" | "agent-handoff",
+): MoonDeploymentFixture {
+  const root = mkdtempSync(join(tmpdir(), `moon-${projectId}-deployment-`));
+  const repository = join(root, "repository");
+  const home = join(root, "home");
+  const source = join(project, "tooling", projectId);
+  const destination = join(repository, "tooling", projectId);
+  fixtures.push(root);
+  copyMoonProjectFixture({
+    destination,
+    home,
+    projectId,
+    repository,
+    source,
+  });
+  initializeGitRepository(repository);
+  return { home, repository, root };
+}
+
+function copyMoonProjectFixture({
+  destination,
+  home,
+  projectId,
+  repository,
+  source,
+}: MoonProjectFixturePaths): void {
+  mkdirSync(join(repository, ".moon"), { recursive: true });
+  mkdirSync(join(repository, ".github", "workflows"), { recursive: true });
+  mkdirSync(home);
+  cpSync(source, destination, {
+    filter: (path) => !path.includes(`${join(source, "target")}/`),
+    recursive: true,
+  });
+  cpSync(
+    join(project, ".github", "workflows", `test-${projectId}.yml`),
+    join(repository, ".github", "workflows", `test-${projectId}.yml`),
+  );
+  writeFileSync(
+    join(repository, ".moon", "workspace.yml"),
+    `projects:\n  repository: .\n  ${projectId}: tooling/${projectId}\n\ndefaultProject: repository\n\nvcs:\n  defaultBranch: main\n`,
+  );
+  writeFileSync(
+    join(repository, "moon.yml"),
+    "tasks:\n  rust:\n    command: noop\n    toolchains: system\n    options:\n      cache: false\n      runInCI: skip\n",
+  );
+}
+
+function initializeGitRepository(repository: string): void {
+  expectSuccess(
+    spawn([requireCommand("git"), "init", "--initial-branch=main"], {
+      cwd: repository,
+      environment: process.env,
+    }),
+  );
+  expectSuccess(
+    spawn([requireCommand("git"), "add", "."], {
+      cwd: repository,
+      environment: process.env,
+    }),
+  );
+  expectSuccess(
+    spawn(
+      [
+        requireCommand("git"),
+        "-c",
+        "user.name=Moon deployment test",
+        "-c",
+        "user.email=moon-deployment@example.invalid",
+        "commit",
+        "-m",
+        "fixture",
+      ],
+      { cwd: repository, environment: process.env },
+    ),
+  );
+}
+
+function cleanupMoonDeploymentFixtures(): void {
+  for (const root of fixtures.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
+function runMoon(
+  fixture: MoonDeploymentFixture,
+  target: string,
+  options: RunMoonOptions = {},
+): CommandResult {
+  return spawn(
+    [
+      requireCommand("moon"),
+      "exec",
+      "--quiet",
+      "--ignore-ci-checks",
+      "--no-actions",
+      "--cache",
+      options.cache ?? "read-write",
+      ...(options.force === true ? ["--force"] : []),
+      target,
+    ],
+    {
+      cwd: fixture.repository,
+      environment: {
+        ...withoutMoonTaskContext(process.env),
+        CARGO_HOME: process.env.CARGO_HOME ?? join(homedir(), ".cargo"),
+        HOME: fixture.home,
+        MOON_HOME: join(fixture.root, "moon-home"),
+        RUSTUP_HOME: process.env.RUSTUP_HOME ?? join(homedir(), ".rustup"),
+        ...options.environment,
+      },
+    },
+  );
+}
+
+function withoutMoonTaskContext(
+  environment: Readonly<NodeJS.ProcessEnv>,
+): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(environment).filter(
+      (entry: readonly [string, string | undefined]) =>
+        !entry[0].startsWith("MOON_"),
+    ),
+  );
+}
+
+function spawn(
+  command: readonly string[],
+  options: Readonly<{
+    cwd: string;
+    environment: Readonly<NodeJS.ProcessEnv>;
+  }>,
+): CommandResult {
+  const result = Bun.spawnSync([...command], {
+    cwd: options.cwd,
+    env: options.environment,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
+  };
+}
+
+export { cleanupMoonDeploymentFixtures, createMoonDeploymentFixture, runMoon };
+export type { MoonDeploymentFixture };

--- a/tooling/deployment-moon-test-support.ts
+++ b/tooling/deployment-moon-test-support.ts
@@ -70,7 +70,15 @@ function copyMoonProjectFixture({
   );
   writeFileSync(
     join(repository, ".moon", "workspace.yml"),
-    `projects:\n  repository: .\n  ${projectId}: tooling/${projectId}\n\ndefaultProject: repository\n\nvcs:\n  defaultBranch: main\n`,
+    `projects:
+  repository: .
+  ${projectId}: tooling/${projectId}
+
+defaultProject: repository
+
+vcs:
+  defaultBranch: main
+`,
   );
   writeFileSync(
     join(repository, "moon.yml"),


### PR DESCRIPTION
## Description

- Migrates Hunspell dictionaries, Agent Memory, and Agent Handoff from Make implementations to direct Moon tasks while preserving Make compatibility delegates.
- Extends the install graph from `repository:install -> applications-install, harness:install` to `repository:install -> applications-install, hunspell-dictionaries, harness:install`, with `harness:install -> arnes:install, agent-memory:install, agent-handoff:install` and each agent `install -> binary -> build -> repository:rust`.
- Keeps `harness:semctx` explicit and outside both aggregate install paths.
- Caches reproducible Rust builds and behavioral tests; HOME mutations and dictionary installation remain uncached.
- Uses clean-state binary deployment and removes unsupported historical Agent Handoff link migration behavior.
- Updates current architecture claims and CI path filters, including root Cargo configuration.

Commits:

1. `feat(moon): install Hunspell dictionaries`
2. `feat(moon): install Agent Memory`
3. `feat(moon): install Agent Handoff`

## Useful Links

- Issue: #277, partial delivery of the behavioral Moon test slice
- Base: current `main` containing #302

## How to Test

Local environment: macOS 26.6.2 arm64, Moon 2.5.3, Bun 1.4.0.

- Full Bun barrier: 344 passed, 1 skipped, 0 failed across 48 files.
- Moon deployment tests: Agent Memory 13 passed; Agent Handoff 11 passed; Hunspell 19 passed.
- Second Moon run: 3 of 3 tasks restored from cache.
- Rust: Agent Memory fmt, Clippy, and 251 listed tests green; Agent Handoff fmt, Clippy, and 53 listed tests green.
- Arnes install barrier: 4 tasks completed, 3 cached; 640 listed Rust tests.
- TypeScript lint, typecheck, and format green; Prettier and ShellCheck green.
- `make -n hunspell-dictionaries agent-memory agent-handoff` resolves only to Moon entry points.
- Moon native task queries validate the aliases, dependencies, cache policy, and exclusion of `harness:semctx` from `harness:install`.
- Independent final review: no Critical or Important findings.

Remote CI proves Linux behavior and the disposable macOS installation/smoke path: 25 of 25 checks succeeded.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] No breaking changes

Comments added: none.
