### PR TITLE
feat: add optional Lumen installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,11 @@ bundle-optional:
 	@skip_mas=; if [ "$(SKIP_PAID_APPS)" = "1" ]; then skip_mas="411643860 904280696"; fi; HOMEBREW_BUNDLE_MAS_SKIP="$$skip_mas" brew bundle check --quiet --no-upgrade --file "${DOTFILES_PATH}/Brewfile.optional" || { echo "brew bundle --no-upgrade --file ${DOTFILES_PATH}/Brewfile.optional"; HOMEBREW_BUNDLE_MAS_SKIP="$$skip_mas" brew bundle --no-upgrade --file "${DOTFILES_PATH}/Brewfile.optional" </dev/null; }
 
 .PHONY: optional-artifacts
-optional-artifacts: cspell cursor cloakbrowser scrapling postgresql daisydisk things-3
+optional-artifacts: cspell cursor cloakbrowser scrapling postgresql daisydisk things-3 lumen
+
+.PHONY: lumen
+lumen:
+	@bun "${DOTFILES_PATH}/tooling/install-lumen.ts" "${APP_BIN}"
 
 .PHONY: docker
 docker:

--- a/docs/software-source-exceptions.md
+++ b/docs/software-source-exceptions.md
@@ -3,16 +3,25 @@
 Ce document est l'inventaire opérationnel des installations que Homebrew Bundle ne porte pas,
 référencé par [ADR-002](adr/002-homebrew-source-unique.md).
 
-| Source                   | Version                            | Intégrité                                    | Mise à jour                            | Rejeu                                               |
-| ------------------------ | ---------------------------------- | -------------------------------------------- | -------------------------------------- | --------------------------------------------------- |
-| Amorçage Homebrew        | Installateur officiel `HEAD`       | HTTPS Homebrew                               | Gérée par Homebrew après installation  | Seulement si `brew` est absent                      |
-| Node via Volta           | Pin `volta.node` du `package.json` | Vérification du registre par le gestionnaire | `tooling/upgrade`                      | Version du défaut utilisateur vérifiée hors projet  |
-| Paquets via Volta ou npm | Coordonnée de la cible             | Vérification du registre par le gestionnaire | `tooling/upgrade`                      | Sentinelle du shim ou du binaire                    |
-| Plugins Fisher et TPM    | Révision distante à l'installation | Objets GitHub en HTTPS                       | Commande explicite du gestionnaire     | Configuration Fisher ou checkout TPM                |
-| Claude Code              | Canal éditeur `latest`             | HTTPS éditeur                                | `claude update`                        | Sentinelle du binaire                               |
-| Moon                     | Canal éditeur `latest`             | HTTPS éditeur                                | `tooling/upgrade` → `moon upgrade`     | Sentinelle du binaire                               |
-| Images Docker des MCP    | Image et tag déclarés              | Manifeste et couches du registre             | `docker pull` ou `docker compose pull` | Image locale réutilisée                             |
-| Thèmes Bat               | Branche Catppuccin par défaut      | HTTPS GitHub                                 | Changement explicite de source         | Fichier de thème existant                           |
-| Dictionnaires Hunspell   | Commit LibreOffice déclaré         | SHA-256 déclaré                              | Changement du commit et du checksum    | Destination identique conservée, divergence refusée |
+| Source                   | Version                            | Intégrité                                    | Mise à jour                                | Rejeu                                                     |
+| ------------------------ | ---------------------------------- | -------------------------------------------- | ------------------------------------------ | --------------------------------------------------------- |
+| Amorçage Homebrew        | Installateur officiel `HEAD`       | HTTPS Homebrew                               | Gérée par Homebrew après installation      | Seulement si `brew` est absent                            |
+| Node via Volta           | Pin `volta.node` du `package.json` | Vérification du registre par le gestionnaire | `tooling/upgrade`                          | Version du défaut utilisateur vérifiée hors projet        |
+| Paquets via Volta ou npm | Coordonnée de la cible             | Vérification du registre par le gestionnaire | `tooling/upgrade`                          | Sentinelle du shim ou du binaire                          |
+| Plugins Fisher et TPM    | Révision distante à l'installation | Objets GitHub en HTTPS                       | Commande explicite du gestionnaire         | Configuration Fisher ou checkout TPM                      |
+| Claude Code              | Canal éditeur `latest`             | HTTPS éditeur                                | `claude update`                            | Sentinelle du binaire                                     |
+| Moon                     | Canal éditeur `latest`             | HTTPS éditeur                                | `tooling/upgrade` → `moon upgrade`         | Sentinelle du binaire                                     |
+| Images Docker des MCP    | Image et tag déclarés              | Manifeste et couches du registre             | `docker pull` ou `docker compose pull`     | Image locale réutilisée                                   |
+| Thèmes Bat               | Branche Catppuccin par défaut      | HTTPS GitHub                                 | Changement explicite de source             | Fichier de thème existant                                 |
+| Dictionnaires Hunspell   | Commit LibreOffice déclaré         | SHA-256 déclaré                              | Changement du commit et du checksum        | Destination identique conservée, divergence refusée       |
+| Lumen (Sonpiaz)          | DMG officiel `0.1.0`               | SHA-256 et signature du bundle vérifiés      | Changement explicite de version et SHA-256 | Application signée existante conservée, collision refusée |
+
+Lumen est installé par `make optional` ou `make lumen`, via `tooling/install-lumen.ts`.
+Le DMG publié pour cette version contient uniquement un exécutable Apple Silicon, malgré la
+compatibilité Intel annoncée dans le README amont ; l'installation refuse donc Intel.
+Le cask Homebrew `lumen` concerne un autre logiciel (luminosité automatique), et le tap Sonpiaz
+ne propose pas encore ce moniteur système.
+Une installation existante valide est conservée : modifier le pin ne la met pas à jour ;
+son remplacement nécessite une réinstallation explicite.
 
 Les sources internes à un outil local appelé par Moon ou le `Makefile` relèvent des tests de cet outil.

