### PR TITLE
fix(arnes): avoid exposing duplicate JSON keys in diagnostics

### DIFF
--- a/tooling/arnes/src/measure/json.rs
+++ b/tooling/arnes/src/measure/json.rs
@@ -88,10 +88,43 @@ impl<'de> Visitor<'de> for ValueVisitor {
         let mut values = Map::new();
         while let Some(key) = object.next_key::<String>()? {
             if !keys.insert(key.clone()) {
-                return Err(de::Error::custom(format!("duplicate JSON key: {key}")));
+                return Err(de::Error::custom("duplicate JSON object key"));
             }
             values.insert(key, object.next_value_seed(ValueSeed)?);
         }
         Ok(Value::Object(values))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+
+    #[test]
+    fn duplicate_key_diagnostics_do_not_expose_input_keys() {
+        let cases: &[(&[u8], &str)] = &[
+            (
+                br#"{"private_marker":1,"private_marker":2}"#,
+                "private_marker",
+            ),
+            (
+                br#"{"nested":{"/fixture/private-marker":1,"/fixture/private-marker":2}}"#,
+                "/fixture/private-marker",
+            ),
+            (
+                br#"{"\u0070rivate_marker":1,"private_marker":2}"#,
+                "private_marker",
+            ),
+        ];
+
+        for (payload, private_key) in cases {
+            let error = parse(payload).unwrap_err();
+            let diagnostic = error.to_string();
+
+            assert!(diagnostic.contains("duplicate"));
+            assert!(!diagnostic.contains(private_key));
+            assert!(error.line() > 0);
+            assert!(error.column() > 0);
+        }
     }
 }


### PR DESCRIPTION
## Description

Rejecting duplicate JSON object keys echoed the raw key in parser diagnostics, which the measurement collector can persist in `invalid.jsonl`. Return a generic duplicate-key diagnostic while preserving rejection and source location.

The regression test covers plain, nested, and Unicode-escaped duplicate keys. It failed before the production change and passes afterward.

## Useful Links

- [ADR-043 — accepted telemetry privacy contract](https://github.com/SebastienElet/dotfiles/blob/main/docs/adr/043-telemetrie-arnes-minimale-et-bornee.md)

## How to Test

Verified on macOS 26.6.2, arm64, Rust 1.98.0:

```sh
RUSTFLAGS=-Funsafe-code cargo test --manifest-path tooling/arnes/Cargo.toml --locked --offline --lib
cargo fmt --manifest-path tooling/arnes/Cargo.toml --check
RUSTFLAGS=-Funsafe-code cargo clippy --manifest-path tooling/arnes/Cargo.toml --locked --offline --all-targets -- -D warnings
RUSTFLAGS=-Funsafe-code cargo check --manifest-path tooling/arnes/Cargo.toml --locked --offline --all-targets
```

All 33 library tests passed. The full integration suite was not run locally; the existing Ubuntu CI job runs `arnes:fmt`, `arnes:clippy`, `arnes:check`, and `arnes:test`.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation reviewed; the change restores the existing ADR-043 contract
- [x] No structured interface changes; duplicate-key diagnostic text intentionally no longer includes the key
