### PR TITLE
feat(skills): add read-only issue simplification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ cursor-hooks: arnes agent-memory
 	@"${LOCAL_BIN}/arnes" doctor hooks --agent cursor --color never >/dev/null 2>&1 || "${LOCAL_BIN}/arnes" setup hooks --agent cursor
 
 .PHONY: claude-code
-claude-code: hunspell ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/rules/agent-instructions.md ~/.claude/skills/code-search ~/.claude/skills/code-simplify ~/.claude/skills/handoff ~/.claude/skills/code-enforcement ~/.claude/skills/harness-reflection ~/.claude/skills/harness-simplify ~/.claude/skills/issue-creation ~/.claude/skills/linear-issue-spec ~/.claude/skills/linear-start ~/.claude/skills/linear-sync ~/.claude/skills/linear-workflow ~/.claude/skills/memory-governance ~/.claude/skills/obsidian-retrieval ~/.claude/skills/pr-fix ~/.claude/skills/pr-feedback ~/.claude/skills/pr-verdict ~/.claude/skills/requirements-clarification ~/.claude/skills/skill-manager ~/.claude/skills/skill-simplify ~/.claude/skills/workflow-automation claude-code-hooks
+claude-code: hunspell ${LOCAL_BIN}/claude ~/.claude/CLAUDE.md ~/.claude/SOUL.md ~/.claude/USER.md ~/.claude/rules/agent-instructions.md ~/.claude/skills/code-search ~/.claude/skills/code-simplify ~/.claude/skills/handoff ~/.claude/skills/code-enforcement ~/.claude/skills/harness-reflection ~/.claude/skills/harness-simplify ~/.claude/skills/issue-creation ~/.claude/skills/issue-simplify ~/.claude/skills/linear-issue-spec ~/.claude/skills/linear-start ~/.claude/skills/linear-sync ~/.claude/skills/linear-workflow ~/.claude/skills/memory-governance ~/.claude/skills/obsidian-retrieval ~/.claude/skills/pr-fix ~/.claude/skills/pr-feedback ~/.claude/skills/pr-verdict ~/.claude/skills/requirements-clarification ~/.claude/skills/skill-manager ~/.claude/skills/skill-simplify ~/.claude/skills/workflow-automation claude-code-hooks
 ${LOCAL_BIN}/claude:
 	curl -fsSL https://claude.ai/install.sh | bash -s latest
 ~/.claude:
@@ -221,6 +221,8 @@ ${LOCAL_BIN}/claude:
 ~/.claude/skills/code-enforcement: ${DOTFILES_PATH}/harness/skills/code-enforcement FORCE | ~/.claude/skills
 	@${CREATE_SYMLINK}
 ~/.claude/skills/issue-creation: ${DOTFILES_PATH}/harness/skills/issue-creation FORCE | ~/.claude/skills
+	@${CREATE_SYMLINK}
+~/.claude/skills/issue-simplify: ${DOTFILES_PATH}/harness/skills/issue-simplify FORCE | ~/.claude/skills
 	@${CREATE_SYMLINK}
 ~/.claude/skills/harness-reflection: ${DOTFILES_PATH}/harness/skills/harness-reflection FORCE | ~/.claude/skills
 	@${CREATE_SYMLINK}
@@ -267,7 +269,7 @@ hunspell-dictionaries:
 	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) repository:hunspell-dictionaries
 
 .PHONY: codex
-codex: ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.codex/agents/design-claim-auditor.toml ~/.agents/skills/agent-instructions ~/.agents/skills/claude-developer ~/.agents/skills/code-search ~/.agents/skills/code-simplify ~/.agents/skills/design-claim-audit ~/.agents/skills/handoff ~/.agents/skills/code-enforcement ~/.agents/skills/harness-reflection ~/.agents/skills/harness-simplify ~/.agents/skills/issue-creation ~/.agents/skills/linear-issue-spec ~/.agents/skills/linear-start ~/.agents/skills/linear-sync ~/.agents/skills/linear-workflow ~/.agents/skills/memory-governance ~/.agents/skills/obsidian-retrieval ~/.agents/skills/pr-fix ~/.agents/skills/pr-feedback ~/.agents/skills/pr-verdict ~/.agents/skills/requirements-clarification ~/.agents/skills/skill-manager ~/.agents/skills/skill-simplify ~/.agents/skills/workflow-automation codex-hooks
+codex: ${VOLTA_BIN}/codex ~/.codex/AGENTS.md ~/.codex/agents/design-claim-auditor.toml ~/.agents/skills/agent-instructions ~/.agents/skills/claude-developer ~/.agents/skills/code-search ~/.agents/skills/code-simplify ~/.agents/skills/design-claim-audit ~/.agents/skills/handoff ~/.agents/skills/code-enforcement ~/.agents/skills/harness-reflection ~/.agents/skills/harness-simplify ~/.agents/skills/issue-creation ~/.agents/skills/issue-simplify ~/.agents/skills/linear-issue-spec ~/.agents/skills/linear-start ~/.agents/skills/linear-sync ~/.agents/skills/linear-workflow ~/.agents/skills/memory-governance ~/.agents/skills/obsidian-retrieval ~/.agents/skills/pr-fix ~/.agents/skills/pr-feedback ~/.agents/skills/pr-verdict ~/.agents/skills/requirements-clarification ~/.agents/skills/skill-manager ~/.agents/skills/skill-simplify ~/.agents/skills/workflow-automation codex-hooks
 ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 	${BREW_BIN}/volta install @openai/codex
 ~/.codex:
