### PR TITLE
feat(skills): launch Claude handoffs in interactive terminals

### DIFF
--- a/harness/skills/README.md
+++ b/harness/skills/README.md
@@ -14,7 +14,7 @@ This directory is the canonical source for user-scoped agent skills.
 | Skill                        | Description                                                                                          |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `agent-instructions`         | Maintain coding-agent instructions and their discovery paths.                                        |
-| `claude-developer`           | Prepare manual implementation and correction prompts for Claude Code without invoking it.            |
+| `claude-developer`           | Launch Claude Code with a prepared implementation or correction prompt.                              |
 | `code-enforcement`           | Write code whose purpose is to refuse: hook, guard, validator, permission check, lint rule, CI gate. |
 | `code-search`                | Search codebases with exact and conceptual retrieval.                                                |
 | `code-simplify`              | Simplify code to reduce understanding and maintenance costs.                                         |

--- a/harness/skills/claude-developer/SKILL.md
+++ b/harness/skills/claude-developer/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: claude-developer
 description: >
-  Prepare manual implementation and correction prompts for Claude Code without invoking it. Use
-  when the user asks Codex or Cursor to pass work to Claude or returns its result for another manual
-  iteration. Make sure to intercept delegation requests even when the user does not ask for a
-  prompt; never invoke Claude automatically.
+  Launch Claude Code with a prepared implementation or correction prompt. Use when the user asks
+  Codex or Cursor to pass work to Claude or returns its result for another iteration. Make sure to
+  use this skill for Claude delegation even when no prompt is requested; preserve explicit
+  prompt-only requests.
 metadata:
   category: dev
 ---
@@ -13,18 +13,21 @@ metadata:
 
 ## Overview
 
-Prepare a launch command and one self-contained prompt for a manual Claude Code handoff. The user
-runs the command, pastes the prompt, and returns with the result when ready.
+Prepare one self-contained prompt and launch Claude Code in an interactive terminal in the verified
+worktree. Use a manual handoff when the user asks only for a prompt or the host cannot launch an
+interactive session. Starting a process and displaying it in the app are separate outcomes.
 
 ## Usage
 
 `$claude-developer <task or returned result>` — prepare an implementation or correction handoff.
+Delegation requests authorize one launch; requests for a prompt alone do not authorize execution.
 Direct implementation requests without Claude stay with the current agent.
 
 ## Steps
 
 1. Inspect repository instructions and the minimum read-only context needed for the handoff.
-   Record unresolved facts instead of guessing.
+   Record unresolved facts instead of guessing. For an existing launch, inspect its session and
+   continue at step 6 instead of preparing another prompt or starting another process.
 2. Identify the intended existing worktree from the task context; verify its absolute path and
    branch with `git worktree list --porcelain`. Use the current worktree when the task targets it.
    If the intended worktree is missing or ambiguous, ask for its path before issuing a launch
@@ -34,11 +37,31 @@ Direct implementation requests without Claude stay with the current agent.
    report. Tell Claude to inspect before editing, preserve unrelated changes, and surface conflicts.
    Include the user's authorization limits; reserve consequential actions for the user unless
    explicitly authorized.