--- a/tooling/install-lumen.test.ts
+++ b/tooling/install-lumen.test.ts
@@ -198,7 +198,6 @@ test("a destination appearing during extraction is preserved", async () => {
         );
       },
     }),
-    /appeared/u,
   );
   expect(await readFile(join(directory, "Lumen.app/application"), "utf8")).toBe(
     "concurrent app",

--- a/tooling/install-lumen.test.ts
+++ b/tooling/install-lumen.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, expect, test } from "bun:test";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { installLumen } from "./install-lumen.ts";
+import { join } from "node:path";
+import { rejects } from "node:assert/strict";
+import { tmpdir } from "node:os";
+
+const directories: string[] = [];
+const content = new TextEncoder().encode("abc");
+const checksum =
+  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+async function fixture(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "lumen-test-"));
+  directories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map(async (directory) => {
+      await rm(directory, { recursive: true, force: true });
+    }),
+  );
+});
+
+async function verify(application: string): Promise<void> {
+  if (
+    (await readFile(join(application, "application"), "utf8")) !== "complete"
+  ) {
+    throw new Error("Unknown application");
+  }
+}
+
+async function extract(_image: string, destination: string): Promise<void> {
+  await mkdir(destination);
+  await writeFile(join(destination, "application"), "complete");
+}
+
+test("publishes a complete application and preserves it on replay", async () => {
+  const directory = await fixture();
+  const options = {
+    directory,
+    checksum,
+    verify,
+    download: (): Promise<Uint8Array> => Promise.resolve(content),
+    extract,
+  };
+  await installLumen(options);
+  expect(await readFile(join(directory, "Lumen.app/application"), "utf8")).toBe(
+    "complete",
+  );
+  await installLumen({
+    ...options,
+    download: () => Promise.reject(new Error("offline")),
+  });
+  expect(await readdir(directory)).toEqual(["Lumen.app"]);
+});
+
+test("rejects corrupted downloads before exposing an application", async () => {
+  const directory = await fixture();
+  await rejects(
+    installLumen({
+      directory,
+      checksum,
+      verify,
+      download: () => Promise.resolve(new Uint8Array()),
+      extract,
+    }),
+    /SHA-256/u,
+  );
+  expect(await readdir(directory)).toEqual([]);
+});
+
+test("download failures leave no partial application", async () => {
+  const directory = await fixture();
+  await rejects(
+    installLumen({
+      directory,
+      checksum,
+      verify,
+      download: () => Promise.reject(new Error("offline")),
+      extract,
+    }),
+    /offline/u,
+  );
+  expect(await readdir(directory)).toEqual([]);
+});
+
+test("copy failures remove staging without publishing a partial application", async () => {
+  const directory = await fixture();
+  await rejects(
+    installLumen({
+      directory,
+      checksum,
+      verify,
+      download: (): Promise<Uint8Array> => Promise.resolve(content),
+      extract: async (image, destination) => {
+        await extract(image, destination);
+        throw new Error("disk full");
+      },
+    }),
+    /disk full/u,
+  );
+  expect(await readdir(directory)).toEqual([]);
+});
+
+test("refuses an existing file at the application destination", async () => {
+  const directory = await fixture();
+  await writeFile(join(directory, "Lumen.app"), "existing");
+  await rejects(
+    installLumen({
+      directory,
+      checksum,
+      verify,
+      download: (): Promise<Uint8Array> => Promise.resolve(content),
+      extract,
+    }),
+    /exists/u,
+  );
+  expect(await readFile(join(directory, "Lumen.app"), "utf8")).toBe("existing");
+});
+
+test("refuses a symlink without modifying its target", async () => {
+  const directory = await fixture();
+  const target = await fixture();
+  await writeFile(join(target, "application"), "existing");
+  await symlink(target, join(directory, "Lumen.app"));
+  await rejects(
+    installLumen({
+      directory,
+      checksum,
+      verify,
+      download: () => Promise.resolve(content),
+      extract,
+    }),
+    /exists/u,
+  );
+  expect(await readFile(join(target, "application"), "utf8")).toBe("existing");
+});
+
+test("refuses an unknown application without replacing it", async () => {
+  const directory = await fixture();
+  await mkdir(join(directory, "Lumen.app"));
+  await writeFile(join(directory, "Lumen.app/application"), "other app");
+  await rejects(
+    installLumen({
+      directory,
+      checksum,
+      verify,
+      download: () => Promise.resolve(content),
+      extract,
+    }),
+    /Unknown/u,
+  );
+  expect(await readFile(join(directory, "Lumen.app/application"), "utf8")).toBe(
+    "other app",
+  );
+});
+
+test("signature rejection leaves no installed application", async () => {
+  const directory = await fixture();
+  await rejects(
+    installLumen({
+      directory,
+      checksum,
+      verify: () => Promise.reject(new Error("invalid signature")),
+      download: () => Promise.resolve(content),
+      extract,
+    }),
+    /signature/u,
+  );
+  expect(await readdir(directory)).toEqual([]);
+});
+
+test("a destination appearing during extraction is preserved", async () => {
+  const directory = await fixture();
+  await rejects(
+    installLumen({
+      directory,
+      checksum,
+      verify,
+      download: () => Promise.resolve(content),
+      extract: async (image, destination) => {
+        await extract(image, destination);
+        await mkdir(join(directory, "Lumen.app"));
+        await writeFile(
+          join(directory, "Lumen.app/application"),
+          "concurrent app",
+        );
+      },
+    }),
+    /appeared/u,
+  );
+  expect(await readFile(join(directory, "Lumen.app/application"), "utf8")).toBe(
+    "concurrent app",
+  );
+  expect(await readdir(directory)).toEqual(["Lumen.app"]);
+});

