### PR TITLE
fix(pr-fix): publier un résumé cumulatif après validation finale

### DIFF
--- a/harness/skills/pr-fix/SKILL.md
+++ b/harness/skills/pr-fix/SKILL.md
@@ -20,8 +20,9 @@ Turn a head-specific verdict into reviewed corrections on the contributor's bran
 repair request authorizes edits, commits and a standard push to that branch; it does not authorize a
 force-push, issue creation or verdict publication. The repaired head earns its own verdict from a
 fresh context because the context that wrote a fix cannot independently validate it.
-Mutating someone else's branch also carries a mandatory public repair record: it documents what was
-changed and proved, engages no merge decision, and therefore does not require publication consent.
+Accumulate corrections in a local journal across passes and sessions. Publish one cumulative repair
+record only when the current head is independently approved and its required remote CI is green.
+This factual record engages no merge decision and needs no separate publication consent.
 
 ## Usage
 
@@ -39,6 +40,15 @@ re-review a PR belongs to `pr-verdict` and must not mutate the branch.
    publishing it. Resolve the source repository and source ref from forge metadata; never infer the
    push target from the local branch name or `origin`.
 
+   Before repairing, open or create
+   `~/.local/state/pr-fix/<forge-host>/<destination-owner>/<destination-repository>/<pr>/journal.md`
+   from `assets/repair-journal.md`. Derive the identity from the canonical PR URL, verify the URL
+   stored in an existing journal, and encode path separators inside individual identity components.
+   Keep this operational journal outside Git, any temporary worktree and durable agent memory.
+   Read earlier passes before planning; reconcile them against the current diff and commits.
+   If the journal is missing or damaged, recover only verifiable history from the forge and report
+   any gap; never invent prior corrections. One repair session owns a PR journal at a time.
+
 2. **Bound the repair.** Present one repair slate before editing: every blocker has its failure
    mechanism, broken invariant and lift test; at most three non-blocking items may follow, and only
    when they are objective, localized and observable. Continue without another confirmation because
@@ -53,6 +63,11 @@ re-review a PR belongs to `pr-verdict` and must not mutate the branch.
    observe it fail for the expected reason, then correct the cause. A declarative change with no
    useful behavioral test gets the repository's relevant smoke or validation check. Do not turn
    naming, style or speculative cleanup into repair work.
+
+   Update the journal after each correction and validation: problem, final behavior, commits,
+   failed-then-passing evidence, environment and limits. Preserve corrections to earlier corrections
+   and mark reverted or superseded work. Write a sibling temporary file, then rename it over the
+   journal; a failed write pauses the repair before another push or publication.
 
 5. **Run a barrier sized to the delta.** Take the merge-blocking commands from the CI configuration,
    never from a same-named package script, then run the tier the corrections actually reach on the
@@ -78,24 +93,45 @@ re-review a PR belongs to `pr-verdict` and must not mutate the branch.
    commits local and becomes an explicit delivery blocker. One repair produces one judged head:
    every extra push discards a verdict already delegated and buys another review pass.
 
+   Record prepared commits before pushing and mark them pushed only after verifying the remote
+   result. On interruption or an ambiguous push result, reconcile remote commits before resuming.
+
 7. **Judge the pushed head independently.** Resolve the SHA now shown by the PR and delegate a full
    `pr-verdict` review of that exact head to a fresh context, including its barrier. Do not delegate
    while a correction is still pending — a head you intend to amend is a head whose verdict you are
    about to throw away. When that review does find a defect in the repair itself, correct it, push
    once, and scope the second delegation to the new delta and its barrier tier instead of repeating
-   the whole sweep. Return only the final head's verdict as current. Publish it only when the user
-   separately confirms publication or explicitly included publication in the original request.
+   the whole sweep. Record the verdict and its SHA in the journal; an older verdict is historical.
+   All delegated passes stop after phase 5 without publishing comments or opening tickets.
+   Return only the final head's verdict as current. Verdict publication remains subject to separate
+   user authorization; repair authority alone publishes only the factual summary in step 8.
 