-4. Return two fenced blocks in order: a `sh` block with the copyable one-line command
-   `cd <shell-quoted absolute worktree path> && claude`, then a `text` block with the prompt to paste
-   into that session. Substitute the verified path, quoting shell metacharacters safely. Repeat both
-   blocks for every replacement or corrective prompt, then stop.
-5. On a returned result, review only supplied evidence and explicitly authorized local state.
+4. For a prompt-only request, or when interactive execution is unavailable, return two fenced
+   blocks: `sh` with `cd <shell-quoted absolute worktree path> && claude`, then `text` with the prompt
+   to paste. Explain any unavailable capability, then stop without launching.
+5. Otherwise, use the host's interactive execution tool. In Codex, call `exec_command` with
+   `workdir` set to the verified absolute path, `tty: true`, and `cmd` set to
+   `claude <shell-quoted complete prompt>`. Preserve newlines inside the single prompt argument;
+   use POSIX quoting in a POSIX-compatible shell, or the host shell's native quoting otherwise.
+   Do not interpolate raw prompt text,
+   execute it as shell syntax, or substitute `claude -p`, which exits after its response.
+6. Keep the returned session identifier and inspect startup output with `write_stdin`, using empty
+   input for observation. A session identifier alone is not evidence that Claude started. Report
+   missing executables, authentication, trust prompts, hook errors, or early exits as observed.
+   If the sandbox prevents access to Claude's normal configuration or credentials, use the host's
+   approval mechanism for the exact launch; stop the failed process before an approved retry.
+7. In the Codex desktop app, request the terminal panel with `mcp__codex_app__open_in_codex`, target
+   `{"type":"terminal","sessionId":"<returned session identifier>"}`. Check
+   `mcp__codex_app__read_thread_terminal` for output matching the launched process. A `queued`
+   response, an empty panel, or unrelated output does not prove attachment: report the observed
+   execution state and that panel attachment is unconfirmed. Never launch another
+   Claude process to compensate for a display failure or bypass a Computer Use refusal.
+8. Report the worktree, command, session identifier, observed startup state, and panel state, then
+   leave the live session available. Forward only user-requested follow-up input to that session;
+   do not submit the initial prompt again. If execution was not started, provide the manual blocks
+   from step 4; if its outcome is uncertain, inspect the original session before proposing a retry.
+9. On a returned result, review only supplied evidence and explicitly authorized local state.
    Produce a corrective handoff only when the user requests another iteration; an unexecuted prompt
    revision replaces the previous handoff.
 
@@ -46,19 +69,31 @@ Direct implementation requests without Claude stay with the current agent.
 
 - **Starting in the wrong checkout** — a bare `claude` uses the terminal's current directory;
   supply the verified absolute path and `&&` so a failed `cd` prevents launch.
-- **Losing the manual handoff** — executing the command or starting another iteration removes the
-  user's control; supply the two blocks and wait.
+- **Confusing terminal identifiers** — an execution session may not attach to the app panel;
+  verify matching output and report uncertainty instead of claiming the panel shows Claude.
+- **Duplicating a launch** — an opening failure does not stop the existing process; retain its
+  session identifier and inspect it before retrying or forwarding input.
+- **Expanding the prompt in the shell** — quotes, backticks, and substitutions can execute prompt
+  content; pass one safely quoted argument and preserve its literal text.
 - **Trusting a returned summary** — it may omit defects or failed checks; inspect the available diff
   and evidence before making a verification claim.
 
 ## Constraints
 
-- Activate only for requests explicitly involving Claude Code, a manual handoff, or its returned
-  result; intercept automatic Claude delegation as a manual handoff.
-- During preparation, never invoke Claude, an automation wrapper, or another implementation agent;
-  never create a branch or checkout, edit files, or validate the implementation.
+- Activate only for requests explicitly involving Claude Code, a handoff, or its returned result.
+- Never launch for a prompt-only request. During preparation, never create a branch or checkout,
+  edit repository files, or validate the implementation; delegate only the authorized task.
 - Never authorize commits, pushes, merges, deletion, publication, or permission bypasses unless the
   user's current request explicitly permits them.
 - Produce at most one prompt per response and wait for the user before every subsequent iteration.
+- Preserve Claude's configured model, permission mode, and hooks unless the user requests a change.
+  Leave authentication and permission decisions to the user; do not answer them automatically.
 - This is advisory policy, not a technical execution barrier. Never claim Claude's result is
   verified without reviewing the named evidence in its stated environment.
