### PR TITLE
feat(arnes): record PR timelines with 90-day retention

### DIFF
--- a/harness/skills/pr-verdict/SKILL.md
+++ b/harness/skills/pr-verdict/SKILL.md
@@ -113,6 +113,12 @@ says to post directly.
    lose or corrupt data blocks even when the author disagrees. A style, naming or structure
    preference never blocks: label it non-blocking, or drop it.
 
+   Complete the structured review summary from the phase-1 anchor, findings, changed-behavior
+   ledger and distinct evidence-gap inventory, then emit it with `arnes measure pr-verdict` as
+   specified in `references/measurement.md`. Do this before returning phase 5, including the
+   pre-repair pass of `pr-fix` and an unpublished verdict. Report the measurement status separately;
+   a measurement failure leaves the verdict unchanged and does not prevent its return.
+
 6. **Trace and publish.** When running inside the pre-repair pass of `pr-fix`, return the phase 5
    verdict without a ticket or publication and let that workflow continue. Otherwise, open or reuse
    a fix ticket for blocking defects, and link the initial verdict if one exists. Never open a
@@ -195,3 +201,5 @@ says to post directly.
   slots. Filled in phase 6.
 - [references/cases.md](references/cases.md) — three behavioral cases with their expected verdicts,
   forge coverage, and the record of what they have never validated.
+- [references/measurement.md](references/measurement.md) — structured local emission at the end of
+  phase 5, including duplicate and storage-failure handling.

