### PR TITLE
chore(deps): update semctx to 0.1.20

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "oxlint": "1.80.0",
         "oxlint-tsgolint": "7.0.2001",
         "prettier": "3.9.6",
-        "semctx": "0.1.18",
+        "semctx": "0.1.20",
         "typescript": "7.0.2",
       },
     },
@@ -161,7 +161,7 @@
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
-    "semctx": ["semctx@0.1.18", "", { "bin": { "semctx": "dist/index.js" } }, "sha512-3XDQP6xZdbN6brVm8j66/43pAwpm8SmsxS/44Xsn8LG05AQcaRCTDBMVqlDW7cHGwUE5jqEdGWnQQ2TZfc1Pxg=="],
+    "semctx": ["semctx@0.1.20", "", { "bin": { "semctx": "dist/index.js" } }, "sha512-8PyPzEOtUtPSPqNOi5NWood5X3sRBC6Aw3nE7wytla+NQqT16dnnwEt/6XHIuk6p91JDurx7jHM40ZwnFmRIjQ=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "oxlint": "1.80.0",
     "oxlint-tsgolint": "7.0.2001",
     "prettier": "3.9.6",
-    "semctx": "0.1.18",
+    "semctx": "0.1.20",
     "typescript": "7.0.2"
   }
 }


### PR DESCRIPTION
## Description

Pin Semctx to 0.1.20 and refresh the Bun lockfile. The existing `moon run harness:semctx` task resolves this pinned CLI and installs or updates the detected Codex and Claude Code plugins.

Keep installation explicit, as required by ADR-001; no Moon task or repository semantic configuration changes are needed.

## Useful Links

- Architecture: `docs/adr/001-makefile-installateur.md`

## How to Test

Verified locally on macOS:

- `bun install --frozen-lockfile --ignore-scripts` — passes.
- `bun run prettier --check package.json` — passes.
- `git diff --check` — passes.
- `semctx --version` — 0.1.20.
- `moon run harness:semctx` — succeeds for Codex and Claude Code.
- `bun run semctx plugin-status --host auto --json` — both installed plugins report 0.1.20, enabled, and matching their marketplace snapshots; aggregate status remains UNKNOWN because public-release attestation and running-session versions are unavailable.

Load the updated plugin in a new Codex task; use `/reload-plugins` in Claude Code.

## Checklist

- [x] Changes have been tested locally through the existing installation entry point.
- [x] Documentation reviewed; no update necessary.
- [x] No repository interface changes.