-8. **Publish the repair record.** Fill `assets/repair-record.md` in the pull request's language and
-   pass it as a body file with the forge commands from `pr-verdict/references/forges.md`. Search
-   existing comments for `<!-- pr-fix:<pr>:<final-head-sha-12> -->`: update the same marker in place,
-   or publish one new comment when the SHA differs. Publish even after merge and without
-   confirmation. This mandatory factual record is not the verdict; step 7 still governs verdict
-   publication.
+8. **Publish once approved.** Re-read the PR head and required remote checks. Publish only when
+   the independent verdict is exactly `approved`, the required remote CI has succeeded on that
+   same SHA, and no correction remains pending. `approved with reservations`, failed or pending CI,
+   unavailable evidence, or a moved head keeps the journal pending with no intermediate comment.
+   When no remote check is required, record that fact explicitly instead of claiming CI passed.
+   A merged PR still requires evidence for the reviewed source head; merge alone is no substitute.
 
-9. **Close the repair.** Report the original findings, commits pushed, final SHA, final verdict and
-   residual evidence gaps. Do not create a fix ticket for a defect corrected by this run. Remove the
-   temporary worktree only after its commits are pushed and it is clean.
+   Build `assets/repair-record.md` from all journal passes in the PR's language: one opening sentence
+   with the final SHA, one short bullet per corrected problem, then validation counts and limits.
+   Consolidate repeated fixes by their final outcome and omit superseded attempts; retain their
+   history and detailed mechanisms in the journal. Block publication if missing history prevents
+   an accurate cumulative summary. If nothing was corrected, no repair comment is needed.
+
+   Search all existing comments for the stable marker `<!-- pr-fix:<pr> -->`. Update the matching
+   comment only when owned by the publishing account; otherwise keep publication pending and report
+   the ownership conflict. Create one only when none exists. For legacy `<pr>:<sha>` markers, reuse
+   the latest repair comment owned by the publishing account and replace its marker, preserving other comments
+   and replies. Pass the body through a file using `pr-verdict/references/forges.md` and save the
+   returned comment ID, URL and published SHA in the journal. After a timeout or uncertain response,
+   re-read remote comments before retrying; if lookup fails, keep publication pending.
+
+9. **Close or pause the repair.** Report the final SHA, verdict, journal path and either the summary
+   URL or the reason publication is pending. Keep the journal across sessions and after publication;
+   a later correction resumes it and updates the same comment only after renewed approval and CI.
+   Do not create a fix ticket for a defect corrected by this run. Remove the temporary worktree only
+   after its commits are pushed and it is clean; retain the journal even when removing the worktree.
 
 ## Gotchas
 
@@ -111,12 +147,16 @@ re-review a PR belongs to `pr-verdict` and must not mutate the branch.
 - **Small remarks become a cleanup pass** — the PR gains unrelated churn and review risk. Keep at
   most three objective, localized non-blockers and drop preferences.
 - **Repair publication and verdict publication are conflated** — either a team-visible merge
-  decision appears without consent or the contributor receives no account of mutations already
-  made to their branch. Publish the factual repair record without confirmation, including after
-  merge; keep the verdict subject to separate consent.
+  decision appears without consent or each pass solicits premature replies. Keep intermediate
+  results in the journal and publish the cumulative factual summary after final approval and CI;
+  keep verdict publication subject to separate consent.
 - **The record follows commits instead of mechanisms** — commits expose chronology but omit why a