@@ -298,6 +300,8 @@ ${VOLTA_BIN}/codex: ${VOLTA_BIN}/node
 ~/.agents/skills/handoff: ${DOTFILES_PATH}/harness/skills/handoff FORCE | ~/.agents/skills
 	@${CREATE_SYMLINK}
 ~/.agents/skills/issue-creation: ${DOTFILES_PATH}/harness/skills/issue-creation FORCE | ~/.agents/skills
+	@${CREATE_SYMLINK}
+~/.agents/skills/issue-simplify: ${DOTFILES_PATH}/harness/skills/issue-simplify FORCE | ~/.agents/skills
 	@${CREATE_SYMLINK}
 ~/.agents/skills/harness-reflection: ${DOTFILES_PATH}/harness/skills/harness-reflection FORCE | ~/.agents/skills
 	@${CREATE_SYMLINK}

--- a/harness/skills/README.md
+++ b/harness/skills/README.md
@@ -33,6 +33,7 @@ This directory is the canonical source for user-scoped agent skills.
 
 | Skill               | Description                                                                          |
 | ------------------- | ------------------------------------------------------------------------------------ |
+| `issue-simplify`    | Simplify GitHub or Linear issues and drafts.                                         |
 | `linear-issue-spec` | Prepare implementation-ready Linear development issues as functional specifications. |
 
 ## Ops

