### PR TITLE
feat: add optional Anarlog installation through Moon

### DIFF
--- a/.moon/tasks/workstation.yml
+++ b/.moon/tasks/workstation.yml
@@ -41,6 +41,26 @@ tasks:
     script: |-
       export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
       brew bundle install --no-upgrade --file Brewfile
+  anarlog:
+    description: Install the optional Anarlog meeting notepad
+    deps:
+      - homebrew
+    checks:
+      - check: condition
+        script: |-
+          export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
+          brew list --cask --versions anarlog
+    env:
+      HOMEBREW_NO_ASK: "1"
+    toolchains: system
+    options:
+      cache: false
+      mutex: homebrew
+      os: macos
+      runInCI: false
+    script: |-
+      export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
+      brew install --cask anarlog
   rust:
     description: Install Rust and Cargo with Homebrew
     deps:

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ minimal: bootstrap
 .PHONY: optional
 optional: minimal
 	@$(MAKE) --no-print-directory bundle-optional </dev/null
+	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) repository:anarlog </dev/null
 	@$(MAKE) --no-print-directory optional-artifacts </dev/null
 
 .PHONY: smoke-minimal

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ cd && \
 
 Install the separately maintained optional profile with `make optional`.
 
+Anarlog belongs to the optional profile, alongside Handy. Install it independently
+with `moon exec repository:anarlog` (macOS 15 or newer).
+
 Moon installs the complete minimal profile. With Moon available:
 
 ```bash


### PR DESCRIPTION
Add Anarlog as an optional meeting-notes application, in the same profile as Handy. `make optional` now invokes the standalone `moon exec repository:anarlog` task; the minimal profile remains unchanged.

The task installs the official Homebrew cask, uses Homebrew's installed-cask probe, shares the Homebrew mutex, and runs only on macOS. The cask currently requires macOS 15 or newer. Its package declaration lives only in Moon.

Validation on macOS 26.6.2 / arm64:
- Moon task inspection and action graph passed; the minimal installation graph excludes Anarlog.
- `make -n optional` includes the Moon invocation.
- Homebrew cask metadata resolves Anarlog and its macOS requirement.
- Prettier and `git diff --check` passed.
- Independent static review found no objective defects.

The application installation was not executed from this worktree; these checks do not prove installation or application behavior. Remote CI must pass before merge.

No comments added. The existing Makefile exceeds the repository's size review trigger; the change adds one delegation line to its cohesive optional-profile recipe without restructuring unrelated legacy targets.