-  correction works, while one mechanism may span several commits. Use the compact mechanism and
-  proof list from the template, including corrections to earlier corrections and reasoned omissions.
+  correction works, while one problem may span several commits. Keep mechanisms and proofs in the
+  journal and summarize the final behavior once per corrected problem in the public comment.
+- **The journal lives in a temporary worktree** — cleanup loses earlier passes. Use the stable
+  PR path outside the checkout and reload it whenever another session resumes the repair.
+- **A timeout is treated as a failed publication** — a blind retry duplicates an accepted comment.
+  Look up the stable PR marker before retrying and preserve the journal when lookup is unavailable.
 - **A failed push worktree is discarded** — the only copy of useful commits becomes hard to recover.
   Preserve the worktree and report the commit SHAs when the branch cannot be updated.
 - **The head is amended after its verdict was delegated** — the fresh context spends its whole pass
@@ -132,20 +172,20 @@ re-review a PR belongs to `pr-verdict` and must not mutate the branch.
 - Never force-push, overwrite a moved head or guess the PR source repository or ref.
 - Never publish a verdict, create an issue or open another PR from repair authority alone; the
   mandatory factual repair record is not a verdict and requires no confirmation.
-- Never close a repair without publishing exactly one record for the final `<pr>:<sha>` marker,
-  updating the matching comment in place even when the pull request is already merged; always pass
-  its body through a file.
-- Never organize the record by commit or open with defects: start with what held, then give every
-  correction its mechanism and proof, every omission its reason, and numeric barrier evidence
-  immediately followed by its limits.
+- Never publish a repair summary before independent `approved` and successful required remote CI
+  on the current head; pause with the journal intact when that condition is unmet.
+- Never create a new repair comment merely because the SHA changed; use the stable PR marker,
+  preserve existing replies, and always pass the body through a file.
+- Keep every correction, its mechanism, evidence and reasoned omission in the journal; publish a
+  concise cumulative account of final outcomes with numeric validation evidence and its limits.
 - Never claim a defect fixed before its failure-path test and the barrier tier its delta reaches
   both pass, and never report a gate you did not run.
 - Never let the context that wrote the repaired head perform its final failure-class sweep.
 - Never delegate a verdict on a head you still intend to amend; one repair lands one judged head.
 - Never repair subjective preferences or broaden the change beyond proven findings.
-- Never remove a temporary worktree that contains unpushed commits or uncommitted changes.
+- Never remove a temporary worktree that contains commits not yet pushed or uncommitted changes.
 
 ## References
 
-- [assets/repair-record.md](assets/repair-record.md) — skeleton and publication self-check. Fill it
-  in step 8.
+- [assets/repair-journal.md](assets/repair-journal.md) — local cumulative state, loaded in step 1.
+- [assets/repair-record.md](assets/repair-record.md) — concise public summary, filled in step 8.

--- a/harness/skills/pr-fix/assets/repair-journal.md
+++ b/harness/skills/pr-fix/assets/repair-journal.md
@@ -1,0 +1,48 @@
+# PR repair journal template
+
+Keep one local journal per canonical PR URL at the path defined in `SKILL.md`. Reload it across
+sessions, update it after each correction or external result, and retain it after publication.
+This is operational state, not durable agent memory or a file to commit to the contributor's branch.
+
+## Skeleton
+
+```markdown
+# Repair journal
+
+PR: <canonical URL>
+Source: <repository and ref>
+Initial head: <SHA>
+Current head: <SHA>
+Status: <in progress | pending validation | pending publication | published>
+Pending: <remaining correction, check, decision or publication error; none when complete>
+Comment: <ID and URL, or not published>
+Published head: <SHA, or not published>
+
+## Corrections
+
+- <problem>: <failure mechanism and broken invariant> → <final behavior>.
+  Commits: <SHAs>; delivery: <prepared | pushed | reverted | superseded>.
+  Evidence: <failing observation, then passing command and counts; tested SHA and environment>.
+  Limits: <what the evidence does not cover>.
+
+## Passes
+
+- <date, starting SHA → resulting SHA>: <corrections and any superseded attempts>.
+  Barrier: <tier, commands, counts, environment and evidence limits>.
+  Independent verdict: <result and reviewed SHA, or pending>.
+  Required remote CI: <result URL and SHA, pending, unavailable or none required>.
+
+## Deliberate omissions
+
+- <finding and reason, or none>
+```
+
+## Resume checks
+
+- Match the stored PR URL and source to forge metadata before using the journal.
+- Reconcile prepared commits with the remote after an interrupted push; local preparation is not
+  proof of delivery.
+- Preserve earlier evidence with its original SHA; a new head requires a current verdict and checks.
+- After an uncertain publication, find the stable PR marker remotely before retrying; a missing
+  local comment ID does not prove that the comment was never created.
+- If history is incomplete, record the gap and recover only verifiable facts before summarizing.

