### PR TITLE
fix(moon): allow password prompts for Anarlog installation

### DIFF
--- a/.moon/tasks/workstation.yml
+++ b/.moon/tasks/workstation.yml
@@ -55,6 +55,7 @@ tasks:
     toolchains: system
     options:
       cache: false
+      interactive: true
       mutex: homebrew
       os: macos
       runInCI: false

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ minimal: bootstrap
 .PHONY: optional
 optional: minimal
 	@$(MAKE) --no-print-directory bundle-optional </dev/null
-	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) repository:anarlog </dev/null
+	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) repository:anarlog
 	@$(MAKE) --no-print-directory optional-artifacts </dev/null
 
 .PHONY: smoke-minimal


### PR DESCRIPTION
## Description

Anarlog installation can require a sudo password when Homebrew copies the application into `/Applications`. The Moon task was non-interactive, and `make optional` additionally redirected its stdin from `/dev/null`.

Enable Moon's interactive mode for `repository:anarlog` and preserve stdin in its Make adapter so the installation can prompt from a terminal. The Homebrew mutex and macOS-only scope remain in place.

## Useful Links

- [Moon interactive tasks](https://moonrepo.dev/docs/concepts/task#interactive)

## How to Test

Validated locally on macOS with Moon 2.5.4:

- `moon exec repository:prettier-check` passed.
- `moon task repository:anarlog --json` and `moon action-graph repository:anarlog --json` report the task as interactive.
- `make -n optional MAKE='make -n'` preserves stdin for the Anarlog invocation.
- `git diff --cached --check` passed; independent static review found no blocking defects.

Manual installation remains untested: from a terminal on a Mac without Anarlog installed, run `moon exec repository:anarlog` and verify that a sudo prompt is usable if Homebrew requires elevated permissions. No global application installation was run from the worktree. Remote CI must pass before merge.

## Checklist

- [x] Changes have been tested locally (configuration, graph, formatting, and Make dry-run; installation not exercised)
- [x] Documentation has been updated if necessary (no documentation change required)
- [x] No breaking changes (or documented if necessary)

No code comments added. The existing 298-line Makefile is retained because this fix only changes one adapter invocation.