+
+## References
+
+- [Claude Code CLI reference](https://code.claude.com/docs/en/cli-reference) — interactive initial
+  prompts and print mode
+- [Integrated terminal](https://learn.chatgpt.com/docs/integrated-terminal) — app terminal and
+  reusable actions; execution-session attachment must be verified with the available host tools

--- a/harness/skills/claude-developer/SKILL.md
+++ b/harness/skills/claude-developer/SKILL.md
@@ -13,87 +13,70 @@ metadata:
 
 ## Overview
 
-Prepare one self-contained prompt and launch Claude Code in an interactive terminal in the verified
-worktree. Use a manual handoff when the user asks only for a prompt or the host cannot launch an
-interactive session. Starting a process and displaying it in the app are separate outcomes.
+Prepare one self-contained prompt and launch Claude Code interactively in the verified worktree.
+Use a manual handoff for prompt-only requests or when interactive execution is unavailable.
 
 ## Usage
 
-`$claude-developer <task or returned result>` — prepare an implementation or correction handoff.
-Delegation requests authorize one launch; requests for a prompt alone do not authorize execution.
-Direct implementation requests without Claude stay with the current agent.
+`$claude-developer <task or returned result>` — delegate one implementation or correction.
+Requests without Claude stay with the current agent; prompt-only requests authorize no execution.
 
 ## Steps
 
-1. Inspect repository instructions and the minimum read-only context needed for the handoff.
-   Record unresolved facts instead of guessing. For an existing launch, inspect its session and
-   continue at step 6 instead of preparing another prompt or starting another process.
-2. Identify the intended existing worktree from the task context; verify its absolute path and
-   branch with `git worktree list --porcelain`. Use the current worktree when the task targets it.
-   If the intended worktree is missing or ambiguous, ask for its path before issuing a launch
-   command; do not invent a path or create a checkout.
-3. Write one prompt with the outcome, verified worktree path and branch (or detached HEAD), relevant
-   facts, constraints, acceptance criteria, allowed scope, expected verification, and delivery
-   report. Tell Claude to inspect before editing, preserve unrelated changes, and surface conflicts.
-   Include the user's authorization limits; reserve consequential actions for the user unless
-   explicitly authorized.
-4. For a prompt-only request, or when interactive execution is unavailable, return two fenced
-   blocks: `sh` with `cd <shell-quoted absolute worktree path> && claude`, then `text` with the prompt
-   to paste. Explain any unavailable capability, then stop without launching.
-5. Otherwise, use the host's interactive execution tool. In Codex, call `exec_command` with
-   `workdir` set to the verified absolute path, `tty: true`, and `cmd` set to
-   `claude <shell-quoted complete prompt>`. Preserve newlines inside the single prompt argument;
-   use POSIX quoting in a POSIX-compatible shell, or the host shell's native quoting otherwise.
-   Do not interpolate raw prompt text,
-   execute it as shell syntax, or substitute `claude -p`, which exits after its response.
-6. Keep the returned session identifier and inspect startup output with `write_stdin`, using empty
-   input for observation. A session identifier alone is not evidence that Claude started. Report
-   missing executables, authentication, trust prompts, hook errors, or early exits as observed.
-   If the sandbox prevents access to Claude's normal configuration or credentials, use the host's
-   approval mechanism for the exact launch; stop the failed process before an approved retry.
-7. In the Codex desktop app, request the terminal panel with `mcp__codex_app__open_in_codex`, target
-   `{"type":"terminal","sessionId":"<returned session identifier>"}`. Check
-   `mcp__codex_app__read_thread_terminal` for output matching the launched process. A `queued`
-   response, an empty panel, or unrelated output does not prove attachment: report the observed
-   execution state and that panel attachment is unconfirmed. Never launch another
-   Claude process to compensate for a display failure or bypass a Computer Use refusal.
-8. Report the worktree, command, session identifier, observed startup state, and panel state, then
-   leave the live session available. Forward only user-requested follow-up input to that session;
-   do not submit the initial prompt again. If execution was not started, provide the manual blocks
-   from step 4; if its outcome is uncertain, inspect the original session before proposing a retry.
-9. On a returned result, review only supplied evidence and explicitly authorized local state.
-   Produce a corrective handoff only when the user requests another iteration; an unexecuted prompt
-   revision replaces the previous handoff.
+1. Inspect repository instructions and only the read-only context needed. For an existing launch,
+   continue at step 5 without preparing or resending a prompt. On a returned result, review only
+   supplied evidence and explicitly authorized local state; continue only if another iteration is
+   requested. An unexecuted prompt revision replaces the previous handoff.
+2. Verify the intended existing worktree's absolute path and branch (or detached HEAD) with
+   `git worktree list --porcelain`; use the current worktree when targeted. If missing or ambiguous,
+   ask for its path before issuing a command.
+3. Prepare the prompt: outcome, verified worktree and branch, relevant facts and uncertainties,
+   constraints, allowed scope, acceptance criteria, verification, and delivery report. Tell Claude
+   to inspect before editing, preserve unrelated changes, surface conflicts, and respect the user's
+   authorization limits.
+4. Choose the handoff:
+   - **Manual:** return a `sh` block containing `cd <shell-quoted absolute worktree path> && claude`,
+     then a `text` block containing the prompt. Explain unavailable execution when relevant and stop.
+   - **Automatic:** use the host's interactive execution tool. In Codex, call `exec_command` with
+     the verified `workdir`, `tty: true`, and `cmd: claude <shell-quoted complete prompt>`. Use the
+     host shell's quoting to preserve the complete prompt, including newlines, as one literal
+     argument. Do not use print mode (`claude -p`), which exits after responding.
+5. Retain the session identifier and observe startup; in Codex, use `write_stdin` with empty input.
+   Report missing executables, authentication or trust prompts, hook errors, and early exits as
+   observed. For sandbox access failures, request host approval for the exact launch and stop the
+   failed process before retrying. If no process started, provide the manual blocks; if uncertain,
+   inspect the original session before retrying.
+6. In Codex desktop, call `mcp__codex_app__open_in_codex` with target
+   `{"type":"terminal","sessionId":"<returned session identifier>"}`, then check
+   `mcp__codex_app__read_thread_terminal` for matching output. Report the worktree, command, session
+   identifier, observed execution state, and panel state; leave a live session available. Forward
+   only user-requested follow-up input, without resending the initial prompt.
 
 ## Gotchas
 
-- **Starting in the wrong checkout** — a bare `claude` uses the terminal's current directory;
-  supply the verified absolute path and `&&` so a failed `cd` prevents launch.
-- **Confusing terminal identifiers** — an execution session may not attach to the app panel;
-  verify matching output and report uncertainty instead of claiming the panel shows Claude.
-- **Duplicating a launch** — an opening failure does not stop the existing process; retain its
-  session identifier and inspect it before retrying or forwarding input.
-- **Expanding the prompt in the shell** — quotes, backticks, and substitutions can execute prompt
-  content; pass one safely quoted argument and preserve its literal text.
-- **Trusting a returned summary** — it may omit defects or failed checks; inspect the available diff
-  and evidence before making a verification claim.
+- **Wrong checkout** — a bare `claude` inherits the terminal directory; set `workdir` for execution
+  or use the verified `cd ... && claude` for a manual launch.
+- **Shell expansion** — quotes, backticks, and substitutions can execute prompt content; use POSIX
+  quoting in compatible shells and native quoting elsewhere, never raw interpolation.
+- **Unconfirmed panel attachment** — `queued`, empty, or unrelated output does not prove that the
+  execution session is displayed; report attachment as unconfirmed, never launch a duplicate or
+  bypass a Computer Use refusal.
 
 ## Constraints
 
-- Activate only for requests explicitly involving Claude Code, a handoff, or its returned result.
-- Never launch for a prompt-only request. During preparation, never create a branch or checkout,
-  edit repository files, or validate the implementation; delegate only the authorized task.
-- Never authorize commits, pushes, merges, deletion, publication, or permission bypasses unless the
-  user's current request explicitly permits them.
-- Produce at most one prompt per response and wait for the user before every subsequent iteration.
-- Preserve Claude's configured model, permission mode, and hooks unless the user requests a change.
-  Leave authentication and permission decisions to the user; do not answer them automatically.
-- This is advisory policy, not a technical execution barrier. Never claim Claude's result is
-  verified without reviewing the named evidence in its stated environment.
+- During preparation, never create a branch or checkout, edit repository files, or validate the
+  implementation; delegate only the authorized task.
+- Produce at most one prompt per response and wait for the user before each subsequent iteration.
+- Preserve Claude's configured model, permission mode, and hooks unless the user requests a change;
+  leave authentication and permission decisions to the user.
+- Never authorize commits, pushes, merges, deletion, publication, or permission bypasses without
+  explicit authorization in the current request.
+- This is advisory policy, not an execution barrier. Neither a session identifier nor Claude's
+  summary proves success; verify claims against observed output and named evidence in its stated
+  environment.
 
 ## References
 
-- [Claude Code CLI reference](https://code.claude.com/docs/en/cli-reference) — interactive initial
-  prompts and print mode
-- [Integrated terminal](https://learn.chatgpt.com/docs/integrated-terminal) — app terminal and
-  reusable actions; execution-session attachment must be verified with the available host tools
+- [Claude Code CLI reference](https://code.claude.com/docs/en/cli-reference) — interactive prompts
+  and print mode
+- [Integrated terminal](https://learn.chatgpt.com/docs/integrated-terminal) — app terminal and actions

--- a/harness/skills/claude-developer/evals/trigger-queries.json
+++ b/harness/skills/claude-developer/evals/trigger-queries.json
@@ -1,11 +1,11 @@
 {
   "skill": "claude-developer",
-  "version": "1.0",
+  "version": "2.0",
   "queries": [
     {
       "query": "Delegate the approved authentication fix to Claude Code",
       "should_activate": true,
-      "reason": "Every explicit Claude delegation is converted into a manual prompt"
+      "reason": "Explicit Claude delegation authorizes one interactive launch with a prepared prompt"
     },
     {
       "query": "Write a prompt I can paste into Claude Code for this migration",
@@ -20,7 +20,17 @@
     {
       "query": "Launch Claude Code and have it implement this change automatically",
       "should_activate": true,
-      "reason": "The skill must intercept automatic delegation and return a manual prompt instead"
+      "reason": "Automatic delegation uses the host interactive execution tool and verifies startup"
+    },
+    {
+      "query": "Prepare the Claude Code command and prompt, but do not launch anything",
+      "should_activate": true,
+      "reason": "An explicit prompt-only request preserves the manual handoff"
+    },
+    {
+      "query": "Claude is already running but the Codex terminal panel is empty; show its session",
+      "should_activate": true,
+      "reason": "A panel attachment failure must not duplicate the existing Claude process"
     },
     {
       "query": "Implement the approved authentication fix",


### PR DESCRIPTION
Claude delegation currently always returns a manual command and prompt, even when the user asks to launch it. This change starts one interactive Claude Code session in the verified worktree with the complete prompt as a literal argument, while preserving prompt-only requests and user-controlled subsequent iterations.

The skill records startup separately from terminal-panel attachment, observes an existing session before any retry, and uses the host approval mechanism when Claude cannot access its normal configuration. It preserves Claude's model, permissions, and hooks. The existing activation scenarios and generated skills index are updated.

Attachment to the visible Codex terminal panel is not confirmed: `open_in_codex` returned `queued` and terminal reads did not show the launched PTY. The skill reports that limitation and does not launch a duplicate process. Automatic execution in the PTY was demonstrated; the complete visible-panel workflow remains unverified.

Validation on macOS:
- Claude Code 2.1.263 launched interactively in the intended worktree and answered `CLAUDE_TERMINAL_OK`, using a plan-mode prompt that forbade tools and file changes. The sandboxed attempt could not access normal configuration; the exact launch succeeded after native approval. Both probe processes were stopped afterward.
- The successful probe reported an existing non-blocking `agent-handoff` Stop hook error (`no supported usage record in transcript`); this PR does not change that hook.
- POSIX quoting preserved a multiline prompt containing quotes, backticks, dollar signs, and command substitutions as one literal argument in zsh.
- Repository-wide Prettier check and indexed diff whitespace check passed; the final edited files passed Prettier again after review corrections.
- Local skill conventions and the eight activation scenario records validated; README generation was byte-identical on its second run. `skills-ref` is not installed, so standard validator execution was unavailable.
- Independent comparison of the original and simplified instructions covered nine scenarios (18 document simulations), including automatic launch, prompt-only mode, returned results, missing worktrees, attachment failure, and an approved sandbox retry; no material regression was found. This was a document comparison, not a new Claude execution.

Cursor and Windows execution were not exercised. Remote CI is required before merge. No code comments added.