--- a/harness/skills/pr-fix/assets/repair-record.md
+++ b/harness/skills/pr-fix/assets/repair-record.md
@@ -1,31 +1,27 @@
 # PR repair record template
 
-Fill this compact skeleton in the pull request's language and pass it through a body file. Repeat
-the correction line, not the surrounding structure.
+Fill this skeleton from the complete journal in the pull request's language. Use one short bullet
+per corrected problem, describing the final behavior. Keep detailed mechanisms, per-pass proofs and
+superseded attempts in the local journal. Pass the public summary through a body file.
 
 ## Skeleton
 
 ```text
-<!-- pr-fix:<pr>:<final-head-sha-12> -->
-## Repair record
+<!-- pr-fix:<pr> -->
+Corrections completed on `<final-head-sha>`.
 
-Review completed on `<final-head-sha>`: <what held under review, with the evidence that established it>.
+- <problem corrected and resulting behavior>.
 
-Corrections pushed:
-- `<correction>` — mechanism: <failure sequence and broken invariant>; proof: <failing observation, then passing check and result>.
-
-Not repaired:
-- `<finding>` — reason: <why it was deliberately excluded>.
-<Write "None" when every finding was repaired.>
-
-Barrier: <tier, commands, and numeric results>. Limits: <what those results do not cover>.
+Validation: <environment, tier, principal checks and counts>; required CI: <linked result on this SHA, or none required>; independent review: <no remaining actionable defect>.
+Limits: <material evidence gaps or deliberately excluded findings and reasons; omit this line when none>.
 ```
 
 ## Self-check before publishing
 
-- Marker first; same `<pr>:<sha>` updated, different SHA published once.
-- What held comes first; every correction, including a correction to an earlier correction, has a
-  mechanism and proof.
-- Every deliberate omission has a reason, or the record says `None`.
-- Barrier numbers are immediately followed by their limits.
-- Body passed through a file; no verdict or merge decision.
+- Publish only after independent `approved` and successful required remote CI on the current SHA.
+- Stable PR marker first; update the existing repair comment even when the SHA changes.
+- One opening sentence, correction bullets, one validation paragraph; aim for 15 non-empty lines.
+- Cover all final corrected problems across passes; group related outcomes instead of truncating.
+- State material limits and reasoned omissions directly after validation; retain full proof in the
+  journal and never copy old results as evidence for the final SHA.
+- Body passed through a file; no local paths, formal verdict, approval action or merge decision.


### PR DESCRIPTION
Les passes de réparation publiaient des commentaires successifs sur la PR, auxquels les développeurs répondaient avant la fin des corrections. `pr-fix` conserve désormais un journal Markdown local entre les passes et les sessions, puis publie un résumé cumulatif après un verdict indépendant `approved` et la réussite de la CI requise sur le SHA courant.

Le commentaire utilise un marqueur stable par PR et un format concis : SHA final, puces décrivant les corrections et validation chiffrée avec ses limites. Les anciens commentaires compatibles sont réutilisés sans supprimer les réponses ; les interruptions et résultats de publication incertains restent consignés pour reprise.

Validation sur macOS : Prettier sur le dépôt, CSpell sur les trois fichiers modifiés, 2 tests existants d’invocation réussis et index des skills régénéré à résultat identique. Cinq scénarios simulés ont été relus indépendamment ; aucune publication réelle sur une forge n’a été testée et `skills-ref` n’est pas installé.
