### PR TITLE
feat(moon): aggregate static checks and migrate Lua lint

### DIFF
--- a/.github/workflows/check-typescript.yml
+++ b/.github/workflows/check-typescript.yml
@@ -16,6 +16,6 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095
-      - run: >-
-          moon ci repository:typescript-lint repository:typescript-typecheck
-          repository:typescript-format-check repository:prettier-check
+      - name: Install luacheck
+        run: sudo apt-get update && sudo apt-get install -y lua-check
+      - run: moon ci repository:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,19 +7,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095
 
       - name: Install luacheck
         run: brew install luacheck
 
       - name: Lint Lua files
-        run: |
-          set -euo pipefail
-          echo "Checking Lua syntax..."
-          test -f home/.config/nvim/init.lua
-          test -f home/.config/wezterm/wezterm.lua
-          luacheck home/.config/nvim --no-unused-args --no-max-line-length --globals vim
-          luacheck home/.config/wezterm/wezterm.lua --no-max-line-length
-          echo "✅ Lua syntax OK"
+        run: moon ci repository:lua-lint
 
   shellcheck:
     name: Shell scripts

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ moon exec install
 moon action-graph repository:install
 ```
 
+## Checks
+
+With Moon and `luacheck` available on `PATH`, run the shared static check task:
+
+```bash
+moon run repository:check
+```
+
+This runs TypeScript lint, type checking and formatting, Prettier, and Lua lint.
+Run Lua lint alone with `moon run repository:lua-lint`; tests remain separate tasks.
+
 ## Architecture decisions
 
 Structural choices — installer, shell, editor, container runtime, agent

--- a/moon.yml
+++ b/moon.yml
@@ -73,6 +73,29 @@ tasks:
     options:
       cache: false
       runInCI: false
+  check:
+    description: Run repository static checks
+    command: noop
+    deps:
+      - typescript-lint
+      - typescript-typecheck
+      - typescript-format-check
+      - prettier-check
+      - lua-lint
+    toolchains: system
+  lua-lint:
+    script: |
+      set -euo pipefail
+      test -f home/.config/nvim/init.lua
+      test -f home/.config/wezterm/wezterm.lua
+      luacheck home/.config/nvim --no-unused-args --no-max-line-length --globals vim
+      luacheck home/.config/wezterm/wezterm.lua --no-max-line-length
+    inputs:
+      - home/.config/nvim/**/*.lua
+      - home/.config/wezterm/wezterm.lua
+      - .github/workflows/lint.yml
+      - .github/workflows/check-typescript.yml
+    toolchains: system
   skill-simplify-claude:
     description: Install the skill-simplify user skill for Claude Code
     script: |


### PR DESCRIPTION
## Description

Add `repository:check` as the shared entry point for TypeScript lint, type checking, TypeScript formatting, Prettier and Lua lint. Move the existing Lua commands into `repository:lua-lint` and have CI invoke the Moon tasks.

The static Ubuntu job installs `lua-check`; the existing Lua macOS job remains. Local use requires `luacheck` on PATH, as documented in the README.

## Useful Links

No linked issue.

## How to Test

- Run `moon run repository:check` with Moon and luacheck available.
- On macOS, the four TypeScript/Prettier tasks and actionlint passed after rebasing onto main; the Moon action graph resolves all five dependencies.
- Local Lua execution could not complete because luacheck is absent. GitHub CI must validate Lua on both Ubuntu and macOS before merge.

## Checklist

- [ ] Full aggregate tested locally (Lua prerequisite absent; covered by CI)
- [x] Documentation updated
- [x] Local luacheck prerequisite documented

No code comments added. The root Moon file remains above 250 lines because simple repository tasks belong in the existing root project.