--- a/harness/skills/pr-verdict/references/measurement.md
+++ b/harness/skills/pr-verdict/references/measurement.md
@@ -1,0 +1,96 @@
+# Local PR measurement
+
+At the end of phase 5, invoke `arnes measure pr-verdict` once from the structured review summary.
+This is a local measurement, independent of publication consent and the forge's comment marker.
+It also runs before returning the pre-repair verdict to `pr-fix`. Do not parse the final Markdown,
+transcript, a hook payload or a published comment to recover these values.
+
+Build the summary from the review's working inventories:
+
+| Argument                  | Source                                                                                                                                                          |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--forge`                 | Lowercase hostname of the anchored PR URL, such as `github.com` or `bitbucket.org`, without scheme, credentials or path                                         |
+| `--repository`            | Canonical repository path from the anchored PR's forge metadata, without hostname or `.git`; the repository containing the PR, including for fork contributions |
+| `--pr-id`                 | Positive numeric identifier resolved in phase 1                                                                                                                 |
+| `--head-sha`              | Full lowercase SHA actually reviewed; never re-resolve it from the current branch at emission time                                                              |
+| `--agent`                 | `codex`, `claude-code` or `cursor` when known; omit when unavailable                                                                                            |
+| `--verdict`               | `changes-required`, `approved-with-reservations` or `approved` selected in phase 5                                                                              |
+| `--blocking-findings`     | Number of distinct retained blocking findings, including findings about missing evidence                                                                        |
+| `--non-blocking-findings` | Number of retained reservations or non-blocking findings, counting each once                                                                                    |
+| `--observable-behaviors`  | Number of rows in the changed-behavior ledger                                                                                                                   |
+| `--evidence-gaps`         | Number of distinct missing-evidence items inventoried in phases 2–4, across both ledger and barrier; an item repeated in several places counts once             |
+
+For evidence gaps, missing positive evidence and a missing negative witness are separate items;
+an uncovered platform or integration boundary is another item when explicitly inventoried. Keep
+these items in the working inventory before composing the verdict; a blocker and a gap may describe
+the same missing proof but are separate counts. Unknown counts are not zero: complete the inventory
+or report measurement unavailable, without inventing values or changing the verdict.
+
+This synthetic example represents two blocking findings, one reservation, three behavior rows and
+two distinct gaps; replace every value from the actual review before invocation:
+
+```sh
+arnes measure pr-verdict \
+  --forge github.com --repository example/project --pr-id 1042 \
+  --head-sha aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --agent codex \
+  --verdict changes-required --blocking-findings 2 --non-blocking-findings 1 \
+  --observable-behaviors 3 --evidence-gaps 2
+```
+
+Arnes adds the schema version, event type, UTC Unix timestamp in milliseconds, operating system and
+architecture. It does not infer the verdict from the counts, check the remote PR, inspect the diff
+or establish causal links. The phase-1 anchor remains the evidence for the declared PR and SHA.
+No network service, session identifier, personal hostname, prompt or verdict text is stored.
+Measurement v2 has no retained verdict artifact, so this iteration adds no artifact reference.
+
+The command uses the existing measurement store:
+`$XDG_STATE_HOME/dotfiles/agent-harness/pull-requests/<identity-hash>/events.jsonl`, with
+`~/.local/state` as the default state base. The hash is SHA-256 of the compact JSON PR identity
+object in `forge`, `repository`, `pr_id` order; events retain that identity in readable form.
+The timeline is shared across agents and sessions, regardless of their Git worktree. It has schema version
+1, independently of hook run versions, and does not require a run to exist. Existing runs and their
+60-day v2 retention are unchanged. A whole PR timeline expires 90 days after its latest event
+timestamp; a new event preserves the whole history until that inactivity interval elapses again.
+Hooks and successful PR emissions invoke the same opportunistic maintenance, at most once per day.
+Without another invocation, expiry is not an immediate scheduled deletion. Corrupt, empty, unsafe
+or future-dated timelines are preserved with an observable maintenance error.
+
+Lifecycle locks live outside deleted timelines in `pr-locks/<hash-prefix>.lock`, using 256 shared
+slots. Writers take the lock before creating a PR directory; maintenance rechecks expiration under
+that same lock immediately before deletion. `retention.json` version 2 reports `candidate_prs` and
+`removed_prs` alongside the existing run counts and maintenance status; version 1 remains readable.
+
+Each line is one factual event: `schema_version`, `event_type`, `timestamp_ms`, `pr`, `head_sha`,
+nullable `agent`, `operating_system`, `architecture`, and `data` containing the verdict and four
+counts. The writer validates existing records and holds its lifecycle lock across duplicate detection
+and append. It preserves existing bytes and refuses unsupported schema versions or corrupt history.
+A partial write can leave a visibly invalid tail: no automatic repair or deletion is attempted.
+
+Handle the command result before returning the verdict:
+
+- Exit 0, `recorded`: report `Measurement: recorded` separately from the verdict.
+- Exit 0, `duplicate`: the same `{pr, head_sha, event_type}` and verdict data already exist;
+  report `Measurement: duplicate (existing event found)`. Agent and timestamp differences do
+  not create another observation or refresh its age. Routine maintenance may expire that event.
+- Nonzero exit: report `Measurement: failed` with the diagnostic, separately from the unchanged
+  verdict. A different verdict or count for an existing key is a conflict; keep the first event
+  and surface the conflict. There is no replacement flag in this iteration. A maintenance error
+  after emission explicitly says whether the PR event was recorded or found as a duplicate;
+  it does not undo the write or change the verdict.
+- Missing Arnes or unsupported subcommand: report `Measurement: unavailable` with the diagnostic
+  and return the unchanged verdict; do not install tools or fall back to a parallel store.
+
+Keep a failed emission's structured summary in the current task for an explicit retry after the
+storage problem is resolved. Do not suppress stderr, translate telemetry errors into review findings,
+or let a failed command prevent the review's return. A retry after a successful write is idempotent
+while its event remains stored; purged history no longer provides duplicate detection.
+
+## Next iteration checkpoint
+
+The next iteration can add a new event type and its producer to this same PR envelope and store,
+with its own behavioral tests and an explicit decision on same-SHA revisions when needed. Deferred:
+raw prompts, intention summaries, `pr-feedback` ingestion, `pr-fix` history, generic corrections,
+pre-PR association through a Git worktree, causal analysis, derived metrics, dashboards and reports.
+Future causal links must distinguish at least `inferred` and `confirmed`; none exist here.
+`pr-feedback` remains read-only, `pr-verdict` remains independent with no auto-fix, and
+`harness-reflection` remains unchanged for later cross-measurement analysis.

--- a/tooling/arnes/src/cli.rs
+++ b/tooling/arnes/src/cli.rs
@@ -1,7 +1,9 @@
 use arnes::diagnostic::ColorMode;
 use arnes::hooks::SetupHooksArgs;
 use arnes::manifest::{Agent, Scope};
-use arnes::measure::{FeedbackArgs, FinishArgs, HookAgent, ListArgs, OutcomeArgs, ReportArgs};
+use arnes::measure::{
+    FeedbackArgs, FinishArgs, HookAgent, ListArgs, OutcomeArgs, PrVerdictArgs, ReportArgs,
+};
 use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
@@ -51,6 +53,7 @@ pub(crate) enum MeasureCommand {
     Finish(FinishArgs),
     Feedback(FeedbackArgs),
     Outcome(OutcomeArgs),
+    PrVerdict(PrVerdictArgs),
     Report(ReportArgs),
 }
 

--- a/tooling/arnes/src/measure.rs
+++ b/tooling/arnes/src/measure.rs
@@ -5,6 +5,7 @@ mod input;
 mod json;
 mod model;
 mod outcome;
+mod pr_timeline;
 mod report;
 mod repository;
 mod result;
@@ -17,6 +18,7 @@ use std::fmt::{self, Display};
 pub use hook::capture;
 pub use model::HookAgent;
 pub use outcome::{OutcomeArgs, OutcomeStatus, UnjudgeableReason, record as outcome};
+pub use pr_timeline::{PrVerdictArgs, record as pr_verdict};
 pub use report::{ReportArgs, render as report};
 pub use result::{
     Adjudication, FailureCategory, FeedbackArgs, FeedbackSource, FinishArgs, ListArgs, ListFormat,

--- a/tooling/arnes/src/measure/hook.rs
+++ b/tooling/arnes/src/measure/hook.rs
@@ -53,9 +53,9 @@ fn persist_hook(
     deployment_root: &Path,
 ) -> Result<(), MeasureError> {
     let run_id = digest(&[agent.as_str().as_bytes(), session.as_bytes()]);
-    let run_dir = store.run_dir(&run_id)?;
     let lifecycle = store.open_run_lock(&run_id)?;
     lifecycle.lock()?;
+    let run_dir = store.run_dir(&run_id)?;
     let timestamp_ms = now_ms();
     let run_json = run_dir.join("run.json");
     let run = if run_json.exists()? {

--- a/tooling/arnes/src/measure/pr_timeline.rs
+++ b/tooling/arnes/src/measure/pr_timeline.rs
@@ -1,0 +1,91 @@
+mod model;
+pub(super) mod retention;
+mod validation;
+
+use super::MeasureError;
+use super::hook::now_ms;
+use super::result::{open_store, visit_jsonl_typed};
+use super::store::{ManagedPath, Store, append_jsonl_bytes, jsonl_bytes};
+pub use model::PrVerdictArgs;
+use model::{EventType, PrEventRecord, PrIdentity, VerdictData};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+
+pub fn record(args: PrVerdictArgs) -> Result<&'static str, MeasureError> {
+    validation::input(&args)?;
+    let store = open_store()?;
+    let status = persist(&store, args)?;
+    super::retention::retain(&store, now_ms()).map_err(|error| {
+        MeasureError::new(format!("PR event {status}; retention failed: {error}"))
+    })?;
+    Ok(status)
+}
+
+fn persist(store: &Store, args: PrVerdictArgs) -> Result<&'static str, MeasureError> {
+    let pr_hash = identity_hash(&args.pr)?;
+    let lock = store.open_pr_lock(&pr_hash)?;
+    lock.lock()?;
+    let directory = store.state_path("pull-requests").join(&pr_hash);
+    directory.create_dir_all()?;
+    let path = directory.join("events.jsonl");
+    if let Some(existing) = recorded_verdict(&path, &pr_hash, &args.head_sha)? {
+        if existing == args.data {
+            return Ok("duplicate");
+        }
+        return Err(MeasureError::new(
+            "different verdict already recorded for this PR, SHA and event type; history is unchanged",
+        ));
+    }
+    let event = PrEventRecord {
+        schema_version: 1,
+        event_type: EventType::PrVerdict,
+        timestamp_ms: now_ms(),
+        pr: args.pr,
+        head_sha: args.head_sha,
+        agent: args.agent.map(|agent| agent.as_str().to_owned()),
+        operating_system: std::env::consts::OS.to_owned(),
+        architecture: std::env::consts::ARCH.to_owned(),
+        data: args.data,
+    };
+    validation::record(&event)?;
+    append_jsonl_bytes(&path, &jsonl_bytes(&event)?)?;
+    Ok("recorded")
+}
+
+fn recorded_verdict(
+    path: &ManagedPath,
+    pr_hash: &str,
+    head_sha: &str,
+) -> Result<Option<VerdictData>, MeasureError> {
+    let mut existing = None;
+    visit_events(path, pr_hash, |record| {
+        if record.event_type == EventType::PrVerdict && record.head_sha == head_sha {
+            existing = Some(record.data);
+        }
+        Ok(())
+    })?;
+    Ok(existing)
+}
+
+fn visit_events(
+    path: &ManagedPath,
+    pr_hash: &str,
+    mut visitor: impl FnMut(PrEventRecord) -> Result<(), MeasureError>,
+) -> Result<(), MeasureError> {
+    let mut keys = HashSet::new();
+    visit_jsonl_typed(path, "PR events.jsonl", |record: PrEventRecord| {
+        validation::record(&record)?;
+        if identity_hash(&record.pr)? != pr_hash
+            || !keys.insert((record.event_type, record.head_sha.clone()))
+        {
+            return Err(MeasureError::new(
+                "managed PR timeline has a conflicting identity or duplicate event",
+            ));
+        }
+        visitor(record)
+    })
+}
+
+fn identity_hash(pr: &PrIdentity) -> Result<String, MeasureError> {
+    Ok(format!("{:x}", Sha256::digest(serde_json::to_vec(pr)?)))
+}

--- a/tooling/arnes/src/measure/pr_timeline/model.rs
+++ b/tooling/arnes/src/measure/pr_timeline/model.rs
@@ -1,0 +1,79 @@
+use super::super::model::HookAgent;
+use clap::{Args, ValueEnum};
+use serde::{Deserialize, Serialize};
+
+#[derive(Args)]
+#[command(about = "Append an explicit PR verdict to the local measurement timeline")]
+pub struct PrVerdictArgs {
+    #[command(flatten)]
+    pub(super) pr: PrIdentity,
+    #[arg(
+        long,
+        help = "Full head SHA actually judged, never the current branch inferred later"
+    )]
+    pub(super) head_sha: String,
+    #[arg(long, value_enum)]
+    pub(super) agent: Option<HookAgent>,
+    #[command(flatten)]
+    pub(super) data: VerdictData,
+}
+
+#[derive(Args, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PrIdentity {
+    #[arg(long, help = "Canonical lowercase forge hostname, such as github.com")]
+    pub forge: String,
+    #[arg(
+        long,
+        help = "Canonical repository path from the PR metadata, without host or .git"
+    )]
+    pub repository: String,
+    #[arg(long)]
+    pub pr_id: u64,
+}
+
+#[derive(Args, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct VerdictData {
+    #[arg(long, value_enum)]
+    pub verdict: Verdict,
+    #[arg(long)]
+    pub blocking_findings: u64,
+    #[arg(long)]
+    pub non_blocking_findings: u64,
+    #[arg(long, help = "Number of rows in the changed-behavior ledger")]
+    pub observable_behaviors: u64,
+    #[arg(
+        long,
+        help = "Number of distinct missing-evidence items in the review inventory"
+    )]
+    pub evidence_gaps: u64,
+}
+
+#[derive(Clone, Copy, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum Verdict {
+    ChangesRequired,
+    ApprovedWithReservations,
+    Approved,
+}
+
+#[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum EventType {
+    PrVerdict,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PrEventRecord {
+    pub schema_version: u8,
+    pub event_type: EventType,
+    pub timestamp_ms: u64,
+    pub pr: PrIdentity,
+    pub head_sha: String,
+    pub agent: Option<String>,
+    pub operating_system: String,
+    pub architecture: String,
+    pub data: VerdictData,
+}

--- a/tooling/arnes/src/measure/pr_timeline/retention.rs
+++ b/tooling/arnes/src/measure/pr_timeline/retention.rs
@@ -1,0 +1,85 @@
+use super::super::MeasureError;
+use super::super::store::{ManagedPath, Store};
+use super::visit_events;
+use std::fs::File;
+
+const RETENTION_MS: u64 = 90 * 86_400_000;
+
+struct ExpiredPr {
+    path: ManagedPath,
+    _lifecycle: File,
+}
+
+pub(in crate::measure) fn candidates(
+    store: &Store,
+    now_ms: u64,
+) -> Result<Vec<String>, MeasureError> {
+    let timelines = store.state_path("pull-requests");
+    if !timelines.exists()? {
+        return Ok(Vec::new());
+    }
+    let mut names = timelines.read_dir_names()?;
+    names.sort();
+    let mut candidates = Vec::new();
+    for name in names {
+        let pr_hash = name
+            .into_string()
+            .map_err(|_| MeasureError::new("managed PR identity hash is not UTF-8"))?;
+        if expired_pr(store, &pr_hash, now_ms)?.is_some() {
+            candidates.push(pr_hash);
+        }
+    }
+    Ok(candidates)
+}
+
+pub(in crate::measure) fn remove_candidates(
+    store: &Store,
+    candidates: &[String],
+    now_ms: u64,
+    removed: &mut u64,
+) -> Result<(), MeasureError> {
+    for pr_hash in candidates {
+        if let Some(pr) = expired_pr(store, pr_hash, now_ms)? {
+            pr.path.remove_tree()?;
+            *removed += 1;
+        }
+    }
+    Ok(())
+}
+
+fn expired_pr(
+    store: &Store,
+    pr_hash: &str,
+    now_ms: u64,
+) -> Result<Option<ExpiredPr>, MeasureError> {
+    let lock = store.open_pr_lock(pr_hash)?;
+    lock.lock()?;
+    let path = store.state_path("pull-requests").join(pr_hash);
+    if !path.exists()? {
+        return Ok(None);
+    }
+    path.open_directory()?;
+    let now_ms = now_ms.max(super::super::hook::now_ms());
+    let mut last_event = None;
+    visit_events(&path.join("events.jsonl"), pr_hash, |record| {
+        if record.timestamp_ms > now_ms {
+            return Err(MeasureError::new(
+                "retention refuses future PR event timestamps",
+            ));
+        }
+        last_event = Some(last_event.map_or(record.timestamp_ms, |last: u64| {
+            last.max(record.timestamp_ms)
+        }));
+        Ok(())
+    })?;
+    let last_event = last_event
+        .ok_or_else(|| MeasureError::new("retention refuses a PR timeline without events"))?;
+    if now_ms.saturating_sub(last_event) < RETENTION_MS {
+        return Ok(None);
+    }
+    path.validate_removal()?;
+    Ok(Some(ExpiredPr {
+        path,
+        _lifecycle: lock,
+    }))
+}

--- a/tooling/arnes/src/measure/pr_timeline/validation.rs
+++ b/tooling/arnes/src/measure/pr_timeline/validation.rs
@@ -1,0 +1,69 @@
+use super::super::MeasureError;
+use super::model::{PrEventRecord, PrIdentity, PrVerdictArgs};
+
+pub(super) fn input(args: &PrVerdictArgs) -> Result<(), MeasureError> {
+    identity(&args.pr)?;
+    head_sha(&args.head_sha)
+}
+
+pub(super) fn record(record: &PrEventRecord) -> Result<(), MeasureError> {
+    identity(&record.pr)?;
+    head_sha(&record.head_sha)?;
+    let valid_agent = record
+        .agent
+        .as_deref()
+        .is_none_or(|agent| matches!(agent, "codex" | "claude-code" | "cursor"));
+    if record.schema_version != 1
+        || record.timestamp_ms == 0
+        || !valid_agent
+        || record.operating_system.is_empty()
+        || record.architecture.is_empty()
+    {
+        return Err(MeasureError::new(
+            "managed PR event has invalid metadata or schema version",
+        ));
+    }
+    Ok(())
+}
+
+fn identity(pr: &PrIdentity) -> Result<(), MeasureError> {
+    let valid_host = (1..=253).contains(&pr.forge.len())
+        && pr.forge.split('.').all(|label| {
+            (1..=63).contains(&label.len())
+                && !label.starts_with('-')
+                && !label.ends_with('-')
+                && label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        });
+    let valid_repository = (1..=255).contains(&pr.repository.len())
+        && pr.repository.contains('/')
+        && !pr.repository.ends_with(".git")
+        && pr.repository.split('/').all(|segment| {
+            !segment.is_empty()
+                && !matches!(segment, "." | "..")
+                && segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        });
+    if !valid_host || !valid_repository || pr.pr_id == 0 {
+        return Err(MeasureError::new(
+            "PR identity requires a lowercase forge hostname, canonical repository path and positive PR id",
+        ));
+    }
+    Ok(())
+}
+
+fn head_sha(value: &str) -> Result<(), MeasureError> {
+    if matches!(value.len(), 40 | 64)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err(MeasureError::new(
+            "head SHA must be 40 or 64 lowercase hexadecimal characters",
+        ))
+    }
+}

--- a/tooling/arnes/src/measure/retention.rs
+++ b/tooling/arnes/src/measure/retention.rs
@@ -1,5 +1,6 @@
 use super::MeasureError;
 use super::outcome::latest as latest_outcome;
+use super::pr_timeline::retention as pr_retention;
 use super::result::{open_run, read_events_for_list_with, read_optional_json};
 use super::store::{Store, open_private_append, validation, write_json_atomic};
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,10 @@ struct RetentionState {
     next_sweep_at_ms: u64,
     candidate_runs: u64,
     removed_runs: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    candidate_prs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    removed_prs: Option<u64>,
 }
 
 #[derive(Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
@@ -42,30 +47,45 @@ pub fn retain(store: &Store, now_ms: u64) -> Result<(), MeasureError> {
     if read_state(&state_path)?.is_some_and(|state| suppresses_sweep(&state, now_ms)) {
         return Ok(());
     }
-    let candidates = match candidates(store, now_ms) {
-        Ok(candidates) => candidates,
-        Err(error) => {
-            write_state(&state_path, RetentionStatus::Failed, now_ms, 0, 0)?;
-            return Err(error);
-        }
+    let mut state = RetentionState {
+        schema_version: 2,
+        status: RetentionStatus::Sweeping,
+        swept_at_ms: now_ms,
+        next_sweep_at_ms: now_ms.saturating_add(DAY_MS),
+        candidate_runs: 0,
+        removed_runs: 0,
+        candidate_prs: Some(0),
+        removed_prs: Some(0),
     };
-    let candidate_runs = u64::try_from(candidates.len())
+    let result = sweep(store, &state_path, &mut state);
+    state.status = if result.is_ok() {
+        RetentionStatus::Complete
+    } else {
+        RetentionStatus::Failed
+    };
+    write_json_atomic(&state_path, &state)?;
+    result
+}
+
+fn sweep(
+    store: &Store,
+    state_path: &super::store::ManagedPath,
+    state: &mut RetentionState,
+) -> Result<(), MeasureError> {
+    let runs = candidates(store, state.swept_at_ms)?;
+    let prs = pr_retention::candidates(store, state.swept_at_ms)?;
+    state.candidate_runs = u64::try_from(runs.len())
         .map_err(|_| MeasureError::new("retention candidate count overflow"))?;
-    write_state(
-        &state_path,
-        RetentionStatus::Sweeping,
-        now_ms,
-        candidate_runs,
-        0,
-    )?;
-    let removed_runs = remove_candidates(store, &candidates, now_ms, &state_path)?;
-    write_state(
-        &state_path,
-        RetentionStatus::Complete,
-        now_ms,
-        candidate_runs,
-        removed_runs,
-    )
+    state.candidate_prs = Some(
+        u64::try_from(prs.len())
+            .map_err(|_| MeasureError::new("retention candidate count overflow"))?,
+    );
+    write_json_atomic(state_path, state)?;
+    remove_candidates(store, &runs, state.swept_at_ms, &mut state.removed_runs)?;
+    let mut removed_prs = 0;
+    let result = pr_retention::remove_candidates(store, &prs, state.swept_at_ms, &mut removed_prs);
+    state.removed_prs = Some(removed_prs);
+    result
 }
 
 fn candidates(store: &Store, now_ms: u64) -> Result<Vec<String>, MeasureError> {
@@ -92,40 +112,17 @@ fn remove_candidates(
     store: &Store,
     candidates: &[String],
     now_ms: u64,
-    state_path: &super::store::ManagedPath,
-) -> Result<u64, MeasureError> {
-    let mut removed = 0_u64;
+    removed: &mut u64,
+) -> Result<(), MeasureError> {
     for run_id in candidates {
-        let run = match expired_run(store, run_id, now_ms) {
-            Ok(run) => run,
-            Err(error) => {
-                write_state(
-                    state_path,
-                    RetentionStatus::Failed,
-                    now_ms,
-                    u64::try_from(candidates.len()).unwrap_or(u64::MAX),
-                    removed,
-                )?;
-                return Err(error);
-            }
-        };
-        if let Some(run) = run {
-            if let Err(error) = run.path.remove_tree() {
-                write_state(
-                    state_path,
-                    RetentionStatus::Failed,
-                    now_ms,
-                    u64::try_from(candidates.len()).unwrap_or(u64::MAX),
-                    removed,
-                )?;
-                return Err(error);
-            }
-            removed = removed
+        if let Some(run) = expired_run(store, run_id, now_ms)? {
+            run.path.remove_tree()?;
+            *removed = removed
                 .checked_add(1)
                 .ok_or_else(|| MeasureError::new("retention removal count overflow"))?;
         }
     }
-    Ok(removed)
+    Ok(())
 }
 
 fn expired_run(
@@ -170,26 +167,6 @@ fn expired_run(
     }))
 }
 
-fn write_state(
-    path: &super::store::ManagedPath,
-    status: RetentionStatus,
-    now_ms: u64,
-    candidate_runs: u64,
-    removed_runs: u64,
-) -> Result<(), MeasureError> {
-    write_json_atomic(
-        path,
-        &RetentionState {
-            schema_version: 1,
-            status,
-            swept_at_ms: now_ms,
-            next_sweep_at_ms: now_ms.saturating_add(DAY_MS),
-            candidate_runs,
-            removed_runs,
-        },
-    )
-}
-
 fn suppresses_sweep(state: &RetentionState, now_ms: u64) -> bool {
     state.status != RetentionStatus::Sweeping && state.next_sweep_at_ms > now_ms
 }
@@ -197,7 +174,7 @@ fn suppresses_sweep(state: &RetentionState, now_ms: u64) -> bool {
 fn read_state(path: &super::store::ManagedPath) -> Result<Option<RetentionState>, MeasureError> {
     let state = read_optional_json(path, "retention.json")?;
     if state.as_ref().is_some_and(|state: &RetentionState| {
-        state.schema_version != 1
+        !valid_version(state)
             || state.next_sweep_at_ms < state.swept_at_ms
             || state.removed_runs > state.candidate_runs
     }) {
@@ -206,4 +183,12 @@ fn read_state(path: &super::store::ManagedPath) -> Result<Option<RetentionState>
         ));
     }
     Ok(state)
+}
+
+fn valid_version(state: &RetentionState) -> bool {
+    match (state.schema_version, state.candidate_prs, state.removed_prs) {
+        (1, None, None) => true,
+        (2, Some(candidates), Some(removed)) => removed <= candidates,
+        _ => false,
+    }
 }

--- a/tooling/arnes/src/measure/retention.rs
+++ b/tooling/arnes/src/measure/retention.rs
@@ -130,15 +130,14 @@ fn expired_run(
     run_id: &str,
     now_ms: u64,
 ) -> Result<Option<ExpiredRun>, MeasureError> {
+    let lock = store.open_run_lock(run_id)?;
+    lock.lock()?;
     let run = open_run(store, run_id)?;
     let metadata = validation::read_run(&run.join("run.json"))?;
     if metadata.schema_version() != 2 {
         return Ok(None);
     }
-    let lock = store.open_run_lock(run_id)?;
-    lock.lock()?;
     let now_ms = now_ms.max(super::hook::now_ms());
-    let metadata = validation::read_run(&run.join("run.json"))?;
     let (events, ()) = read_events_for_list_with(&run.join("events.jsonl"), run_id, || Ok(()))?;
     if !events.timestamps_consistent() {
         return Err(MeasureError::new(

--- a/tooling/arnes/src/measure/store.rs
+++ b/tooling/arnes/src/measure/store.rs
@@ -79,6 +79,19 @@ impl Store {
         append_jsonl_bytes(&self.root.join("invalid.jsonl"), &bytes)
     }
 
+    pub fn open_pr_lock(&self, pr_hash: &str) -> Result<std::fs::File, MeasureError> {
+        if pr_hash.len() != 64
+            || !pr_hash
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(MeasureError::new("managed PR identity hash is invalid"));
+        }
+        let locks = self.root.join("pr-locks");
+        locks.create_dir_all()?;
+        open_private_append(&locks.join(format!("{}.lock", &pr_hash[..2])))
+    }
+
     pub fn usage(&self) -> Result<StorageUsage, MeasureError> {
         usage(&self.root)
     }

--- a/tooling/arnes/src/measure/store/tests.rs
+++ b/tooling/arnes/src/measure/store/tests.rs
@@ -9,6 +9,44 @@ use std::sync::{Arc, Barrier};
 const MAX_RECORD_BYTES: usize = 1_100_000;
 
 #[test]
+fn pr_retention_rechecks_a_candidate_after_a_fresh_append() {
+    use crate::measure::{hook::now_ms, pr_timeline::retention};
+    use serde_json::json;
+
+    let directory = tempfile::tempdir().unwrap();
+    let store = Store::open_from_state_base(directory.path(), &[]).unwrap();
+    let pr_hash = "ca2553be5531ecdb5e2cffad537225c437eeb107490fb7e44a189a38b3869421";
+    let timeline = store.state_path("pull-requests").join(pr_hash);
+    timeline.create_dir_all().unwrap();
+    let path = timeline.join("events.jsonl");
+    let now = now_ms();
+    let mut event = json!({
+        "schema_version": 1, "event_type": "pr-verdict",
+        "timestamp_ms": now - 91 * 86_400_000,
+        "pr": {"forge": "github.com", "repository": "example/project", "pr_id": 1042},
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "agent": "codex", "operating_system": "macos", "architecture": "aarch64",
+        "data": {"verdict": "changes-required", "blocking_findings": 2,
+                 "non_blocking_findings": 1, "observable_behaviors": 3, "evidence_gaps": 2}
+    });
+    append_jsonl_bytes(&path, &super::jsonl_bytes(&event).unwrap()).unwrap();
+    let candidates = retention::candidates(&store, now).unwrap();
+    assert_eq!(candidates, [pr_hash]);
+
+    let lock = store.open_pr_lock(pr_hash).unwrap();
+    lock.lock().unwrap();
+    event["timestamp_ms"] = json!(now_ms());
+    event["head_sha"] = json!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    append_jsonl_bytes(&path, &super::jsonl_bytes(&event).unwrap()).unwrap();
+    drop(lock);
+
+    let mut removed = 0;
+    retention::remove_candidates(&store, &candidates, now_ms(), &mut removed).unwrap();
+    assert_eq!(removed, 0);
+    assert!(path.exists().unwrap());
+}
+
+#[test]
 fn jsonl_writer_accepts_the_readers_exact_line_limit() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("events.jsonl");

--- a/tooling/arnes/src/measure/store/tests.rs
+++ b/tooling/arnes/src/measure/store/tests.rs
@@ -9,6 +9,45 @@ use std::sync::{Arc, Barrier};
 const MAX_RECORD_BYTES: usize = 1_100_000;
 
 #[test]
+fn retention_waits_for_run_initialization_before_reading_metadata() {
+    use crate::measure::{hook::now_ms, retention};
+    use serde_json::json;
+    use std::sync::mpsc::{self, RecvTimeoutError};
+    use std::time::Duration;
+
+    let directory = tempfile::tempdir().unwrap();
+    let store = Store::open_from_state_base(directory.path(), &[]).unwrap();
+    let run_id = "ab".repeat(32);
+    let lifecycle = store.open_run_lock(&run_id).unwrap();
+    lifecycle.lock().unwrap();
+    let run = store.run_dir(&run_id).unwrap();
+    let (sender, receiver) = mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        sender.send(retention::retain(&store, now_ms())).unwrap();
+    });
+    let before_initialization = receiver.recv_timeout(Duration::from_secs(1));
+    let metadata = json!({
+        "schema_version": 2, "run_id": run_id, "agent": "codex",
+        "started_at_ms": now_ms(), "model_fingerprint": null,
+        "repository_commit": null, "repository_dirty": null,
+        "harness_fingerprint": "00".repeat(32), "harness_fingerprint_limitations": [],
+        "operating_system": "macos", "architecture": "aarch64"
+    });
+    super::write_json_atomic(&run.join("run.json"), &metadata).unwrap();
+    drop(lifecycle);
+    worker.join().unwrap();
+    assert!(
+        matches!(before_initialization, Err(RecvTimeoutError::Timeout)),
+        "retention read an uninitialized run: {before_initialization:?}"
+    );
+    receiver
+        .recv_timeout(Duration::from_secs(5))
+        .unwrap()
+        .unwrap();
+    assert!(run.join("run.json").exists().unwrap());
+}
+
+#[test]
 fn pr_retention_rechecks_a_candidate_after_a_fresh_append() {
     use crate::measure::{hook::now_ms, pr_timeline::retention};
     use serde_json::json;

--- a/tooling/arnes/src/measure_cli.rs
+++ b/tooling/arnes/src/measure_cli.rs
@@ -23,6 +23,9 @@ pub(super) fn run_measure(command: MeasureCommand) -> ExitCode {
         MeasureCommand::Finish(args) => finish_measure(measure::finish(args)),
         MeasureCommand::Feedback(args) => finish_measure(measure::feedback(args)),
         MeasureCommand::Outcome(args) => finish_measure(measure::outcome(args)),
+        MeasureCommand::PrVerdict(args) => finish_measure(
+            measure::pr_verdict(args).and_then(|status| write_output(status).map_err(Into::into)),
+        ),
         MeasureCommand::Report(args) => match measure::report(args) {
             Ok(output) => match write_output(&output) {
                 Ok(()) => ExitCode::SUCCESS,

--- a/tooling/arnes/tests/measure_pr_timeline.rs
+++ b/tooling/arnes/tests/measure_pr_timeline.rs
@@ -1,0 +1,116 @@
+#[path = "measure_pr_timeline/retention.rs"]
+mod retention;
+#[path = "measure_pr_timeline/storage.rs"]
+mod storage;
+#[path = "measure_pr_timeline/support.rs"]
+mod support;
+
+use support::*;
+
+#[test]
+fn records_a_compact_verdict_on_the_explicit_pr_head() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    let event = harness.events().remove(0);
+    assert_eq!(event["schema_version"], 1);
+    assert_eq!(event["event_type"], "pr-verdict");
+    assert!(event["timestamp_ms"].as_u64().unwrap() > 0);
+    assert_eq!(
+        event["pr"],
+        json!({"forge": "github.com", "repository": "example/project", "pr_id": 1042})
+    );
+    assert_eq!(event["head_sha"], SHA);
+    assert_eq!(event["agent"], "codex");
+    assert_eq!(event["operating_system"], std::env::consts::OS);
+    assert_eq!(event["architecture"], std::env::consts::ARCH);
+    assert_eq!(
+        event["data"],
+        json!({
+            "verdict": "changes-required", "blocking_findings": 2,
+            "non_blocking_findings": 1, "observable_behaviors": 3, "evidence_gaps": 2
+        })
+    );
+    assert!(event.to_string().len() < 1000);
+    assert!(
+        !event
+            .to_string()
+            .contains(harness.root.path().to_str().unwrap())
+    );
+}
+
+#[test]
+fn retries_across_agents_do_not_duplicate_the_same_sha() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    let original = fs::read(harness.timeline()).unwrap();
+    assert_status(&harness.record(&[("--agent", "cursor")]), "duplicate");
+    assert_eq!(fs::read(harness.timeline()).unwrap(), original);
+    assert_eq!(harness.events().len(), 1);
+}
+
+#[test]
+fn a_different_verdict_for_the_same_key_is_an_observable_conflict() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    let original = fs::read(harness.timeline()).unwrap();
+    let output = harness.record(&[("--blocking-findings", "3")]);
+    assert_error(&output, "different verdict already recorded");
+    assert_eq!(fs::read(harness.timeline()).unwrap(), original);
+}
+
+#[test]
+fn different_heads_append_without_replacing_history() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    let original = fs::read(harness.timeline()).unwrap();
+    assert_status(&harness.record(&[("--head-sha", OTHER_SHA)]), "recorded");
+    assert!(fs::read(harness.timeline()).unwrap().starts_with(&original));
+    assert_eq!(harness.events()[1]["head_sha"], OTHER_SHA);
+}
+
+#[test]
+fn forge_repository_and_pr_id_each_partition_the_timeline() {
+    let harness = Harness::new();
+    for overrides in [
+        vec![],
+        vec![("--forge", "bitbucket.org")],
+        vec![("--repository", "example/other")],
+        vec![("--pr-id", "1043")],
+    ] {
+        assert_status(&harness.record(&overrides), "recorded");
+    }
+    assert_eq!(
+        fs::read_dir(harness.measure_root().join("pull-requests"))
+            .unwrap()
+            .count(),
+        4
+    );
+}
+
+#[test]
+fn concurrent_retries_record_exactly_one_event() {
+    let harness = Harness::new();
+    let children: Vec<_> = (0..8)
+        .map(|_| harness.command(&[]).spawn().unwrap())
+        .collect();
+    let outputs: Vec<_> = children
+        .into_iter()
+        .map(|child| child.wait_with_output().unwrap())
+        .collect();
+    assert_eq!(
+        outputs
+            .iter()
+            .filter(|output| output.stdout == b"recorded\n")
+            .count(),
+        1
+    );
+    assert_eq!(
+        outputs
+            .iter()
+            .filter(|output| output.stdout == b"duplicate\n")
+            .count(),
+        7
+    );
+    assert!(outputs.iter().all(|output| output.status.success()));
+    assert_eq!(harness.events().len(), 1);
+}

--- a/tooling/arnes/tests/measure_pr_timeline/retention.rs
+++ b/tooling/arnes/tests/measure_pr_timeline/retention.rs
@@ -1,0 +1,217 @@
+use super::support::*;
+use std::io::Write;
+use std::os::unix::fs::symlink;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const DAY_MS: u64 = 86_400_000;
+
+#[test]
+fn expires_the_whole_pr_timeline_at_90_days() {
+    for age in [89, 90, 91] {
+        let harness = Harness::new();
+        assert_status(&harness.record(&[]), "recorded");
+        let timeline = harness.timeline();
+        age_events(&harness, age);
+        force_sweep(&harness);
+        assert!(trigger_hook(&harness).stderr.is_empty());
+        assert_eq!(timeline.parent().unwrap().exists(), age < 90);
+        let state = retention_state(&harness);
+        assert_eq!(state["status"], "complete");
+        assert_eq!(state["removed_prs"], u64::from(age >= 90));
+    }
+}
+
+#[test]
+fn a_new_head_preserves_the_entire_history_and_triggers_maintenance() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    age_events(&harness, 91);
+    force_sweep(&harness);
+    assert_status(&harness.record(&[("--head-sha", OTHER_SHA)]), "recorded");
+    assert_eq!(harness.events().len(), 2);
+    assert_eq!(retention_state(&harness)["removed_prs"], 0);
+}
+
+#[test]
+fn sweeps_prs_at_most_once_per_day() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    age_events(&harness, 91);
+    assert!(trigger_hook(&harness).stderr.is_empty());
+    assert_eq!(harness.events().len(), 1);
+    force_sweep(&harness);
+    let path = harness.timeline();
+    assert!(trigger_hook(&harness).stderr.is_empty());
+    assert!(!path.exists());
+}
+
+#[test]
+fn a_duplicate_does_not_refresh_the_expiration_clock() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    age_events(&harness, 91);
+    let path = harness.timeline();
+    force_sweep(&harness);
+    assert_status(&harness.record(&[]), "duplicate");
+    assert!(!path.exists());
+    assert_status(&harness.record(&[]), "recorded");
+    assert_eq!(harness.events().len(), 1);
+}
+
+#[test]
+fn refuses_unsafe_or_unproven_expiration_without_deleting_data() {
+    for damage in ["future", "empty", "truncated", "identity", "symlink"] {
+        let harness = Harness::new();
+        assert_status(&harness.record(&[]), "recorded");
+        age_events(&harness, 91);
+        let timeline = harness.timeline();
+        let mut event = harness.events().remove(0);
+        match damage {
+            "future" => {
+                event["timestamp_ms"] = json!(now_ms() + DAY_MS);
+                write_events(&harness, &[event]);
+            }
+            "empty" => fs::write(&timeline, "").unwrap(),
+            "truncated" => fs::write(&timeline, "{").unwrap(),
+            "identity" => {
+                event["pr"]["pr_id"] = json!(999);
+                write_events(&harness, &[event]);
+            }
+            _ => {
+                let outside = harness.root.path().join("outside");
+                fs::write(&outside, "sentinel").unwrap();
+                symlink(outside, timeline.parent().unwrap().join("unsafe")).unwrap();
+            }
+        }
+        let before = fs::read(&timeline).unwrap();
+        force_sweep(&harness);
+        let output = trigger_hook(&harness);
+        assert_eq!(output.status.code(), Some(0));
+        assert!(!output.stderr.is_empty(), "{damage}");
+        assert_eq!(retention_state(&harness)["status"], "failed");
+        assert_eq!(fs::read(timeline).unwrap(), before);
+    }
+}
+
+#[test]
+fn concurrent_writers_and_purge_preserve_every_new_head() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    age_events(&harness, 91);
+    force_sweep(&harness);
+    let children: Vec<_> = (0..16)
+        .map(|index| {
+            let sha = format!("{index:040x}");
+            harness.command(&[("--head-sha", &sha)]).spawn().unwrap()
+        })
+        .collect();
+    let hook = trigger_hook(&harness);
+    assert!(
+        hook.stderr.is_empty(),
+        "{}",
+        String::from_utf8_lossy(&hook.stderr)
+    );
+    for child in children {
+        assert_status(&child.wait_with_output().unwrap(), "recorded");
+    }
+    let events = harness.events();
+    for index in 0..16 {
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event["head_sha"] == format!("{index:040x}"))
+                .count(),
+            1
+        );
+    }
+}
+
+#[test]
+fn reads_the_existing_retention_state_before_upgrading_it() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    let path = harness.measure_root().join("retention.json");
+    fs::write(&path, json!({"schema_version":1,"status":"complete","swept_at_ms":1,"next_sweep_at_ms":2,"candidate_runs":0,"removed_runs":0}).to_string()).unwrap();
+    assert!(trigger_hook(&harness).stderr.is_empty());
+    assert_eq!(retention_state(&harness)["schema_version"], 2);
+}
+
+#[test]
+fn invalid_maintenance_state_reports_failure_after_preserving_the_new_verdict() {
+    for invalid in [
+        json!({}),
+        json!({"schema_version":2,"status":"complete","swept_at_ms":1,"next_sweep_at_ms":2,"candidate_runs":0,"removed_runs":0}),
+        json!({"schema_version":2,"status":"complete","swept_at_ms":1,"next_sweep_at_ms":2,"candidate_runs":0,"removed_runs":0,"candidate_prs":0,"removed_prs":1}),
+    ] {
+        let harness = Harness::new();
+        assert_status(&harness.record(&[]), "recorded");
+        fs::write(
+            harness.measure_root().join("retention.json"),
+            invalid.to_string(),
+        )
+        .unwrap();
+        assert_error(
+            &harness.record(&[("--head-sha", OTHER_SHA)]),
+            "PR event recorded; retention failed:",
+        );
+        assert_eq!(harness.events().len(), 2);
+        assert_eq!(harness.events()[1]["data"]["verdict"], "changes-required");
+        assert_eq!(retention_state(&harness), invalid);
+    }
+}
+
+fn trigger_hook(harness: &Harness) -> Output {
+    let mut child = harness
+        .base_command()
+        .args(["measure", "hook", "--agent", "codex"])
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(br#"{"session_id":"retention-trigger","hook_event_name":"Stop"}"#)
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn age_events(harness: &Harness, days: u64) {
+    let mut events = harness.events();
+    for event in &mut events {
+        event["timestamp_ms"] = json!(now_ms() - days * DAY_MS);
+    }
+    write_events(harness, &events);
+}
+
+fn write_events(harness: &Harness, events: &[Value]) {
+    fs::write(
+        harness.timeline(),
+        events
+            .iter()
+            .map(|event| format!("{event}\n"))
+            .collect::<String>(),
+    )
+    .unwrap();
+}
+
+fn force_sweep(harness: &Harness) {
+    let path = harness.measure_root().join("retention.json");
+    if path.exists() {
+        fs::remove_file(path).unwrap();
+    }
+}
+
+fn retention_state(harness: &Harness) -> Value {
+    serde_json::from_slice(&fs::read(harness.measure_root().join("retention.json")).unwrap())
+        .unwrap()
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .try_into()
+        .unwrap()
+}

--- a/tooling/arnes/tests/measure_pr_timeline/storage.rs
+++ b/tooling/arnes/tests/measure_pr_timeline/storage.rs
@@ -1,0 +1,175 @@
+use super::support::*;
+use std::io::Write;
+use std::os::unix::fs::{PermissionsExt, symlink};
+
+#[test]
+fn output_failure_preserves_the_recorded_event_and_allows_an_idempotent_retry() {
+    let harness = Harness::new();
+    let destination = harness.root.path().join("read-only-stdout");
+    fs::write(&destination, "untouched").unwrap();
+    let output = harness
+        .command(&[])
+        .stdout(fs::File::open(&destination).unwrap())
+        .output()
+        .unwrap();
+    assert_error(&output, "measure:");
+    assert_eq!(fs::read(destination).unwrap(), b"untouched");
+    assert_eq!(harness.events().len(), 1);
+    assert_status(&harness.record(&[]), "duplicate");
+    assert_eq!(harness.events().len(), 1);
+}
+
+#[test]
+fn storage_failure_is_separate_from_the_review_and_can_be_retried() {
+    let harness = Harness::new();
+    let state = harness.root.path().join("state");
+    fs::write(&state, "occupied").unwrap();
+    assert_error(&harness.record(&[]), "measure:");
+    assert_eq!(fs::read(&state).unwrap(), b"occupied");
+    fs::remove_file(state).unwrap();
+    assert_status(&harness.record(&[]), "recorded");
+    assert_eq!(harness.events()[0]["data"]["verdict"], "changes-required");
+}
+
+#[test]
+fn refuses_invalid_anchors_and_counts_without_writing_events() {
+    for (flag, value) in [
+        ("--forge", "https://github.com"),
+        ("--forge", "../escape"),
+        ("--repository", "../escape"),
+        ("--repository", "/local/path"),
+        ("--repository", "example/project.git"),
+        ("--repository", "example//project"),
+        ("--pr-id", "0"),
+        ("--head-sha", "abcdef"),
+        ("--head-sha", "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"),
+        ("--blocking-findings", "-1"),
+        ("--observable-behaviors", "unknown"),
+        ("--verdict", "looks good"),
+        ("--agent", "unknown"),
+    ] {
+        let harness = Harness::new();
+        assert_error(&harness.record(&[(flag, value)]), "");
+        assert!(!harness.measure_root().join("pull-requests").exists());
+    }
+}
+
+#[test]
+fn refuses_a_corrupt_or_conflicting_history_without_appending() {
+    for damage in ["truncated", "version", "identity", "duplicate"] {
+        let harness = Harness::new();
+        assert_status(&harness.record(&[]), "recorded");
+        let mut event = harness.events().remove(0);
+        let content = match damage {
+            "truncated" => "{\"schema_version\":".to_owned(),
+            "version" => {
+                event["schema_version"] = json!(99);
+                format!("{event}\n")
+            }
+            "identity" => {
+                event["pr"]["pr_id"] = json!(999);
+                format!("{event}\n")
+            }
+            _ => format!("{event}\n{event}\n"),
+        };
+        fs::write(harness.timeline(), &content).unwrap();
+        assert_error(&harness.record(&[("--head-sha", OTHER_SHA)]), "measure:");
+        assert_eq!(fs::read_to_string(harness.timeline()).unwrap(), content);
+    }
+}
+
+#[test]
+fn preserves_existing_measurement_runs_and_outcomes() {
+    let harness = Harness::new();
+    let mut child = harness
+        .base_command()
+        .args(["measure", "hook", "--agent", "codex"])
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(br#"{"session_id":"fixture","hook_event_name":"Stop"}"#)
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    assert!(
+        output.stderr.is_empty(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let run = fs::read_dir(harness.measure_root().join("runs"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let outcome = harness
+        .base_command()
+        .args([
+            "measure",
+            "outcome",
+            run.file_name().unwrap().to_str().unwrap(),
+            "--status",
+            "pass",
+            "--oracle",
+            "fixture-test",
+        ])
+        .output()
+        .unwrap();
+    assert!(outcome.status.success());
+    let before: Vec<_> = ["run.json", "events.jsonl", "outcomes.jsonl"]
+        .map(|name| (name, fs::read(run.join(name)).unwrap()))
+        .into();
+    assert_status(&harness.record(&[]), "recorded");
+    for (name, bytes) in before {
+        assert_eq!(fs::read(run.join(name)).unwrap(), bytes);
+    }
+    for args in [
+        vec!["measure", "list", "--format", "json"],
+        vec!["measure", "report", "--format", "json"],
+    ] {
+        let output = harness.base_command().args(args).output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice::<Value>(&output.stdout).unwrap();
+    }
+}
+
+#[test]
+fn keeps_events_private_and_refuses_symlink_redirection() {
+    let harness = Harness::new();
+    assert_status(&harness.record(&[]), "recorded");
+    assert_eq!(
+        fs::metadata(harness.timeline())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    let outside = harness.root.path().join("outside");
+    fs::write(&outside, "untouched").unwrap();
+    fs::remove_file(harness.timeline()).unwrap();
+    symlink(&outside, harness.timeline()).unwrap();
+    assert_error(&harness.record(&[]), "measure:");
+    assert_eq!(fs::read(outside).unwrap(), b"untouched");
+}
+
+#[test]
+fn refuses_state_inside_the_checkout() {
+    let harness = Harness::new();
+    let repository = harness.root.path().join("repository");
+    let output = harness
+        .command(&[])
+        .env("XDG_STATE_HOME", repository.join("state"))
+        .output()
+        .unwrap();
+    assert_error(&output, "inside the repository");
+    assert!(!repository.join("state").exists());
+}

--- a/tooling/arnes/tests/measure_pr_timeline/support.rs
+++ b/tooling/arnes/tests/measure_pr_timeline/support.rs
@@ -1,0 +1,108 @@
+pub(super) use serde_json::{Value, json};
+pub(super) use std::fs;
+use std::path::PathBuf;
+pub(super) use std::process::{Command, Output, Stdio};
+
+pub(super) const SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+pub(super) const OTHER_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+pub(super) struct Harness {
+    pub root: tempfile::TempDir,
+}
+
+impl Harness {
+    pub fn new() -> Self {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir(root.path().join("repository")).unwrap();
+        fs::create_dir(root.path().join("home")).unwrap();
+        assert!(
+            Command::new("git")
+                .args(["init", "-q"])
+                .current_dir(root.path().join("repository"))
+                .status()
+                .unwrap()
+                .success()
+        );
+        Self { root }
+    }
+
+    pub fn base_command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_arnes"));
+        command
+            .current_dir(self.root.path().join("repository"))
+            .env_clear()
+            .env("HOME", self.root.path().join("home"))
+            .env("XDG_STATE_HOME", self.root.path().join("state"))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    }
+
+    pub fn command(&self, overrides: &[(&str, &str)]) -> Command {
+        let mut command = self.base_command();
+        command.args(["measure", "pr-verdict"]);
+        for (flag, default) in [
+            ("--forge", "github.com"),
+            ("--repository", "example/project"),
+            ("--pr-id", "1042"),
+            ("--head-sha", SHA),
+            ("--agent", "codex"),
+            ("--verdict", "changes-required"),
+            ("--blocking-findings", "2"),
+            ("--non-blocking-findings", "1"),
+            ("--observable-behaviors", "3"),
+            ("--evidence-gaps", "2"),
+        ] {
+            let value = overrides
+                .iter()
+                .find(|(key, _)| *key == flag)
+                .map_or(default, |(_, value)| *value);
+            command.args([flag, value]);
+        }
+        command
+    }
+
+    pub fn record(&self, overrides: &[(&str, &str)]) -> Output {
+        self.command(overrides).output().unwrap()
+    }
+
+    pub fn measure_root(&self) -> PathBuf {
+        self.root.path().join("state/dotfiles/agent-harness")
+    }
+
+    pub fn timeline(&self) -> PathBuf {
+        let entries: Vec<_> = fs::read_dir(self.measure_root().join("pull-requests"))
+            .unwrap()
+            .collect();
+        assert_eq!(entries.len(), 1);
+        entries[0].as_ref().unwrap().path().join("events.jsonl")
+    }
+
+    pub fn events(&self) -> Vec<Value> {
+        fs::read_to_string(self.timeline())
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+}
+
+pub(super) fn assert_status(output: &Output, expected: &str) {
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), expected);
+    assert!(output.stderr.is_empty());
+}
+
+pub(super) fn assert_error(output: &Output, expected: &str) {
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tooling/arnes/tests/measure_retention.rs
+++ b/tooling/arnes/tests/measure_retention.rs
@@ -43,7 +43,7 @@ fn expires_v2_after_60_days_and_never_automatically_removes_v1() {
         "unknown run",
     );
     let state = read_json(harness.state_root().join("retention.json"));
-    assert_eq!(state["schema_version"], 1);
+    assert_eq!(state["schema_version"], 2);
     assert_eq!(state["status"], "complete");
     assert_eq!(state["candidate_runs"], 2);
     assert_eq!(state["removed_runs"], 2);


### PR DESCRIPTION
## Description

Record structured `pr-verdict` events in the existing local measurement store, keyed by forge hostname, canonical repository path and PR number, with the full reviewed SHA, verdict and review counts. Phase 5 emits the event before returning, including unpublished and pre-repair reviews; measurement failures remain separate from the verdict.

Timelines are append-only while retained. Identical events return `duplicate`; conflicting data for the same PR, SHA and event type are rejected. The existing opportunistic daily maintenance removes a whole PR timeline 90 days after its latest event. Expiration is rechecked under the writer's lifecycle lock, and malformed or unsafe histories are preserved with diagnostics. Run initialization and retention also share the lifecycle lock before publishing or reading metadata. Run retention stays at 60 days; the previous retention-state format remains readable.

This iteration excludes raw prompts, intention summaries, harness fingerprints in PR events, human-review feedback, correction history, pre-PR worktree associations, causal links and derived reports. Duplicate detection ends when its event is purged. Expiration needs another measurement invocation; there is no scheduled deletion service or new dependency.

## Useful Links

- Scope requested directly; no tracking issue.

## How to Test

From `tooling/arnes`, run `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo check --all-targets --locked`, and `cargo test --locked` with `RUSTFLAGS=-Funsafe-code`.

Local validation on macOS ARM64: 681 Rust tests pass, including CLI/storage integration, stale purge candidates and run-initialization concurrency. Manual-invocation tests, Prettier and CSpell pass. Fixture trials exercised phase-5 emission, duplicates and storage failures; adversarial tests exercised concurrent writers and purge. Remote Linux validation is supplied by this PR's CI.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated
- [x] Compatibility limits documented: retention state writes v2 and reads v1/v2; old binaries cannot read the new state format