--- a/tooling/install-lumen.ts
+++ b/tooling/install-lumen.ts
@@ -1,0 +1,154 @@
+import { lstat, mkdtemp, rm, rmdir, writeFile } from "node:fs/promises";
+import type { Stats } from "node:fs";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { z } from "zod";
+
+type Installation = Readonly<{
+  directory: string;
+  checksum: string;
+  download: () => Promise<Uint8Array>;
+  extract: (image: string, destination: string) => Promise<void>;
+  verify: (application: string) => Promise<void>;
+}>;
+
+async function command(arguments_: readonly string[]): Promise<void> {
+  const child = Bun.spawn([...arguments_], {
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const status = await child.exited;
+  if (status !== 0) {
+    throw new Error(`${arguments_[0]} failed (${status})`);
+  }
+}
+
+async function metadata(path: string): Promise<Stats | null> {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (z.object({ code: z.literal("ENOENT") }).safeParse(error).success) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function installLumen(installation: Installation): Promise<void> {
+  const destination = join(installation.directory, "Lumen.app");
+  const existing = await metadata(destination);
+  if (existing !== null) {
+    if (!existing.isDirectory() || existing.isSymbolicLink()) {
+      throw new Error(`${destination} exists`);
+    }
+    await installation.verify(destination);
+    return;
+  }
+  const content = await verifiedDownload(installation);
+  const staging = await mkdtemp(join(installation.directory, ".lumen-"));
+  try {
+    const image = join(staging, "Lumen.dmg");
+    const application = join(staging, "Lumen.app");
+    await writeFile(image, content);
+    await installation.extract(image, application);
+    await installation.verify(application);
+    await command(["mv", "-n", application, installation.directory]);
+    if (await metadata(application)) {
+      throw new Error(`${destination} appeared during installation`);
+    }
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}
+
+async function verify(application: string): Promise<void> {
+  await command([
+    "/usr/bin/codesign",
+    "--verify",
+    "--deep",
+    "--strict",
+    '-R=anchor apple generic and certificate leaf[subject.OU] = "448LBGWBYM" and identifier "com.sonpiaz.lumen"',
+    application,
+  ]);
+}
+
+async function extract(image: string, destination: string): Promise<void> {
+  const mount = await mkdtemp("/private/tmp/lumen-mount-");
+  try {
+    await command([
+      "/usr/bin/hdiutil",
+      "attach",
+      "-readonly",
+      "-nobrowse",
+      "-mountpoint",
+      mount,
+      image,
+    ]);
+  } catch (error) {
+    await rmdir(mount);
+    throw error;
+  }
+  try {
+    await command(["/usr/bin/ditto", join(mount, "Lumen.app"), destination]);
+  } finally {
+    await command(["/usr/bin/hdiutil", "detach", mount]);
+    await rmdir(mount);
+  }
+}
+
+async function download(): Promise<Uint8Array> {
+  const timeoutMilliseconds = 120_000;
+  const response = await fetch(
+    "https://github.com/sonpiaz/lumen/releases/download/v0.1.0/Lumen-0.1.0.dmg",
+    {
+      signal: AbortSignal.timeout(timeoutMilliseconds),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Lumen download failed: HTTP ${response.status}`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function main(): Promise<void> {
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    throw new Error("The Lumen 0.1.0 release requires macOS on Apple Silicon");
+  }
+  const argumentOffset = 2;
+  const [directory] = z
+    .tuple([z.string().startsWith("/")])
+    .parse(process.argv.slice(argumentOffset));
+  await installLumen({
+    directory,
+    checksum:
+      "f1aa0d00f2752d3623cbb174299b129e67dfd9a2f3fcdf565c903436ab16a65d",
+    download,
+    extract,
+    verify,
+  });
+}
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+async function verifiedDownload(
+  installation: Installation,
+): Promise<Uint8Array> {
+  const content = await installation.download();
+  if (
+    createHash("sha256").update(content).digest("hex") !== installation.checksum
+  ) {
+    throw new Error("Lumen SHA-256 mismatch");
+  }
+  return content;
+}
+
+export { installLumen };


### PR DESCRIPTION
## Description

Add Sonpiaz Lumen to `make optional`, with a standalone `make lumen` target. The installer pins the official 0.1.0 DMG, verifies its SHA-256 and developer signature, and stages the application before publishing it without overwriting an existing destination.

Homebrew's `lumen` cask is a different application; this source exception is documented. The published DMG is Apple Silicon only, so the installer rejects Intel Macs. An existing valid installation is retained; changing the pin does not automatically upgrade it.

## Useful Links

- [Lumen source](https://github.com/sonpiaz/lumen)
- [Pinned release](https://github.com/sonpiaz/lumen/releases/tag/v0.1.0)

## How to Test

- `bun test tooling/install-lumen.test.ts` — 9 tests covering replay, download/integrity failures, failed copies, invalid signatures and destination collisions.
- `bun run typecheck`, `bun run lint`, `bun run format:typescript:check`, and the documentation formatting check passed on macOS Apple Silicon.
- Native installation and replay via `make lumen APP_BIN=<temporary directory>` passed on macOS Apple Silicon; the same target also installed Lumen into `/Applications` successfully.
- Linux and Intel execution were not exercised. Remote CI remains required before merge.

## Checklist

- [x] Changes have been tested locally
- [x] Documentation has been updated if necessary
- [x] Platform restriction documented

No code comments added. The existing Makefile remains intact beyond the new target and optional dependency; the installer and its tests remain separate, focused units.