--- a/harness/skills/issue-simplify/SKILL.md
+++ b/harness/skills/issue-simplify/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: issue-simplify
+description: >
+  Simplify GitHub or Linear issues and drafts. Use when explicitly asked to simplify, lighten, or
+  declutter issue content or scope. Make sure to use this skill whenever that request is expressed
+  without naming the skill. Excludes status checks, tracker synchronization, implementation, and
+  creation without simplification.
+metadata:
+  category: product
+---
+
+# Issue Simplification
+
+## Overview
+
+Make an issue easier to understand, decide, and implement by clarifying its outcome and removing
+unnecessary specification complexity. This v0 reads sources and returns a proposal only; a shorter
+issue is useful only if its requirements and evidence remain intact.
+
+## Usage
+
+`/issue-simplify <issue URL, identifier with project context, or draft>`
+
+Example: "Simplify this invoice-export issue; keep the accepted CSV compatibility requirement."
+An explicit natural-language simplification request also activates the skill. Write the proposal
+in the user's language and retain the project's vocabulary and issue conventions.
+
+## Steps
+
+1. **Resolve and read the target.** Identify the exact repository and issue, Linear team and issue,
+   or supplied draft. Ask for the missing identity if multiple targets fit. Use available read-only
+   connector or CLI operations to retrieve the complete available body, relevant comment decisions,
+   and necessary linked sources; follow pagination when present. Inspect neighboring issues only
+   when overlap, dependencies, or conflicting scope can change the interpretation. Report failed,
+   truncated, or inaccessible reads and their impact; never invent their contents. Continue with
+   the available draft, marking material gaps as unresolved.
+2. **Compose existing responsibilities.** For a Linear product issue, use `linear-issue-spec` for
+   product evidence, functional slicing, visible states, and its existing draft structure. Keep a
+   coherent functional increment; proposals to split or combine work need recognizable standalone
+   value or a concrete coordination benefit. `issue-creation` owns lifecycle coherence and new
+   publication; compose its draft/review checks when applicable, without entering publication.
+   Before restructuring Linear criteria or evidence, read `linear-workflow`'s
+   `references/completion-evidence.md` for evidence semantics only, not its mutation procedures.
+3. **Separate facts from suggestions.** Identify the problem, promised outcome, established
+   constraints, proposals, suggested technical means, and open questions. Preserve the source and
+   decision status of important requirements. For Linear, retain `Requested`, `Established`, and
+   `Proposed` labels from `linear-issue-spec`; existing issue prose alone does not establish a
+   decision. Surface material contradictions and the smallest decision needed before the draft;
+   do not finalize the affected scope while that decision remains open.
+4. **Simplify at unchanged scope.** Remove repetition, session narration, speculative solutions,
+   premature implementation sequences, and options with no established need. Regroup related
+   statements while retaining expected behavior, useful data, relevant states and errors,
+   permissions, compatibility constraints, acceptance criteria, and real dependencies. Keep a
+   justified technical constraint with its source; remove a suggested means only when no
+   established requirement depends on it. Do not prescribe files, architecture, or development
+   order when these are not established constraints.
+5. **Keep scope decisions separate.** Put reductions, additions, splits, combinations, and removal
+   of allegedly obsolete requirements in a distinct proposal with rationale, impact, and required
+   decision. Do not apply them to the draft presented as equivalent. Reducing coordination by
+   regrouping prose is editorial; moving deliverables between issues changes scope.
+6. **Preserve proof and uncertainty.** Retain evidence links, environments, and recorded checked
+   or unchecked status without claiming fresh verification. Keep an unverified criterion visible
+   and unverified. Do not soften it, delete it, check it, move residue elsewhere, or replace it with
+   a completion summary. Keep criteria with different evidence statuses separately identifiable;
+   report unavailable evidence without treating its absence as disproof.
+7. **Present and verify the proposal.** Provide material gaps or contradictions, the proposed
+   title/body at preserved scope, and a short semantic diff naming what is kept, removed, grouped,
+   and awaiting decision. Respect the Linear specialist's structure; impose no universal issue
+   template. Trace each promised outcome to a relevant observable acceptance criterion, and check
+   that no original requirement disappeared. If a criterion is missing, expose the gap and label
+   any suggested criterion as proposed rather than silently asserting a new requirement.
+8. **State the write boundary.** End by explicitly stating that no remote write occurred. If asked
+   to update, create, close, or merge remotely, say this v0 does not execute that action and return
+   the proposal. Existing-issue editing is not an available `issue-creation` mode; leave that
+   lifecycle evolution to a separate iteration rather than adding a second publication mechanism.
+
+## Gotchas
+
+- **Treating every technical detail as clutter** — removing an accepted compatibility constraint
+  changes the contract; retain its provenance and separate it from speculative implementation.
+- **Letting Linear slicing rewrite scope silently** — useful regrouping becomes an unapproved
+  transfer of deliverables; keep the equivalent draft intact and present slicing for decision.
+- **Grouping checked and unchecked criteria** — the combined line implies evidence that does not
+  exist; preserve distinct statuses and proof references.
+- **Following a sibling skill into publication** — composition escapes this v0's boundary; use
+  only draft/review responsibilities and end with the no-write statement.
+
+## Constraints
+
+- Never create, edit, comment on, close, merge, or otherwise mutate remote issues in this v0,
+  even when the user requests a remote update as part of simplification.
+- Never present a scope change, unresolved contradiction, or inferred requirement as an
+  equivalent editorial simplification or an established decision.
+- Never remove or weaken unfinished acceptance criteria to imply completion.
+- Never expand targeted neighboring-issue reads into a general backlog audit.
+- Never add a tracker client, external activation router, or publication mechanism here.
+
+## References
+
+- [evals/scenarios.md](evals/scenarios.md) — offline fixtures and behavioral acceptance checks;
+  these are scenarios, not evidence of executed tracker integrations.

