### PR TITLE
feat: add optional Minutes installation through Moon

### DIFF
--- a/.moon/tasks/workstation.yml
+++ b/.moon/tasks/workstation.yml
@@ -62,6 +62,26 @@ tasks:
     script: |-
       export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
       brew install --cask anarlog
+  minutes:
+    description: Install the optional Minutes meeting recorder
+    deps:
+      - homebrew
+    checks:
+      - check: condition
+        script: |-
+          export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
+          brew list --cask --versions silverstein/tap/minutes
+    env:
+      HOMEBREW_NO_ASK: "1"
+    toolchains: system
+    options:
+      cache: false
+      mutex: homebrew
+      os: macos
+      runInCI: false
+    script: |-
+      export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
+      brew install --cask silverstein/tap/minutes
   rust:
     description: Install Rust and Cargo with Homebrew
     deps:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ minimal: bootstrap
 optional: minimal
 	@$(MAKE) --no-print-directory bundle-optional </dev/null
 	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) repository:anarlog
+	@cd "${DOTFILES_PATH}" && $(MOON_EXEC) repository:minutes </dev/null
 	@$(MAKE) --no-print-directory optional-artifacts </dev/null
 
 .PHONY: smoke-minimal

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Install the separately maintained optional profile with `make optional`.
 Anarlog belongs to the optional profile, alongside Handy. Install it independently
 with `moon exec repository:anarlog` (macOS 15 or newer).
 
+[Minutes](https://useminutes.app/) is also optional. Install the desktop app with
+`moon exec repository:minutes` (Apple Silicon, macOS 14 or newer), using the publisher's
+`silverstein/tap` Homebrew cask. Native call capture requires macOS 15 or newer.
+First launch downloads a local speech model;
+transcription does not require an API key. Summarization is optional and configured
+separately. The Minutes CLI is not installed by this task.
+
 Moon installs the complete minimal profile. With Moon available:
 
 ```bash


### PR DESCRIPTION
## Description

Add the Minutes desktop app as an optional local transcription tool through `moon exec repository:minutes` and `make optional`, using the publisher's `silverstein/tap/minutes` Homebrew cask. The task uses the existing Homebrew prerequisite, native installed-package probe and shared mutex.

Anarlog remains available during the trial. The README documents Apple Silicon/macOS requirements, the initial speech-model download and the separate optional summarization setup. This installs the desktop app only.

## Useful Links

- [Minutes](https://useminutes.app/)
- [Publisher's cask](https://github.com/silverstein/homebrew-tap/blob/main/Casks/minutes.rb)

## How to Test

Validated locally on macOS arm64, Moon 2.5.4:

- `moon task repository:minutes --json` and `moon action-graph repository:minutes --dot`: configuration resolves with Homebrew and bootstrap prerequisites.
- `make -n optional`: includes the Minutes task.
- `bun run prettier --check .moon/tasks/workstation.yml README.md` and `git diff --cached --check`: pass.
- Independent review: no findings.

Installation and transcription were not executed from the worktree. On an Apple Silicon Mac with macOS 14+, run `moon exec repository:minutes` from the main checkout, open Minutes and complete the model download; native call capture requires macOS 15+. Existing remote CI must pass before merge; its minimal-profile smoke does not exercise this optional app.

## Checklist

- [x] Declarative changes checked locally; actual installation remains to be exercised
- [x] Documentation updated
- [x] No breaking changes

No comments added. The existing Makefile exceeds the 250-line review trigger; its one-line delegation stays with the optional profile to preserve cohesion.