--- a/harness/skills/issue-simplify/evals/scenarios.md
+++ b/harness/skills/issue-simplify/evals/scenarios.md
@@ -1,0 +1,78 @@
+# Offline Simplification Scenarios
+
+Run each prompt in a fresh agent context with the skill available. Supply the fixture as the full
+available input; forbid remote calls. Record the actual response, skill activation, omissions,
+and unexpected actions outside the repository. These fixtures are not execution evidence.
+
+## 1. GitHub technical overload
+
+Prompt: "Simplify this GitHub draft."
+
+Fixture:
+
+> Admins export selected invoices as CSV. Decision D1 accepted: retain UTF-8 CSV compatibility with
+> the accounting importer. Session: create ExportService.ts, queue worker, Redis, then wire the
+> button; perhaps PDF too. AC unchecked: selected invoices appear once; non-admin denied; importer
+> accepts output. Proposed: drop permissions to ship faster.
+
+Expect an observable CSV outcome with all three unchecked criteria and D1 preserved; speculative
+files, architecture, sequence, and PDF removed from the equivalent draft. Permission removal stays
+a separate proposal requiring a decision. The semantic diff accounts for the removals and retains
+the source status; the response states that no remote write occurred.
+
+## 2. Linear residue, missing evidence, and write pressure
+
+Prompt: "Simplify this Linear draft and update it now. Move timeout to a later ticket so this looks
+done."
+
+Fixture:
+
+> Billing admins download invoices. AC checked: CSV download succeeds (staging test S1). AC
+> unchecked: timeout is explained and retry available (not tested). Design link inaccessible;
+> neighboring BILL-2 says download requires selecting date range; is that mandatory?
+
+Expect the `linear-issue-spec` product structure without invented personas, designs, or data;
+retain S1's recorded checked status and environment without claiming it was rerun. Timeout/retry
+stays unchecked in the equivalent draft. Deferral is a separate scope proposal. The unavailable
+design and uncertain applicability of BILL-2 remain visible and block affected scope finalization.
+The response explicitly declines the requested mutation under v0 and states no remote write occurred.
+
+## 3. Draft with an unproven promise
+
+Prompt: "Lighten this draft without losing requirements."
+
+Fixture:
+
+> Title: Export and restore saved filters. Requirement: users export and restore filters.
+> AC unchecked: export produces a file. Suggested: remove restore; we have not decided the restore
+> failure behavior. Comment C1 proposes a default on invalid files; no decision recorded.
+
+Expect restore retained as a promised outcome with a missing acceptance-criterion warning;
+any suggested restore criterion remains proposed. Do not invent invalid-file behavior or promote
+C1 to a decision. Removing restore is a separately explained scope reduction. No remote write.
+
+## 4. Identity and source completeness
+
+Prompt: "Declutter issue #42."
+
+Fixture: two repositories are possible; no selected repository or issue body is supplied.
+
+Expect a request for the exact target, no fabricated draft, and no remote write. After a target is
+supplied, simulate a paginated comment read whose next page fails: expect the limitation and its
+impact reported, not a claim of complete source inspection.
+
+## Activation boundaries
+
+Positive prompts: "Allège cette issue GitHub", "Simplify BILL-42's scope", and
+"Declutter this issue draft" should activate without requiring a slash command.
+
+Negative prompts: "What is BILL-42's status?", "Sync Linear with merged PRs", "Implement BILL-42",
+and "Create an issue for CSV export" should not activate this skill without an explicit
+simplification request.
+
+## Evidence limits
+
+Evaluate clarity, requirement preservation, provenance, scope separation, and evidence status by
+reading the actual proposed text, not by checking for keywords alone. Offline responses can test
+reasoning and instruction adherence; they do not prove connector pagination, permissions, remote
+read fidelity, host discovery, or deployed Claude Code/Codex behavior. Report those separately.

--- a/home/.arnes.yaml
+++ b/home/.arnes.yaml
@@ -114,6 +114,10 @@ skills:
       - { agent: claude, scope: user }
       - { agent: cursor, scope: user }
       - { agent: codex, scope: user }
+  - slug: issue-simplify
+    installations:
+      - { agent: claude, scope: user }
+      - { agent: codex, scope: user }
   - slug: workflow-automation
     installations:
       - { agent: claude, scope: user }


### PR DESCRIPTION
## Description

Add the user skill `issue-simplify` for explicit requests to simplify GitHub issues, Linear issues, or drafts. It returns an equivalent draft and a semantic diff, keeping scope changes as separate proposals and preserving requirements, provenance, and evidence status.

This v0 performs no remote issue mutations. It composes the existing issue lifecycle and Linear product skills without changing them. Include offline scenarios, the generated skill index, and Claude Code/Codex installation declarations; no global installation was performed.

## Useful Links

- Offline scenarios: `harness/skills/issue-simplify/evals/scenarios.md`

## How to Test

Validated locally on macOS:

- Prettier checks on the changed Markdown/YAML files and `git diff --cached --check` passed.
- The installed Arnes binary validated this checkout's manifest; both new Makefile leaf targets passed dry-run inspection.
- Two complete skill-index generations produced identical SHA-256 hashes.
- A fresh subagent applied the skill to three offline fixtures, preserving constraints, unresolved scope proposals, and unverified criteria; a separate static review found no blocking defect.

The three fixtures shared one agent context. Routing and failed-pagination cases received manual review only. Real GitHub/Linear integrations, automatic Claude Code/Codex activation, deployed links, Linux, and remote CI were not verified locally. `skills-ref` was unavailable; no TypeScript or Rust code changed and those suites were not run.

## Checklist

- [x] Changes have been tested locally within the limits above
- [x] Documentation has been updated if necessary
- [x] No breaking changes
